### PR TITLE
Add PHP JSON AST inspection

### DIFF
--- a/tests/json-ast/x/php/append_builtin.php.json
+++ b/tests/json-ast/x/php/append_builtin.php.json
@@ -1,0 +1,793 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 11,
+        "endFilePos": 17
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 10,
+          "endFilePos": 16
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "a"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 10,
+            "endFilePos": 16,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 12
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 12,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 15,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 13,
+        "startFilePos": 19,
+        "endLine": 3,
+        "endTokenPos": 78,
+        "endFilePos": 204
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 15,
+            "startFilePos": 24,
+            "endLine": 3,
+            "endTokenPos": 74,
+            "endFilePos": 194
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 15,
+              "startFilePos": 24,
+              "endLine": 3,
+              "endTokenPos": 15,
+              "endFilePos": 34
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 36,
+                "endLine": 3,
+                "endTokenPos": 17,
+                "endFilePos": 42
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 17,
+                  "startFilePos": 36,
+                  "endLine": 3,
+                  "endTokenPos": 17,
+                  "endFilePos": 42,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 20,
+                "startFilePos": 45,
+                "endLine": 3,
+                "endTokenPos": 20,
+                "endFilePos": 51
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 20,
+                  "startFilePos": 45,
+                  "endLine": 3,
+                  "endTokenPos": 20,
+                  "endFilePos": 51,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 23,
+                "startFilePos": 54,
+                "endLine": 3,
+                "endTokenPos": 73,
+                "endFilePos": 193
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 23,
+                  "startFilePos": 54,
+                  "endLine": 3,
+                  "endTokenPos": 73,
+                  "endFilePos": 193
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 23,
+                    "startFilePos": 54,
+                    "endLine": 3,
+                    "endTokenPos": 23,
+                    "endFilePos": 64
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 25,
+                      "startFilePos": 66,
+                      "endLine": 3,
+                      "endTokenPos": 25,
+                      "endFilePos": 71
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 25,
+                        "startFilePos": 66,
+                        "endLine": 3,
+                        "endTokenPos": 25,
+                        "endFilePos": 71,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 28,
+                      "startFilePos": 74,
+                      "endLine": 3,
+                      "endTokenPos": 28,
+                      "endFilePos": 79
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 28,
+                        "startFilePos": 74,
+                        "endLine": 3,
+                        "endTokenPos": 28,
+                        "endFilePos": 79,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 31,
+                      "startFilePos": 82,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 192
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 31,
+                        "startFilePos": 82,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 192
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 31,
+                          "startFilePos": 82,
+                          "endLine": 3,
+                          "endTokenPos": 31,
+                          "endFilePos": 92
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 33,
+                            "startFilePos": 94,
+                            "endLine": 3,
+                            "endTokenPos": 33,
+                            "endFilePos": 97
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 33,
+                              "startFilePos": 94,
+                              "endLine": 3,
+                              "endTokenPos": 33,
+                              "endFilePos": 97,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 36,
+                            "startFilePos": 100,
+                            "endLine": 3,
+                            "endTokenPos": 36,
+                            "endFilePos": 102
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 36,
+                              "startFilePos": 100,
+                              "endLine": 3,
+                              "endTokenPos": 36,
+                              "endFilePos": 102,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 39,
+                            "startFilePos": 105,
+                            "endLine": 3,
+                            "endTokenPos": 71,
+                            "endFilePos": 191
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 39,
+                              "startFilePos": 105,
+                              "endLine": 3,
+                              "endTokenPos": 71,
+                              "endFilePos": 191
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 3,
+                                "startTokenPos": 39,
+                                "startFilePos": 105,
+                                "endLine": 3,
+                                "endTokenPos": 39,
+                                "endFilePos": 115
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 41,
+                                  "startFilePos": 117,
+                                  "endLine": 3,
+                                  "endTokenPos": 41,
+                                  "endFilePos": 119
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 41,
+                                    "startFilePos": 117,
+                                    "endLine": 3,
+                                    "endTokenPos": 41,
+                                    "endFilePos": 119,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 44,
+                                  "startFilePos": 122,
+                                  "endLine": 3,
+                                  "endTokenPos": 44,
+                                  "endFilePos": 125
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 44,
+                                    "startFilePos": 122,
+                                    "endLine": 3,
+                                    "endTokenPos": 44,
+                                    "endFilePos": 125,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 47,
+                                  "startFilePos": 128,
+                                  "endLine": 3,
+                                  "endTokenPos": 70,
+                                  "endFilePos": 190
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 47,
+                                    "startFilePos": 128,
+                                    "endLine": 3,
+                                    "endTokenPos": 70,
+                                    "endFilePos": 190
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 3,
+                                      "startTokenPos": 47,
+                                      "startFilePos": 128,
+                                      "endLine": 3,
+                                      "endTokenPos": 47,
+                                      "endFilePos": 138
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 49,
+                                        "startFilePos": 140,
+                                        "endLine": 3,
+                                        "endTokenPos": 49,
+                                        "endFilePos": 142
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 49,
+                                          "startFilePos": 140,
+                                          "endLine": 3,
+                                          "endTokenPos": 49,
+                                          "endFilePos": 142,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 52,
+                                        "startFilePos": 145,
+                                        "endLine": 3,
+                                        "endTokenPos": 52,
+                                        "endFilePos": 148
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 52,
+                                          "startFilePos": 145,
+                                          "endLine": 3,
+                                          "endTokenPos": 52,
+                                          "endFilePos": 148,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 55,
+                                        "startFilePos": 151,
+                                        "endLine": 3,
+                                        "endTokenPos": 69,
+                                        "endFilePos": 189
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 55,
+                                          "startFilePos": 151,
+                                          "endLine": 3,
+                                          "endTokenPos": 69,
+                                          "endFilePos": 189
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 3,
+                                            "startTokenPos": 55,
+                                            "startFilePos": 151,
+                                            "endLine": 3,
+                                            "endTokenPos": 55,
+                                            "endFilePos": 161
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 57,
+                                              "startFilePos": 163,
+                                              "endLine": 3,
+                                              "endTokenPos": 65,
+                                              "endFilePos": 182
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 57,
+                                                "startFilePos": 163,
+                                                "endLine": 3,
+                                                "endTokenPos": 65,
+                                                "endFilePos": 182
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 3,
+                                                  "startTokenPos": 57,
+                                                  "startFilePos": 163,
+                                                  "endLine": 3,
+                                                  "endTokenPos": 57,
+                                                  "endFilePos": 173
+                                                },
+                                                "name": "array_merge"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 59,
+                                                    "startFilePos": 175,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 59,
+                                                    "endFilePos": 176
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 59,
+                                                      "startFilePos": 175,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 59,
+                                                      "endFilePos": 176
+                                                    },
+                                                    "name": "a"
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                },
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 62,
+                                                    "startFilePos": 179,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 64,
+                                                    "endFilePos": 181
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_Array",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 62,
+                                                      "startFilePos": 179,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 64,
+                                                      "endFilePos": 181,
+                                                      "kind": 2
+                                                    },
+                                                    "items": [
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 3,
+                                                          "startTokenPos": 63,
+                                                          "startFilePos": 180,
+                                                          "endLine": 3,
+                                                          "endTokenPos": 63,
+                                                          "endFilePos": 180
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 3,
+                                                            "startTokenPos": 63,
+                                                            "startFilePos": 180,
+                                                            "endLine": 3,
+                                                            "endTokenPos": 63,
+                                                            "endFilePos": 180,
+                                                            "rawValue": "3",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 3
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      }
+                                                    ]
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 68,
+                                              "startFilePos": 185,
+                                              "endLine": 3,
+                                              "endTokenPos": 68,
+                                              "endFilePos": 188
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 68,
+                                                "startFilePos": 185,
+                                                "endLine": 3,
+                                                "endTokenPos": 68,
+                                                "endFilePos": 188,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 77,
+            "startFilePos": 197,
+            "endLine": 3,
+            "endTokenPos": 77,
+            "endFilePos": 203
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 77,
+              "startFilePos": 197,
+              "endLine": 3,
+              "endTokenPos": 77,
+              "endFilePos": 203
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/avg_builtin.php.json
+++ b/tests/json-ast/x/php/avg_builtin.php.json
@@ -1,0 +1,1012 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 104,
+        "endFilePos": 174
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 99,
+            "endFilePos": 163
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 33,
+              "endFilePos": 60
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 32,
+                  "endFilePos": 59
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Div",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 32,
+                    "endFilePos": 59
+                  },
+                  "left": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 17,
+                      "endFilePos": 40
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 6,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 6,
+                        "endFilePos": 29
+                      },
+                      "name": "array_sum"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 31,
+                          "endLine": 2,
+                          "endTokenPos": 16,
+                          "endFilePos": 39
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 8,
+                            "startFilePos": 31,
+                            "endLine": 2,
+                            "endTokenPos": 16,
+                            "endFilePos": 39,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 9,
+                                "startFilePos": 32,
+                                "endLine": 2,
+                                "endTokenPos": 9,
+                                "endFilePos": 32
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 9,
+                                  "startFilePos": 32,
+                                  "endLine": 2,
+                                  "endTokenPos": 9,
+                                  "endFilePos": 32,
+                                  "rawValue": "1",
+                                  "kind": 10
+                                },
+                                "value": 1
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 12,
+                                "startFilePos": 35,
+                                "endLine": 2,
+                                "endTokenPos": 12,
+                                "endFilePos": 35
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 12,
+                                  "startFilePos": 35,
+                                  "endLine": 2,
+                                  "endTokenPos": 12,
+                                  "endFilePos": 35,
+                                  "rawValue": "2",
+                                  "kind": 10
+                                },
+                                "value": 2
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 15,
+                                "startFilePos": 38,
+                                "endLine": 2,
+                                "endTokenPos": 15,
+                                "endFilePos": 38
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 15,
+                                  "startFilePos": 38,
+                                  "endLine": 2,
+                                  "endTokenPos": 15,
+                                  "endFilePos": 38,
+                                  "rawValue": "3",
+                                  "kind": 10
+                                },
+                                "value": 3
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "right": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 44,
+                      "endLine": 2,
+                      "endTokenPos": 32,
+                      "endFilePos": 59
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 21,
+                        "startFilePos": 44,
+                        "endLine": 2,
+                        "endTokenPos": 21,
+                        "endFilePos": 48
+                      },
+                      "name": "count"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 23,
+                          "startFilePos": 50,
+                          "endLine": 2,
+                          "endTokenPos": 31,
+                          "endFilePos": 58
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 23,
+                            "startFilePos": 50,
+                            "endLine": 2,
+                            "endTokenPos": 31,
+                            "endFilePos": 58,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 24,
+                                "startFilePos": 51,
+                                "endLine": 2,
+                                "endTokenPos": 24,
+                                "endFilePos": 51
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 24,
+                                  "startFilePos": 51,
+                                  "endLine": 2,
+                                  "endTokenPos": 24,
+                                  "endFilePos": 51,
+                                  "rawValue": "1",
+                                  "kind": 10
+                                },
+                                "value": 1
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 27,
+                                "startFilePos": 54,
+                                "endLine": 2,
+                                "endTokenPos": 27,
+                                "endFilePos": 54
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 27,
+                                  "startFilePos": 54,
+                                  "endLine": 2,
+                                  "endTokenPos": 27,
+                                  "endFilePos": 54,
+                                  "rawValue": "2",
+                                  "kind": 10
+                                },
+                                "value": 2
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 30,
+                                "startFilePos": 57,
+                                "endLine": 2,
+                                "endTokenPos": 30,
+                                "endFilePos": 57
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 30,
+                                  "startFilePos": 57,
+                                  "endLine": 2,
+                                  "endTokenPos": 30,
+                                  "endFilePos": 57,
+                                  "rawValue": "3",
+                                  "kind": 10
+                                },
+                                "value": 3
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 37,
+              "startFilePos": 64,
+              "endLine": 2,
+              "endTokenPos": 69,
+              "endFilePos": 121
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 37,
+                "startFilePos": 64,
+                "endLine": 2,
+                "endTokenPos": 37,
+                "endFilePos": 74
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 39,
+                  "startFilePos": 76,
+                  "endLine": 2,
+                  "endTokenPos": 65,
+                  "endFilePos": 114
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Div",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 39,
+                    "startFilePos": 76,
+                    "endLine": 2,
+                    "endTokenPos": 65,
+                    "endFilePos": 114
+                  },
+                  "left": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 76,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 95
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 76,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 84
+                      },
+                      "name": "array_sum"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 41,
+                          "startFilePos": 86,
+                          "endLine": 2,
+                          "endTokenPos": 49,
+                          "endFilePos": 94
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 41,
+                            "startFilePos": 86,
+                            "endLine": 2,
+                            "endTokenPos": 49,
+                            "endFilePos": 94,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 42,
+                                "startFilePos": 87,
+                                "endLine": 2,
+                                "endTokenPos": 42,
+                                "endFilePos": 87
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 42,
+                                  "startFilePos": 87,
+                                  "endLine": 2,
+                                  "endTokenPos": 42,
+                                  "endFilePos": 87,
+                                  "rawValue": "1",
+                                  "kind": 10
+                                },
+                                "value": 1
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 45,
+                                "startFilePos": 90,
+                                "endLine": 2,
+                                "endTokenPos": 45,
+                                "endFilePos": 90
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 45,
+                                  "startFilePos": 90,
+                                  "endLine": 2,
+                                  "endTokenPos": 45,
+                                  "endFilePos": 90,
+                                  "rawValue": "2",
+                                  "kind": 10
+                                },
+                                "value": 2
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 48,
+                                "startFilePos": 93,
+                                "endLine": 2,
+                                "endTokenPos": 48,
+                                "endFilePos": 93
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 48,
+                                  "startFilePos": 93,
+                                  "endLine": 2,
+                                  "endTokenPos": 48,
+                                  "endFilePos": 93,
+                                  "rawValue": "3",
+                                  "kind": 10
+                                },
+                                "value": 3
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "right": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 54,
+                      "startFilePos": 99,
+                      "endLine": 2,
+                      "endTokenPos": 65,
+                      "endFilePos": 114
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 54,
+                        "startFilePos": 99,
+                        "endLine": 2,
+                        "endTokenPos": 54,
+                        "endFilePos": 103
+                      },
+                      "name": "count"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 56,
+                          "startFilePos": 105,
+                          "endLine": 2,
+                          "endTokenPos": 64,
+                          "endFilePos": 113
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 56,
+                            "startFilePos": 105,
+                            "endLine": 2,
+                            "endTokenPos": 64,
+                            "endFilePos": 113,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 57,
+                                "startFilePos": 106,
+                                "endLine": 2,
+                                "endTokenPos": 57,
+                                "endFilePos": 106
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 57,
+                                  "startFilePos": 106,
+                                  "endLine": 2,
+                                  "endTokenPos": 57,
+                                  "endFilePos": 106,
+                                  "rawValue": "1",
+                                  "kind": 10
+                                },
+                                "value": 1
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 60,
+                                "startFilePos": 109,
+                                "endLine": 2,
+                                "endTokenPos": 60,
+                                "endFilePos": 109
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 60,
+                                  "startFilePos": 109,
+                                  "endLine": 2,
+                                  "endTokenPos": 60,
+                                  "endFilePos": 109,
+                                  "rawValue": "2",
+                                  "kind": 10
+                                },
+                                "value": 2
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 63,
+                                "startFilePos": 112,
+                                "endLine": 2,
+                                "endTokenPos": 63,
+                                "endFilePos": 112
+                              },
+                              "key": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 63,
+                                  "startFilePos": 112,
+                                  "endLine": 2,
+                                  "endTokenPos": 63,
+                                  "endFilePos": 112,
+                                  "rawValue": "3",
+                                  "kind": 10
+                                },
+                                "value": 3
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 68,
+                  "startFilePos": 117,
+                  "endLine": 2,
+                  "endTokenPos": 68,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 68,
+                    "startFilePos": 117,
+                    "endLine": 2,
+                    "endTokenPos": 68,
+                    "endFilePos": 120,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Div",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 73,
+              "startFilePos": 125,
+              "endLine": 2,
+              "endTokenPos": 99,
+              "endFilePos": 163
+            },
+            "left": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 73,
+                "startFilePos": 125,
+                "endLine": 2,
+                "endTokenPos": 84,
+                "endFilePos": 144
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 73,
+                  "startFilePos": 125,
+                  "endLine": 2,
+                  "endTokenPos": 73,
+                  "endFilePos": 133
+                },
+                "name": "array_sum"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 75,
+                    "startFilePos": 135,
+                    "endLine": 2,
+                    "endTokenPos": 83,
+                    "endFilePos": 143
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 75,
+                      "startFilePos": 135,
+                      "endLine": 2,
+                      "endTokenPos": 83,
+                      "endFilePos": 143,
+                      "kind": 2
+                    },
+                    "items": [
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 76,
+                          "startFilePos": 136,
+                          "endLine": 2,
+                          "endTokenPos": 76,
+                          "endFilePos": 136
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 76,
+                            "startFilePos": 136,
+                            "endLine": 2,
+                            "endTokenPos": 76,
+                            "endFilePos": 136,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 79,
+                          "startFilePos": 139,
+                          "endLine": 2,
+                          "endTokenPos": 79,
+                          "endFilePos": 139
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 79,
+                            "startFilePos": 139,
+                            "endLine": 2,
+                            "endTokenPos": 79,
+                            "endFilePos": 139,
+                            "rawValue": "2",
+                            "kind": 10
+                          },
+                          "value": 2
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 82,
+                          "startFilePos": 142,
+                          "endLine": 2,
+                          "endTokenPos": 82,
+                          "endFilePos": 142
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 82,
+                            "startFilePos": 142,
+                            "endLine": 2,
+                            "endTokenPos": 82,
+                            "endFilePos": 142,
+                            "rawValue": "3",
+                            "kind": 10
+                          },
+                          "value": 3
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "right": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 88,
+                "startFilePos": 148,
+                "endLine": 2,
+                "endTokenPos": 99,
+                "endFilePos": 163
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 88,
+                  "startFilePos": 148,
+                  "endLine": 2,
+                  "endTokenPos": 88,
+                  "endFilePos": 152
+                },
+                "name": "count"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 90,
+                    "startFilePos": 154,
+                    "endLine": 2,
+                    "endTokenPos": 98,
+                    "endFilePos": 162
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 90,
+                      "startFilePos": 154,
+                      "endLine": 2,
+                      "endTokenPos": 98,
+                      "endFilePos": 162,
+                      "kind": 2
+                    },
+                    "items": [
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 91,
+                          "startFilePos": 155,
+                          "endLine": 2,
+                          "endTokenPos": 91,
+                          "endFilePos": 155
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 91,
+                            "startFilePos": 155,
+                            "endLine": 2,
+                            "endTokenPos": 91,
+                            "endFilePos": 155,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 94,
+                          "startFilePos": 158,
+                          "endLine": 2,
+                          "endTokenPos": 94,
+                          "endFilePos": 158
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 94,
+                            "startFilePos": 158,
+                            "endLine": 2,
+                            "endTokenPos": 94,
+                            "endFilePos": 158,
+                            "rawValue": "2",
+                            "kind": 10
+                          },
+                          "value": 2
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 97,
+                          "startFilePos": 161,
+                          "endLine": 2,
+                          "endTokenPos": 97,
+                          "endFilePos": 161
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 97,
+                            "startFilePos": 161,
+                            "endLine": 2,
+                            "endTokenPos": 97,
+                            "endFilePos": 161,
+                            "rawValue": "3",
+                            "kind": 10
+                          },
+                          "value": 3
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 103,
+            "startFilePos": 167,
+            "endLine": 2,
+            "endTokenPos": 103,
+            "endFilePos": 173
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 103,
+              "startFilePos": 167,
+              "endLine": 2,
+              "endTokenPos": 103,
+              "endFilePos": 173
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/basic_compare.php.json
+++ b/tests/json-ast/x/php/basic_compare.php.json
@@ -1,0 +1,563 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 10,
+        "endFilePos": 17
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 9,
+          "endFilePos": 16
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "a"
+        },
+        "expr": {
+          "nodeType": "Expr_BinaryOp_Minus",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 9,
+            "endFilePos": 16
+          },
+          "left": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 11,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 12,
+              "rawValue": "10",
+              "kind": 10
+            },
+            "value": 10
+          },
+          "right": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 9,
+              "startFilePos": 16,
+              "endLine": 2,
+              "endTokenPos": 9,
+              "endFilePos": 16,
+              "rawValue": "3",
+              "kind": 10
+            },
+            "value": 3
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 12,
+        "startFilePos": 19,
+        "endLine": 3,
+        "endTokenPos": 21,
+        "endFilePos": 29
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 12,
+          "startFilePos": 19,
+          "endLine": 3,
+          "endTokenPos": 20,
+          "endFilePos": 28
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 19,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 20
+          },
+          "name": "b"
+        },
+        "expr": {
+          "nodeType": "Expr_BinaryOp_Plus",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 16,
+            "startFilePos": 24,
+            "endLine": 3,
+            "endTokenPos": 20,
+            "endFilePos": 28
+          },
+          "left": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 16,
+              "startFilePos": 24,
+              "endLine": 3,
+              "endTokenPos": 16,
+              "endFilePos": 24,
+              "rawValue": "2",
+              "kind": 10
+            },
+            "value": 2
+          },
+          "right": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 20,
+              "startFilePos": 28,
+              "endLine": 3,
+              "endTokenPos": 20,
+              "endFilePos": 28,
+              "rawValue": "2",
+              "kind": 10
+            },
+            "value": 2
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 23,
+        "startFilePos": 31,
+        "endLine": 4,
+        "endTokenPos": 48,
+        "endFilePos": 88
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 26,
+            "startFilePos": 37,
+            "endLine": 4,
+            "endTokenPos": 43,
+            "endFilePos": 77
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 26,
+              "startFilePos": 37,
+              "endLine": 4,
+              "endTokenPos": 29,
+              "endFilePos": 48
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 26,
+                "startFilePos": 37,
+                "endLine": 4,
+                "endTokenPos": 26,
+                "endFilePos": 44
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 28,
+                  "startFilePos": 46,
+                  "endLine": 4,
+                  "endTokenPos": 28,
+                  "endFilePos": 47
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 28,
+                    "startFilePos": 46,
+                    "endLine": 4,
+                    "endTokenPos": 28,
+                    "endFilePos": 47
+                  },
+                  "name": "a"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 33,
+              "startFilePos": 52,
+              "endLine": 4,
+              "endTokenPos": 39,
+              "endFilePos": 72
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 33,
+                "startFilePos": 52,
+                "endLine": 4,
+                "endTokenPos": 33,
+                "endFilePos": 62
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 35,
+                  "startFilePos": 64,
+                  "endLine": 4,
+                  "endTokenPos": 35,
+                  "endFilePos": 65
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 35,
+                    "startFilePos": 64,
+                    "endLine": 4,
+                    "endTokenPos": 35,
+                    "endFilePos": 65
+                  },
+                  "name": "a"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 38,
+                  "startFilePos": 68,
+                  "endLine": 4,
+                  "endTokenPos": 38,
+                  "endFilePos": 71
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 38,
+                    "startFilePos": 68,
+                    "endLine": 4,
+                    "endTokenPos": 38,
+                    "endFilePos": 71,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 43,
+              "startFilePos": 76,
+              "endLine": 4,
+              "endTokenPos": 43,
+              "endFilePos": 77
+            },
+            "name": "a"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 47,
+            "startFilePos": 81,
+            "endLine": 4,
+            "endTokenPos": 47,
+            "endFilePos": 87
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 47,
+              "startFilePos": 81,
+              "endLine": 4,
+              "endTokenPos": 47,
+              "endFilePos": 87
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 50,
+        "startFilePos": 90,
+        "endLine": 5,
+        "endTokenPos": 70,
+        "endFilePos": 132
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 53,
+            "startFilePos": 96,
+            "endLine": 5,
+            "endTokenPos": 65,
+            "endFilePos": 121
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Equal",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 53,
+              "startFilePos": 96,
+              "endLine": 5,
+              "endTokenPos": 57,
+              "endFilePos": 102
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 53,
+                "startFilePos": 96,
+                "endLine": 5,
+                "endTokenPos": 53,
+                "endFilePos": 97
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 57,
+                "startFilePos": 102,
+                "endLine": 5,
+                "endTokenPos": 57,
+                "endFilePos": 102,
+                "rawValue": "7",
+                "kind": 10
+              },
+              "value": 7
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 61,
+              "startFilePos": 106,
+              "endLine": 5,
+              "endTokenPos": 61,
+              "endFilePos": 111,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 65,
+              "startFilePos": 115,
+              "endLine": 5,
+              "endTokenPos": 65,
+              "endFilePos": 121,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 69,
+            "startFilePos": 125,
+            "endLine": 5,
+            "endTokenPos": 69,
+            "endFilePos": 131
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 69,
+              "startFilePos": 125,
+              "endLine": 5,
+              "endTokenPos": 69,
+              "endFilePos": 131
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 72,
+        "startFilePos": 134,
+        "endLine": 6,
+        "endTokenPos": 92,
+        "endFilePos": 175
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 75,
+            "startFilePos": 140,
+            "endLine": 6,
+            "endTokenPos": 87,
+            "endFilePos": 164
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Smaller",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 75,
+              "startFilePos": 140,
+              "endLine": 6,
+              "endTokenPos": 79,
+              "endFilePos": 145
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 75,
+                "startFilePos": 140,
+                "endLine": 6,
+                "endTokenPos": 75,
+                "endFilePos": 141
+              },
+              "name": "b"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 79,
+                "startFilePos": 145,
+                "endLine": 6,
+                "endTokenPos": 79,
+                "endFilePos": 145,
+                "rawValue": "5",
+                "kind": 10
+              },
+              "value": 5
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 83,
+              "startFilePos": 149,
+              "endLine": 6,
+              "endTokenPos": 83,
+              "endFilePos": 154,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 87,
+              "startFilePos": 158,
+              "endLine": 6,
+              "endTokenPos": 87,
+              "endFilePos": 164,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 91,
+            "startFilePos": 168,
+            "endLine": 6,
+            "endTokenPos": 91,
+            "endFilePos": 174
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 91,
+              "startFilePos": 168,
+              "endLine": 6,
+              "endTokenPos": 91,
+              "endFilePos": 174
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/bench_block.php.json
+++ b/tests/json-ast/x/php/bench_block.php.json
@@ -1,0 +1,2013 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 8,
+        "endFilePos": 35
+      },
+      "expr": {
+        "nodeType": "Expr_FuncCall",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 7,
+          "endFilePos": 34
+        },
+        "name": {
+          "nodeType": "Name",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "ini_set"
+        },
+        "args": [
+          {
+            "nodeType": "Arg",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 3,
+              "startFilePos": 14,
+              "endLine": 2,
+              "endTokenPos": 3,
+              "endFilePos": 27
+            },
+            "name": null,
+            "value": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 3,
+                "startFilePos": 14,
+                "endLine": 2,
+                "endTokenPos": 3,
+                "endFilePos": 27,
+                "kind": 1,
+                "rawValue": "'memory_limit'"
+              },
+              "value": "memory_limit"
+            },
+            "byRef": false,
+            "unpack": false
+          },
+          {
+            "nodeType": "Arg",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 6,
+              "startFilePos": 30,
+              "endLine": 2,
+              "endTokenPos": 6,
+              "endFilePos": 33
+            },
+            "name": null,
+            "value": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 30,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 33,
+                "kind": 1,
+                "rawValue": "'-1'"
+              },
+              "value": "-1"
+            },
+            "byRef": false,
+            "unpack": false
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 10,
+        "startFilePos": 37,
+        "endLine": 3,
+        "endTokenPos": 15,
+        "endFilePos": 50
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 10,
+          "startFilePos": 37,
+          "endLine": 3,
+          "endTokenPos": 14,
+          "endFilePos": 49
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 10,
+            "startFilePos": 37,
+            "endLine": 3,
+            "endTokenPos": 10,
+            "endFilePos": 45
+          },
+          "name": "now_seed"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 14,
+            "startFilePos": 49,
+            "endLine": 3,
+            "endTokenPos": 14,
+            "endFilePos": 49,
+            "rawValue": "0",
+            "kind": 10
+          },
+          "value": 0
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 17,
+        "startFilePos": 52,
+        "endLine": 4,
+        "endTokenPos": 22,
+        "endFilePos": 71
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 17,
+          "startFilePos": 52,
+          "endLine": 4,
+          "endTokenPos": 21,
+          "endFilePos": 70
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 17,
+            "startFilePos": 52,
+            "endLine": 4,
+            "endTokenPos": 17,
+            "endFilePos": 62
+          },
+          "name": "now_seeded"
+        },
+        "expr": {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 21,
+            "startFilePos": 66,
+            "endLine": 4,
+            "endTokenPos": 21,
+            "endFilePos": 70
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 21,
+              "startFilePos": 66,
+              "endLine": 4,
+              "endTokenPos": 21,
+              "endFilePos": 70
+            },
+            "name": "false"
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 24,
+        "startFilePos": 73,
+        "endLine": 5,
+        "endTokenPos": 32,
+        "endFilePos": 102
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 24,
+          "startFilePos": 73,
+          "endLine": 5,
+          "endTokenPos": 31,
+          "endFilePos": 101
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 24,
+            "startFilePos": 73,
+            "endLine": 5,
+            "endTokenPos": 24,
+            "endFilePos": 74
+          },
+          "name": "s"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 28,
+            "startFilePos": 78,
+            "endLine": 5,
+            "endTokenPos": 31,
+            "endFilePos": 101
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 28,
+              "startFilePos": 78,
+              "endLine": 5,
+              "endTokenPos": 28,
+              "endFilePos": 83
+            },
+            "name": "getenv"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 30,
+                "startFilePos": 85,
+                "endLine": 5,
+                "endTokenPos": 30,
+                "endFilePos": 100
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 30,
+                  "startFilePos": 85,
+                  "endLine": 5,
+                  "endTokenPos": 30,
+                  "endFilePos": 100,
+                  "kind": 1,
+                  "rawValue": "'MOCHI_NOW_SEED'"
+                },
+                "value": "MOCHI_NOW_SEED"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_If",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 34,
+        "startFilePos": 104,
+        "endLine": 9,
+        "endTokenPos": 71,
+        "endFilePos": 189
+      },
+      "cond": {
+        "nodeType": "Expr_BinaryOp_BooleanAnd",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 37,
+          "startFilePos": 108,
+          "endLine": 6,
+          "endTokenPos": 49,
+          "endFilePos": 132
+        },
+        "left": {
+          "nodeType": "Expr_BinaryOp_NotIdentical",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 37,
+            "startFilePos": 108,
+            "endLine": 6,
+            "endTokenPos": 41,
+            "endFilePos": 119
+          },
+          "left": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 37,
+              "startFilePos": 108,
+              "endLine": 6,
+              "endTokenPos": 37,
+              "endFilePos": 109
+            },
+            "name": "s"
+          },
+          "right": {
+            "nodeType": "Expr_ConstFetch",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 41,
+              "startFilePos": 115,
+              "endLine": 6,
+              "endTokenPos": 41,
+              "endFilePos": 119
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 41,
+                "startFilePos": 115,
+                "endLine": 6,
+                "endTokenPos": 41,
+                "endFilePos": 119
+              },
+              "name": "false"
+            }
+          }
+        },
+        "right": {
+          "nodeType": "Expr_BinaryOp_NotIdentical",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 45,
+            "startFilePos": 124,
+            "endLine": 6,
+            "endTokenPos": 49,
+            "endFilePos": 132
+          },
+          "left": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 45,
+              "startFilePos": 124,
+              "endLine": 6,
+              "endTokenPos": 45,
+              "endFilePos": 125
+            },
+            "name": "s"
+          },
+          "right": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 49,
+              "startFilePos": 131,
+              "endLine": 6,
+              "endTokenPos": 49,
+              "endFilePos": 132,
+              "kind": 1,
+              "rawValue": "''"
+            },
+            "value": ""
+          }
+        }
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 54,
+            "startFilePos": 141,
+            "endLine": 7,
+            "endTokenPos": 62,
+            "endFilePos": 163
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 54,
+              "startFilePos": 141,
+              "endLine": 7,
+              "endTokenPos": 61,
+              "endFilePos": 162
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 54,
+                "startFilePos": 141,
+                "endLine": 7,
+                "endTokenPos": 54,
+                "endFilePos": 149
+              },
+              "name": "now_seed"
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 58,
+                "startFilePos": 153,
+                "endLine": 7,
+                "endTokenPos": 61,
+                "endFilePos": 162
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 58,
+                  "startFilePos": 153,
+                  "endLine": 7,
+                  "endTokenPos": 58,
+                  "endFilePos": 158
+                },
+                "name": "intval"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 60,
+                    "startFilePos": 160,
+                    "endLine": 7,
+                    "endTokenPos": 60,
+                    "endFilePos": 161
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 60,
+                      "startFilePos": 160,
+                      "endLine": 7,
+                      "endTokenPos": 60,
+                      "endFilePos": 161
+                    },
+                    "name": "s"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 64,
+            "startFilePos": 169,
+            "endLine": 8,
+            "endTokenPos": 69,
+            "endFilePos": 187
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 64,
+              "startFilePos": 169,
+              "endLine": 8,
+              "endTokenPos": 68,
+              "endFilePos": 186
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 64,
+                "startFilePos": 169,
+                "endLine": 8,
+                "endTokenPos": 64,
+                "endFilePos": 179
+              },
+              "name": "now_seeded"
+            },
+            "expr": {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 68,
+                "startFilePos": 183,
+                "endLine": 8,
+                "endTokenPos": 68,
+                "endFilePos": 186
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 68,
+                  "startFilePos": 183,
+                  "endLine": 8,
+                  "endTokenPos": 68,
+                  "endFilePos": 186
+                },
+                "name": "true"
+              }
+            }
+          }
+        }
+      ],
+      "elseifs": [],
+      "else": null
+    },
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 73,
+        "startFilePos": 191,
+        "endLine": 17,
+        "endTokenPos": 133,
+        "endFilePos": 393
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 10,
+          "startTokenPos": 75,
+          "startFilePos": 200,
+          "endLine": 10,
+          "endTokenPos": 75,
+          "endFilePos": 203
+        },
+        "name": "_now"
+      },
+      "params": [],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Global",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 81,
+            "startFilePos": 213,
+            "endLine": 11,
+            "endTokenPos": 87,
+            "endFilePos": 242
+          },
+          "vars": [
+            {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 83,
+                "startFilePos": 220,
+                "endLine": 11,
+                "endTokenPos": 83,
+                "endFilePos": 228
+              },
+              "name": "now_seed"
+            },
+            {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 86,
+                "startFilePos": 231,
+                "endLine": 11,
+                "endTokenPos": 86,
+                "endFilePos": 241
+              },
+              "name": "now_seeded"
+            }
+          ]
+        },
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 89,
+            "startFilePos": 248,
+            "endLine": 15,
+            "endTokenPos": 123,
+            "endFilePos": 366
+          },
+          "cond": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 92,
+              "startFilePos": 252,
+              "endLine": 12,
+              "endTokenPos": 92,
+              "endFilePos": 262
+            },
+            "name": "now_seeded"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 97,
+                "startFilePos": 275,
+                "endLine": 13,
+                "endTokenPos": 116,
+                "endFilePos": 334
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 97,
+                  "startFilePos": 275,
+                  "endLine": 13,
+                  "endTokenPos": 115,
+                  "endFilePos": 333
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 97,
+                    "startFilePos": 275,
+                    "endLine": 13,
+                    "endTokenPos": 97,
+                    "endFilePos": 283
+                  },
+                  "name": "now_seed"
+                },
+                "expr": {
+                  "nodeType": "Expr_BinaryOp_Mod",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 101,
+                    "startFilePos": 287,
+                    "endLine": 13,
+                    "endTokenPos": 115,
+                    "endFilePos": 333
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 102,
+                      "startFilePos": 288,
+                      "endLine": 13,
+                      "endTokenPos": 110,
+                      "endFilePos": 319
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Mul",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 102,
+                        "startFilePos": 288,
+                        "endLine": 13,
+                        "endTokenPos": 106,
+                        "endFilePos": 306
+                      },
+                      "left": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 102,
+                          "startFilePos": 288,
+                          "endLine": 13,
+                          "endTokenPos": 102,
+                          "endFilePos": 296
+                        },
+                        "name": "now_seed"
+                      },
+                      "right": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 106,
+                          "startFilePos": 300,
+                          "endLine": 13,
+                          "endTokenPos": 106,
+                          "endFilePos": 306,
+                          "rawValue": "1664525",
+                          "kind": 10
+                        },
+                        "value": 1664525
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 110,
+                        "startFilePos": 310,
+                        "endLine": 13,
+                        "endTokenPos": 110,
+                        "endFilePos": 319,
+                        "rawValue": "1013904223",
+                        "kind": 10
+                      },
+                      "value": 1013904223
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 115,
+                      "startFilePos": 324,
+                      "endLine": 13,
+                      "endTokenPos": 115,
+                      "endFilePos": 333,
+                      "rawValue": "2147483647",
+                      "kind": 10
+                    },
+                    "value": 2147483647
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Stmt_Return",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 118,
+                "startFilePos": 344,
+                "endLine": 14,
+                "endTokenPos": 121,
+                "endFilePos": 360
+              },
+              "expr": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 120,
+                  "startFilePos": 351,
+                  "endLine": 14,
+                  "endTokenPos": 120,
+                  "endFilePos": 359
+                },
+                "name": "now_seed"
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        },
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 125,
+            "startFilePos": 372,
+            "endLine": 16,
+            "endTokenPos": 131,
+            "endFilePos": 391
+          },
+          "expr": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 127,
+              "startFilePos": 379,
+              "endLine": 16,
+              "endTokenPos": 130,
+              "endFilePos": 390
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 127,
+                "startFilePos": 379,
+                "endLine": 16,
+                "endTokenPos": 127,
+                "endFilePos": 384
+              },
+              "name": "hrtime"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 129,
+                  "startFilePos": 386,
+                  "endLine": 16,
+                  "endTokenPos": 129,
+                  "endFilePos": 389
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ConstFetch",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 129,
+                    "startFilePos": 386,
+                    "endLine": 16,
+                    "endTokenPos": 129,
+                    "endFilePos": 389
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 129,
+                      "startFilePos": 386,
+                      "endLine": 16,
+                      "endTokenPos": 129,
+                      "endFilePos": 389
+                    },
+                    "name": "true"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 18,
+        "startTokenPos": 135,
+        "startFilePos": 395,
+        "endLine": 18,
+        "endTokenPos": 142,
+        "endFilePos": 428
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 18,
+          "startTokenPos": 135,
+          "startFilePos": 395,
+          "endLine": 18,
+          "endTokenPos": 141,
+          "endFilePos": 427
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 135,
+            "startFilePos": 395,
+            "endLine": 18,
+            "endTokenPos": 135,
+            "endFilePos": 406
+          },
+          "name": "__start_mem"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 139,
+            "startFilePos": 410,
+            "endLine": 18,
+            "endTokenPos": 141,
+            "endFilePos": 427
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 18,
+              "startTokenPos": 139,
+              "startFilePos": 410,
+              "endLine": 18,
+              "endTokenPos": 139,
+              "endFilePos": 425
+            },
+            "name": "memory_get_usage"
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 19,
+        "startTokenPos": 144,
+        "startFilePos": 430,
+        "endLine": 19,
+        "endTokenPos": 151,
+        "endFilePos": 447
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 19,
+          "startTokenPos": 144,
+          "startFilePos": 430,
+          "endLine": 19,
+          "endTokenPos": 150,
+          "endFilePos": 446
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 144,
+            "startFilePos": 430,
+            "endLine": 19,
+            "endTokenPos": 144,
+            "endFilePos": 437
+          },
+          "name": "__start"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 148,
+            "startFilePos": 441,
+            "endLine": 19,
+            "endTokenPos": 150,
+            "endFilePos": 446
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 19,
+              "startTokenPos": 148,
+              "startFilePos": 441,
+              "endLine": 19,
+              "endTokenPos": 148,
+              "endFilePos": 444
+            },
+            "name": "_now"
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 20,
+        "startTokenPos": 153,
+        "startFilePos": 451,
+        "endLine": 20,
+        "endTokenPos": 158,
+        "endFilePos": 460
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 20,
+          "startTokenPos": 153,
+          "startFilePos": 451,
+          "endLine": 20,
+          "endTokenPos": 157,
+          "endFilePos": 459
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 20,
+            "startTokenPos": 153,
+            "startFilePos": 451,
+            "endLine": 20,
+            "endTokenPos": 153,
+            "endFilePos": 452
+          },
+          "name": "n"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 20,
+            "startTokenPos": 157,
+            "startFilePos": 456,
+            "endLine": 20,
+            "endTokenPos": 157,
+            "endFilePos": 459,
+            "rawValue": "1000",
+            "kind": 10
+          },
+          "value": 1000
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 21,
+        "startTokenPos": 160,
+        "startFilePos": 464,
+        "endLine": 21,
+        "endTokenPos": 165,
+        "endFilePos": 470
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 21,
+          "startTokenPos": 160,
+          "startFilePos": 464,
+          "endLine": 21,
+          "endTokenPos": 164,
+          "endFilePos": 469
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 21,
+            "startTokenPos": 160,
+            "startFilePos": 464,
+            "endLine": 21,
+            "endTokenPos": 160,
+            "endFilePos": 465
+          },
+          "name": "s"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 21,
+            "startTokenPos": 164,
+            "startFilePos": 469,
+            "endLine": 21,
+            "endTokenPos": 164,
+            "endFilePos": 469,
+            "rawValue": "0",
+            "kind": 10
+          },
+          "value": 0
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_For",
+      "attributes": {
+        "startLine": 22,
+        "startTokenPos": 167,
+        "startFilePos": 474,
+        "endLine": 24,
+        "endTokenPos": 201,
+        "endFilePos": 520
+      },
+      "init": [
+        {
+          "nodeType": "Expr_Assign",
+          "attributes": {
+            "startLine": 22,
+            "startTokenPos": 170,
+            "startFilePos": 479,
+            "endLine": 22,
+            "endTokenPos": 174,
+            "endFilePos": 484
+          },
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 170,
+              "startFilePos": 479,
+              "endLine": 22,
+              "endTokenPos": 170,
+              "endFilePos": 480
+            },
+            "name": "i"
+          },
+          "expr": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 174,
+              "startFilePos": 484,
+              "endLine": 22,
+              "endTokenPos": 174,
+              "endFilePos": 484,
+              "rawValue": "1",
+              "kind": 10
+            },
+            "value": 1
+          }
+        }
+      ],
+      "cond": [
+        {
+          "nodeType": "Expr_BinaryOp_Smaller",
+          "attributes": {
+            "startLine": 22,
+            "startTokenPos": 177,
+            "startFilePos": 487,
+            "endLine": 22,
+            "endTokenPos": 181,
+            "endFilePos": 493
+          },
+          "left": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 177,
+              "startFilePos": 487,
+              "endLine": 22,
+              "endTokenPos": 177,
+              "endFilePos": 488
+            },
+            "name": "i"
+          },
+          "right": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 181,
+              "startFilePos": 492,
+              "endLine": 22,
+              "endTokenPos": 181,
+              "endFilePos": 493
+            },
+            "name": "n"
+          }
+        }
+      ],
+      "loop": [
+        {
+          "nodeType": "Expr_PostInc",
+          "attributes": {
+            "startLine": 22,
+            "startTokenPos": 184,
+            "startFilePos": 496,
+            "endLine": 22,
+            "endTokenPos": 185,
+            "endFilePos": 499
+          },
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 184,
+              "startFilePos": 496,
+              "endLine": 22,
+              "endTokenPos": 184,
+              "endFilePos": 497
+            },
+            "name": "i"
+          }
+        }
+      ],
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 23,
+            "startTokenPos": 190,
+            "startFilePos": 506,
+            "endLine": 23,
+            "endTokenPos": 199,
+            "endFilePos": 518
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 23,
+              "startTokenPos": 190,
+              "startFilePos": 506,
+              "endLine": 23,
+              "endTokenPos": 198,
+              "endFilePos": 517
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 23,
+                "startTokenPos": 190,
+                "startFilePos": 506,
+                "endLine": 23,
+                "endTokenPos": 190,
+                "endFilePos": 507
+              },
+              "name": "s"
+            },
+            "expr": {
+              "nodeType": "Expr_BinaryOp_Plus",
+              "attributes": {
+                "startLine": 23,
+                "startTokenPos": 194,
+                "startFilePos": 511,
+                "endLine": 23,
+                "endTokenPos": 198,
+                "endFilePos": 517
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 23,
+                  "startTokenPos": 194,
+                  "startFilePos": 511,
+                  "endLine": 23,
+                  "endTokenPos": 194,
+                  "endFilePos": 512
+                },
+                "name": "s"
+              },
+              "right": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 23,
+                  "startTokenPos": 198,
+                  "startFilePos": 516,
+                  "endLine": 23,
+                  "endTokenPos": 198,
+                  "endFilePos": 517
+                },
+                "name": "i"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 25,
+        "startTokenPos": 203,
+        "startFilePos": 522,
+        "endLine": 25,
+        "endTokenPos": 210,
+        "endFilePos": 537
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 25,
+          "startTokenPos": 203,
+          "startFilePos": 522,
+          "endLine": 25,
+          "endTokenPos": 209,
+          "endFilePos": 536
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 25,
+            "startTokenPos": 203,
+            "startFilePos": 522,
+            "endLine": 25,
+            "endTokenPos": 203,
+            "endFilePos": 527
+          },
+          "name": "__end"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 25,
+            "startTokenPos": 207,
+            "startFilePos": 531,
+            "endLine": 25,
+            "endTokenPos": 209,
+            "endFilePos": 536
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 25,
+              "startTokenPos": 207,
+              "startFilePos": 531,
+              "endLine": 25,
+              "endTokenPos": 207,
+              "endFilePos": 534
+            },
+            "name": "_now"
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 26,
+        "startTokenPos": 212,
+        "startFilePos": 539,
+        "endLine": 26,
+        "endTokenPos": 219,
+        "endFilePos": 570
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 26,
+          "startTokenPos": 212,
+          "startFilePos": 539,
+          "endLine": 26,
+          "endTokenPos": 218,
+          "endFilePos": 569
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 26,
+            "startTokenPos": 212,
+            "startFilePos": 539,
+            "endLine": 26,
+            "endTokenPos": 212,
+            "endFilePos": 548
+          },
+          "name": "__end_mem"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 26,
+            "startTokenPos": 216,
+            "startFilePos": 552,
+            "endLine": 26,
+            "endTokenPos": 218,
+            "endFilePos": 569
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 26,
+              "startTokenPos": 216,
+              "startFilePos": 552,
+              "endLine": 26,
+              "endTokenPos": 216,
+              "endFilePos": 567
+            },
+            "name": "memory_get_usage"
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 27,
+        "startTokenPos": 221,
+        "startFilePos": 572,
+        "endLine": 27,
+        "endTokenPos": 236,
+        "endFilePos": 617
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 27,
+          "startTokenPos": 221,
+          "startFilePos": 572,
+          "endLine": 27,
+          "endTokenPos": 235,
+          "endFilePos": 616
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 27,
+            "startTokenPos": 221,
+            "startFilePos": 572,
+            "endLine": 27,
+            "endTokenPos": 221,
+            "endFilePos": 582
+          },
+          "name": "__duration"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 27,
+            "startTokenPos": 225,
+            "startFilePos": 586,
+            "endLine": 27,
+            "endTokenPos": 235,
+            "endFilePos": 616
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 27,
+              "startTokenPos": 225,
+              "startFilePos": 586,
+              "endLine": 27,
+              "endTokenPos": 225,
+              "endFilePos": 591
+            },
+            "name": "intdiv"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 27,
+                "startTokenPos": 227,
+                "startFilePos": 593,
+                "endLine": 27,
+                "endTokenPos": 231,
+                "endFilePos": 609
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_BinaryOp_Minus",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 227,
+                  "startFilePos": 593,
+                  "endLine": 27,
+                  "endTokenPos": 231,
+                  "endFilePos": 609
+                },
+                "left": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 227,
+                    "startFilePos": 593,
+                    "endLine": 27,
+                    "endTokenPos": 227,
+                    "endFilePos": 598
+                  },
+                  "name": "__end"
+                },
+                "right": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 231,
+                    "startFilePos": 602,
+                    "endLine": 27,
+                    "endTokenPos": 231,
+                    "endFilePos": 609
+                  },
+                  "name": "__start"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 27,
+                "startTokenPos": 234,
+                "startFilePos": 612,
+                "endLine": 27,
+                "endTokenPos": 234,
+                "endFilePos": 615
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 234,
+                  "startFilePos": 612,
+                  "endLine": 27,
+                  "endTokenPos": 234,
+                  "endFilePos": 615,
+                  "rawValue": "1000",
+                  "kind": 10
+                },
+                "value": 1000
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 28,
+        "startTokenPos": 238,
+        "startFilePos": 619,
+        "endLine": 28,
+        "endTokenPos": 243,
+        "endFilePos": 634
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 28,
+          "startTokenPos": 238,
+          "startFilePos": 619,
+          "endLine": 28,
+          "endTokenPos": 242,
+          "endFilePos": 633
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 28,
+            "startTokenPos": 238,
+            "startFilePos": 619,
+            "endLine": 28,
+            "endTokenPos": 238,
+            "endFilePos": 629
+          },
+          "name": "__mem_diff"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 28,
+            "startTokenPos": 242,
+            "startFilePos": 633,
+            "endLine": 28,
+            "endTokenPos": 242,
+            "endFilePos": 633,
+            "rawValue": "0",
+            "kind": 10
+          },
+          "value": 0
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 29,
+        "startTokenPos": 245,
+        "startFilePos": 636,
+        "endLine": 29,
+        "endTokenPos": 270,
+        "endFilePos": 728
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 29,
+          "startTokenPos": 245,
+          "startFilePos": 636,
+          "endLine": 29,
+          "endTokenPos": 269,
+          "endFilePos": 727
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 29,
+            "startTokenPos": 245,
+            "startFilePos": 636,
+            "endLine": 29,
+            "endTokenPos": 245,
+            "endFilePos": 643
+          },
+          "name": "__bench"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 29,
+            "startTokenPos": 249,
+            "startFilePos": 647,
+            "endLine": 29,
+            "endTokenPos": 269,
+            "endFilePos": 727,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 29,
+                "startTokenPos": 250,
+                "startFilePos": 648,
+                "endLine": 29,
+                "endTokenPos": 254,
+                "endFilePos": 675
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 250,
+                  "startFilePos": 648,
+                  "endLine": 29,
+                  "endTokenPos": 250,
+                  "endFilePos": 660,
+                  "kind": 2,
+                  "rawValue": "\"duration_us\""
+                },
+                "value": "duration_us"
+              },
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 254,
+                  "startFilePos": 665,
+                  "endLine": 29,
+                  "endTokenPos": 254,
+                  "endFilePos": 675
+                },
+                "name": "__duration"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 29,
+                "startTokenPos": 257,
+                "startFilePos": 678,
+                "endLine": 29,
+                "endTokenPos": 261,
+                "endFilePos": 706
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 257,
+                  "startFilePos": 678,
+                  "endLine": 29,
+                  "endTokenPos": 257,
+                  "endFilePos": 691,
+                  "kind": 2,
+                  "rawValue": "\"memory_bytes\""
+                },
+                "value": "memory_bytes"
+              },
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 261,
+                  "startFilePos": 696,
+                  "endLine": 29,
+                  "endTokenPos": 261,
+                  "endFilePos": 706
+                },
+                "name": "__mem_diff"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 29,
+                "startTokenPos": 264,
+                "startFilePos": 709,
+                "endLine": 29,
+                "endTokenPos": 268,
+                "endFilePos": 726
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 264,
+                  "startFilePos": 709,
+                  "endLine": 29,
+                  "endTokenPos": 264,
+                  "endFilePos": 714,
+                  "kind": 2,
+                  "rawValue": "\"name\""
+                },
+                "value": "name"
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 268,
+                  "startFilePos": 719,
+                  "endLine": 29,
+                  "endTokenPos": 268,
+                  "endFilePos": 726,
+                  "kind": 2,
+                  "rawValue": "\"simple\""
+                },
+                "value": "simple"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 30,
+        "startTokenPos": 272,
+        "startFilePos": 730,
+        "endLine": 30,
+        "endTokenPos": 283,
+        "endFilePos": 763
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 30,
+          "startTokenPos": 272,
+          "startFilePos": 730,
+          "endLine": 30,
+          "endTokenPos": 282,
+          "endFilePos": 762
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 30,
+            "startTokenPos": 272,
+            "startFilePos": 730,
+            "endLine": 30,
+            "endTokenPos": 272,
+            "endFilePos": 733
+          },
+          "name": "__j"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 30,
+            "startTokenPos": 276,
+            "startFilePos": 737,
+            "endLine": 30,
+            "endTokenPos": 282,
+            "endFilePos": 762
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 30,
+              "startTokenPos": 276,
+              "startFilePos": 737,
+              "endLine": 30,
+              "endTokenPos": 276,
+              "endFilePos": 747
+            },
+            "name": "json_encode"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 30,
+                "startTokenPos": 278,
+                "startFilePos": 749,
+                "endLine": 30,
+                "endTokenPos": 278,
+                "endFilePos": 756
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 30,
+                  "startTokenPos": 278,
+                  "startFilePos": 749,
+                  "endLine": 30,
+                  "endTokenPos": 278,
+                  "endFilePos": 756
+                },
+                "name": "__bench"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 30,
+                "startTokenPos": 281,
+                "startFilePos": 759,
+                "endLine": 30,
+                "endTokenPos": 281,
+                "endFilePos": 761
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 30,
+                  "startTokenPos": 281,
+                  "startFilePos": 759,
+                  "endLine": 30,
+                  "endTokenPos": 281,
+                  "endFilePos": 761,
+                  "rawValue": "128",
+                  "kind": 10
+                },
+                "value": 128
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 31,
+        "startTokenPos": 285,
+        "startFilePos": 765,
+        "endLine": 31,
+        "endTokenPos": 299,
+        "endFilePos": 803
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 31,
+          "startTokenPos": 285,
+          "startFilePos": 765,
+          "endLine": 31,
+          "endTokenPos": 298,
+          "endFilePos": 802
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 31,
+            "startTokenPos": 285,
+            "startFilePos": 765,
+            "endLine": 31,
+            "endTokenPos": 285,
+            "endFilePos": 768
+          },
+          "name": "__j"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 31,
+            "startTokenPos": 289,
+            "startFilePos": 772,
+            "endLine": 31,
+            "endTokenPos": 298,
+            "endFilePos": 802
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 31,
+              "startTokenPos": 289,
+              "startFilePos": 772,
+              "endLine": 31,
+              "endTokenPos": 289,
+              "endFilePos": 782
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 31,
+                "startTokenPos": 291,
+                "startFilePos": 784,
+                "endLine": 31,
+                "endTokenPos": 291,
+                "endFilePos": 789
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 291,
+                  "startFilePos": 784,
+                  "endLine": 31,
+                  "endTokenPos": 291,
+                  "endFilePos": 789,
+                  "kind": 2,
+                  "rawValue": "\"    \""
+                },
+                "value": "    "
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 31,
+                "startTokenPos": 294,
+                "startFilePos": 792,
+                "endLine": 31,
+                "endTokenPos": 294,
+                "endFilePos": 795
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 294,
+                  "startFilePos": 792,
+                  "endLine": 31,
+                  "endTokenPos": 294,
+                  "endFilePos": 795,
+                  "kind": 2,
+                  "rawValue": "\"  \""
+                },
+                "value": "  "
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 31,
+                "startTokenPos": 297,
+                "startFilePos": 798,
+                "endLine": 31,
+                "endTokenPos": 297,
+                "endFilePos": 801
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 297,
+                  "startFilePos": 798,
+                  "endLine": 31,
+                  "endTokenPos": 297,
+                  "endFilePos": 801
+                },
+                "name": "__j"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 32,
+        "startTokenPos": 301,
+        "startFilePos": 805,
+        "endLine": 32,
+        "endTokenPos": 307,
+        "endFilePos": 823
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 303,
+            "startFilePos": 810,
+            "endLine": 32,
+            "endTokenPos": 303,
+            "endFilePos": 813
+          },
+          "name": "__j"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 306,
+            "startFilePos": 816,
+            "endLine": 32,
+            "endTokenPos": 306,
+            "endFilePos": 822
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 306,
+              "startFilePos": 816,
+              "endLine": 32,
+              "endTokenPos": 306,
+              "endFilePos": 822
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/bigint_ops.php.json
+++ b/tests/json-ast/x/php/bigint_ops.php.json
@@ -1,0 +1,1390 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 13
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 12
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "a"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 12,
+            "rawValue": "10",
+            "kind": 10
+          },
+          "value": 10
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 15,
+        "endLine": 3,
+        "endTokenPos": 13,
+        "endFilePos": 21
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 15,
+          "endLine": 3,
+          "endTokenPos": 12,
+          "endFilePos": 20
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 15,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 16
+          },
+          "name": "b"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 20,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 20,
+            "rawValue": "5",
+            "kind": 10
+          },
+          "value": 5
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 15,
+        "startFilePos": 23,
+        "endLine": 4,
+        "endTokenPos": 52,
+        "endFilePos": 95
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 18,
+            "startFilePos": 29,
+            "endLine": 4,
+            "endTokenPos": 47,
+            "endFilePos": 84
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 18,
+              "startFilePos": 29,
+              "endLine": 4,
+              "endTokenPos": 25,
+              "endFilePos": 45
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 18,
+                "startFilePos": 29,
+                "endLine": 4,
+                "endTokenPos": 18,
+                "endFilePos": 36
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 20,
+                  "startFilePos": 38,
+                  "endLine": 4,
+                  "endTokenPos": 24,
+                  "endFilePos": 44
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 20,
+                    "startFilePos": 38,
+                    "endLine": 4,
+                    "endTokenPos": 24,
+                    "endFilePos": 44
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 20,
+                      "startFilePos": 38,
+                      "endLine": 4,
+                      "endTokenPos": 20,
+                      "endFilePos": 39
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 24,
+                      "startFilePos": 43,
+                      "endLine": 4,
+                      "endTokenPos": 24,
+                      "endFilePos": 44
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 29,
+              "startFilePos": 49,
+              "endLine": 4,
+              "endTokenPos": 39,
+              "endFilePos": 74
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 29,
+                "startFilePos": 49,
+                "endLine": 4,
+                "endTokenPos": 29,
+                "endFilePos": 59
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 31,
+                  "startFilePos": 61,
+                  "endLine": 4,
+                  "endTokenPos": 35,
+                  "endFilePos": 67
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 31,
+                    "startFilePos": 61,
+                    "endLine": 4,
+                    "endTokenPos": 35,
+                    "endFilePos": 67
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 31,
+                      "startFilePos": 61,
+                      "endLine": 4,
+                      "endTokenPos": 31,
+                      "endFilePos": 62
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 35,
+                      "startFilePos": 66,
+                      "endLine": 4,
+                      "endTokenPos": 35,
+                      "endFilePos": 67
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 38,
+                  "startFilePos": 70,
+                  "endLine": 4,
+                  "endTokenPos": 38,
+                  "endFilePos": 73
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 38,
+                    "startFilePos": 70,
+                    "endLine": 4,
+                    "endTokenPos": 38,
+                    "endFilePos": 73,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 43,
+              "startFilePos": 78,
+              "endLine": 4,
+              "endTokenPos": 47,
+              "endFilePos": 84
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 43,
+                "startFilePos": 78,
+                "endLine": 4,
+                "endTokenPos": 43,
+                "endFilePos": 79
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 47,
+                "startFilePos": 83,
+                "endLine": 4,
+                "endTokenPos": 47,
+                "endFilePos": 84
+              },
+              "name": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 51,
+            "startFilePos": 88,
+            "endLine": 4,
+            "endTokenPos": 51,
+            "endFilePos": 94
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 51,
+              "startFilePos": 88,
+              "endLine": 4,
+              "endTokenPos": 51,
+              "endFilePos": 94
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 54,
+        "startFilePos": 97,
+        "endLine": 5,
+        "endTokenPos": 91,
+        "endFilePos": 169
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 57,
+            "startFilePos": 103,
+            "endLine": 5,
+            "endTokenPos": 86,
+            "endFilePos": 158
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 57,
+              "startFilePos": 103,
+              "endLine": 5,
+              "endTokenPos": 64,
+              "endFilePos": 119
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 57,
+                "startFilePos": 103,
+                "endLine": 5,
+                "endTokenPos": 57,
+                "endFilePos": 110
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 59,
+                  "startFilePos": 112,
+                  "endLine": 5,
+                  "endTokenPos": 63,
+                  "endFilePos": 118
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Minus",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 59,
+                    "startFilePos": 112,
+                    "endLine": 5,
+                    "endTokenPos": 63,
+                    "endFilePos": 118
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 59,
+                      "startFilePos": 112,
+                      "endLine": 5,
+                      "endTokenPos": 59,
+                      "endFilePos": 113
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 63,
+                      "startFilePos": 117,
+                      "endLine": 5,
+                      "endTokenPos": 63,
+                      "endFilePos": 118
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 68,
+              "startFilePos": 123,
+              "endLine": 5,
+              "endTokenPos": 78,
+              "endFilePos": 148
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 68,
+                "startFilePos": 123,
+                "endLine": 5,
+                "endTokenPos": 68,
+                "endFilePos": 133
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 70,
+                  "startFilePos": 135,
+                  "endLine": 5,
+                  "endTokenPos": 74,
+                  "endFilePos": 141
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Minus",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 70,
+                    "startFilePos": 135,
+                    "endLine": 5,
+                    "endTokenPos": 74,
+                    "endFilePos": 141
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 70,
+                      "startFilePos": 135,
+                      "endLine": 5,
+                      "endTokenPos": 70,
+                      "endFilePos": 136
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 74,
+                      "startFilePos": 140,
+                      "endLine": 5,
+                      "endTokenPos": 74,
+                      "endFilePos": 141
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 77,
+                  "startFilePos": 144,
+                  "endLine": 5,
+                  "endTokenPos": 77,
+                  "endFilePos": 147
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 77,
+                    "startFilePos": 144,
+                    "endLine": 5,
+                    "endTokenPos": 77,
+                    "endFilePos": 147,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Minus",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 82,
+              "startFilePos": 152,
+              "endLine": 5,
+              "endTokenPos": 86,
+              "endFilePos": 158
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 82,
+                "startFilePos": 152,
+                "endLine": 5,
+                "endTokenPos": 82,
+                "endFilePos": 153
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 86,
+                "startFilePos": 157,
+                "endLine": 5,
+                "endTokenPos": 86,
+                "endFilePos": 158
+              },
+              "name": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 90,
+            "startFilePos": 162,
+            "endLine": 5,
+            "endTokenPos": 90,
+            "endFilePos": 168
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 90,
+              "startFilePos": 162,
+              "endLine": 5,
+              "endTokenPos": 90,
+              "endFilePos": 168
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 93,
+        "startFilePos": 171,
+        "endLine": 6,
+        "endTokenPos": 130,
+        "endFilePos": 243
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 96,
+            "startFilePos": 177,
+            "endLine": 6,
+            "endTokenPos": 125,
+            "endFilePos": 232
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 96,
+              "startFilePos": 177,
+              "endLine": 6,
+              "endTokenPos": 103,
+              "endFilePos": 193
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 96,
+                "startFilePos": 177,
+                "endLine": 6,
+                "endTokenPos": 96,
+                "endFilePos": 184
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 98,
+                  "startFilePos": 186,
+                  "endLine": 6,
+                  "endTokenPos": 102,
+                  "endFilePos": 192
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 98,
+                    "startFilePos": 186,
+                    "endLine": 6,
+                    "endTokenPos": 102,
+                    "endFilePos": 192
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 98,
+                      "startFilePos": 186,
+                      "endLine": 6,
+                      "endTokenPos": 98,
+                      "endFilePos": 187
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 102,
+                      "startFilePos": 191,
+                      "endLine": 6,
+                      "endTokenPos": 102,
+                      "endFilePos": 192
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 107,
+              "startFilePos": 197,
+              "endLine": 6,
+              "endTokenPos": 117,
+              "endFilePos": 222
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 107,
+                "startFilePos": 197,
+                "endLine": 6,
+                "endTokenPos": 107,
+                "endFilePos": 207
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 109,
+                  "startFilePos": 209,
+                  "endLine": 6,
+                  "endTokenPos": 113,
+                  "endFilePos": 215
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 109,
+                    "startFilePos": 209,
+                    "endLine": 6,
+                    "endTokenPos": 113,
+                    "endFilePos": 215
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 109,
+                      "startFilePos": 209,
+                      "endLine": 6,
+                      "endTokenPos": 109,
+                      "endFilePos": 210
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 113,
+                      "startFilePos": 214,
+                      "endLine": 6,
+                      "endTokenPos": 113,
+                      "endFilePos": 215
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 116,
+                  "startFilePos": 218,
+                  "endLine": 6,
+                  "endTokenPos": 116,
+                  "endFilePos": 221
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 116,
+                    "startFilePos": 218,
+                    "endLine": 6,
+                    "endTokenPos": 116,
+                    "endFilePos": 221,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Mul",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 121,
+              "startFilePos": 226,
+              "endLine": 6,
+              "endTokenPos": 125,
+              "endFilePos": 232
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 121,
+                "startFilePos": 226,
+                "endLine": 6,
+                "endTokenPos": 121,
+                "endFilePos": 227
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 125,
+                "startFilePos": 231,
+                "endLine": 6,
+                "endTokenPos": 125,
+                "endFilePos": 232
+              },
+              "name": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 129,
+            "startFilePos": 236,
+            "endLine": 6,
+            "endTokenPos": 129,
+            "endFilePos": 242
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 129,
+              "startFilePos": 236,
+              "endLine": 6,
+              "endTokenPos": 129,
+              "endFilePos": 242
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 132,
+        "startFilePos": 245,
+        "endLine": 7,
+        "endTokenPos": 169,
+        "endFilePos": 317
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 135,
+            "startFilePos": 251,
+            "endLine": 7,
+            "endTokenPos": 164,
+            "endFilePos": 306
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 135,
+              "startFilePos": 251,
+              "endLine": 7,
+              "endTokenPos": 142,
+              "endFilePos": 267
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 135,
+                "startFilePos": 251,
+                "endLine": 7,
+                "endTokenPos": 135,
+                "endFilePos": 258
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 137,
+                  "startFilePos": 260,
+                  "endLine": 7,
+                  "endTokenPos": 141,
+                  "endFilePos": 266
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Div",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 137,
+                    "startFilePos": 260,
+                    "endLine": 7,
+                    "endTokenPos": 141,
+                    "endFilePos": 266
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 137,
+                      "startFilePos": 260,
+                      "endLine": 7,
+                      "endTokenPos": 137,
+                      "endFilePos": 261
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 141,
+                      "startFilePos": 265,
+                      "endLine": 7,
+                      "endTokenPos": 141,
+                      "endFilePos": 266
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 146,
+              "startFilePos": 271,
+              "endLine": 7,
+              "endTokenPos": 156,
+              "endFilePos": 296
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 146,
+                "startFilePos": 271,
+                "endLine": 7,
+                "endTokenPos": 146,
+                "endFilePos": 281
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 148,
+                  "startFilePos": 283,
+                  "endLine": 7,
+                  "endTokenPos": 152,
+                  "endFilePos": 289
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Div",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 148,
+                    "startFilePos": 283,
+                    "endLine": 7,
+                    "endTokenPos": 152,
+                    "endFilePos": 289
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 148,
+                      "startFilePos": 283,
+                      "endLine": 7,
+                      "endTokenPos": 148,
+                      "endFilePos": 284
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 152,
+                      "startFilePos": 288,
+                      "endLine": 7,
+                      "endTokenPos": 152,
+                      "endFilePos": 289
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 155,
+                  "startFilePos": 292,
+                  "endLine": 7,
+                  "endTokenPos": 155,
+                  "endFilePos": 295
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 155,
+                    "startFilePos": 292,
+                    "endLine": 7,
+                    "endTokenPos": 155,
+                    "endFilePos": 295,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Div",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 160,
+              "startFilePos": 300,
+              "endLine": 7,
+              "endTokenPos": 164,
+              "endFilePos": 306
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 160,
+                "startFilePos": 300,
+                "endLine": 7,
+                "endTokenPos": 160,
+                "endFilePos": 301
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 164,
+                "startFilePos": 305,
+                "endLine": 7,
+                "endTokenPos": 164,
+                "endFilePos": 306
+              },
+              "name": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 168,
+            "startFilePos": 310,
+            "endLine": 7,
+            "endTokenPos": 168,
+            "endFilePos": 316
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 168,
+              "startFilePos": 310,
+              "endLine": 7,
+              "endTokenPos": 168,
+              "endFilePos": 316
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 171,
+        "startFilePos": 319,
+        "endLine": 8,
+        "endTokenPos": 208,
+        "endFilePos": 391
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 174,
+            "startFilePos": 325,
+            "endLine": 8,
+            "endTokenPos": 203,
+            "endFilePos": 380
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 174,
+              "startFilePos": 325,
+              "endLine": 8,
+              "endTokenPos": 181,
+              "endFilePos": 341
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 174,
+                "startFilePos": 325,
+                "endLine": 8,
+                "endTokenPos": 174,
+                "endFilePos": 332
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 176,
+                  "startFilePos": 334,
+                  "endLine": 8,
+                  "endTokenPos": 180,
+                  "endFilePos": 340
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mod",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 176,
+                    "startFilePos": 334,
+                    "endLine": 8,
+                    "endTokenPos": 180,
+                    "endFilePos": 340
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 176,
+                      "startFilePos": 334,
+                      "endLine": 8,
+                      "endTokenPos": 176,
+                      "endFilePos": 335
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 180,
+                      "startFilePos": 339,
+                      "endLine": 8,
+                      "endTokenPos": 180,
+                      "endFilePos": 340
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 185,
+              "startFilePos": 345,
+              "endLine": 8,
+              "endTokenPos": 195,
+              "endFilePos": 370
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 185,
+                "startFilePos": 345,
+                "endLine": 8,
+                "endTokenPos": 185,
+                "endFilePos": 355
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 187,
+                  "startFilePos": 357,
+                  "endLine": 8,
+                  "endTokenPos": 191,
+                  "endFilePos": 363
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mod",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 187,
+                    "startFilePos": 357,
+                    "endLine": 8,
+                    "endTokenPos": 191,
+                    "endFilePos": 363
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 187,
+                      "startFilePos": 357,
+                      "endLine": 8,
+                      "endTokenPos": 187,
+                      "endFilePos": 358
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 191,
+                      "startFilePos": 362,
+                      "endLine": 8,
+                      "endTokenPos": 191,
+                      "endFilePos": 363
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 194,
+                  "startFilePos": 366,
+                  "endLine": 8,
+                  "endTokenPos": 194,
+                  "endFilePos": 369
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 194,
+                    "startFilePos": 366,
+                    "endLine": 8,
+                    "endTokenPos": 194,
+                    "endFilePos": 369,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Mod",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 199,
+              "startFilePos": 374,
+              "endLine": 8,
+              "endTokenPos": 203,
+              "endFilePos": 380
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 199,
+                "startFilePos": 374,
+                "endLine": 8,
+                "endTokenPos": 199,
+                "endFilePos": 375
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 203,
+                "startFilePos": 379,
+                "endLine": 8,
+                "endTokenPos": 203,
+                "endFilePos": 380
+              },
+              "name": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 207,
+            "startFilePos": 384,
+            "endLine": 8,
+            "endTokenPos": 207,
+            "endFilePos": 390
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 207,
+              "startFilePos": 384,
+              "endLine": 8,
+              "endTokenPos": 207,
+              "endFilePos": 390
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/binary_precedence.php.json
+++ b/tests/json-ast/x/php/binary_precedence.php.json
@@ -1,0 +1,1384 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 50,
+        "endFilePos": 84
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 45,
+            "endFilePos": 73
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 15,
+              "endFilePos": 30
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 14,
+                  "endFilePos": 29
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 14,
+                    "endFilePos": 29
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 21,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  },
+                  "right": {
+                    "nodeType": "Expr_BinaryOp_Mul",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 10,
+                      "startFilePos": 25,
+                      "endLine": 2,
+                      "endTokenPos": 14,
+                      "endFilePos": 29
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 10,
+                        "startFilePos": 25,
+                        "endLine": 2,
+                        "endTokenPos": 10,
+                        "endFilePos": 25,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 29,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    }
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 19,
+              "startFilePos": 34,
+              "endLine": 2,
+              "endTokenPos": 33,
+              "endFilePos": 61
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 19,
+                "startFilePos": 34,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 44
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 21,
+                  "startFilePos": 46,
+                  "endLine": 2,
+                  "endTokenPos": 29,
+                  "endFilePos": 54
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 21,
+                    "startFilePos": 46,
+                    "endLine": 2,
+                    "endTokenPos": 29,
+                    "endFilePos": 54
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 46,
+                      "endLine": 2,
+                      "endTokenPos": 21,
+                      "endFilePos": 46,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  },
+                  "right": {
+                    "nodeType": "Expr_BinaryOp_Mul",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 25,
+                      "startFilePos": 50,
+                      "endLine": 2,
+                      "endTokenPos": 29,
+                      "endFilePos": 54
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 50,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 50,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 29,
+                        "startFilePos": 54,
+                        "endLine": 2,
+                        "endTokenPos": 29,
+                        "endFilePos": 54,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    }
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 32,
+                  "startFilePos": 57,
+                  "endLine": 2,
+                  "endTokenPos": 32,
+                  "endFilePos": 60
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 32,
+                    "startFilePos": 57,
+                    "endLine": 2,
+                    "endTokenPos": 32,
+                    "endFilePos": 60,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 37,
+              "startFilePos": 65,
+              "endLine": 2,
+              "endTokenPos": 45,
+              "endFilePos": 73
+            },
+            "left": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 37,
+                "startFilePos": 65,
+                "endLine": 2,
+                "endTokenPos": 37,
+                "endFilePos": 65,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            },
+            "right": {
+              "nodeType": "Expr_BinaryOp_Mul",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 41,
+                "startFilePos": 69,
+                "endLine": 2,
+                "endTokenPos": 45,
+                "endFilePos": 73
+              },
+              "left": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 41,
+                  "startFilePos": 69,
+                  "endLine": 2,
+                  "endTokenPos": 41,
+                  "endFilePos": 69,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 45,
+                  "startFilePos": 73,
+                  "endLine": 2,
+                  "endTokenPos": 45,
+                  "endFilePos": 73,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              }
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 49,
+            "startFilePos": 77,
+            "endLine": 2,
+            "endTokenPos": 49,
+            "endFilePos": 83
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 49,
+              "startFilePos": 77,
+              "endLine": 2,
+              "endTokenPos": 49,
+              "endFilePos": 83
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 52,
+        "startFilePos": 86,
+        "endLine": 3,
+        "endTokenPos": 107,
+        "endFilePos": 170
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 92,
+            "endLine": 3,
+            "endTokenPos": 102,
+            "endFilePos": 159
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 55,
+              "startFilePos": 92,
+              "endLine": 3,
+              "endTokenPos": 68,
+              "endFilePos": 112
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 55,
+                "startFilePos": 92,
+                "endLine": 3,
+                "endTokenPos": 55,
+                "endFilePos": 99
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 57,
+                  "startFilePos": 101,
+                  "endLine": 3,
+                  "endTokenPos": 67,
+                  "endFilePos": 111
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 57,
+                    "startFilePos": 101,
+                    "endLine": 3,
+                    "endTokenPos": 67,
+                    "endFilePos": 111
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 58,
+                      "startFilePos": 102,
+                      "endLine": 3,
+                      "endTokenPos": 62,
+                      "endFilePos": 106
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 58,
+                        "startFilePos": 102,
+                        "endLine": 3,
+                        "endTokenPos": 58,
+                        "endFilePos": 102,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 62,
+                        "startFilePos": 106,
+                        "endLine": 3,
+                        "endTokenPos": 62,
+                        "endFilePos": 106,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 67,
+                      "startFilePos": 111,
+                      "endLine": 3,
+                      "endTokenPos": 67,
+                      "endFilePos": 111,
+                      "rawValue": "3",
+                      "kind": 10
+                    },
+                    "value": 3
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 72,
+              "startFilePos": 116,
+              "endLine": 3,
+              "endTokenPos": 88,
+              "endFilePos": 145
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 72,
+                "startFilePos": 116,
+                "endLine": 3,
+                "endTokenPos": 72,
+                "endFilePos": 126
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 74,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 84,
+                  "endFilePos": 138
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 74,
+                    "startFilePos": 128,
+                    "endLine": 3,
+                    "endTokenPos": 84,
+                    "endFilePos": 138
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 75,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 79,
+                      "endFilePos": 133
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 75,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 75,
+                        "endFilePos": 129,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 79,
+                        "startFilePos": 133,
+                        "endLine": 3,
+                        "endTokenPos": 79,
+                        "endFilePos": 133,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 138,
+                      "endLine": 3,
+                      "endTokenPos": 84,
+                      "endFilePos": 138,
+                      "rawValue": "3",
+                      "kind": 10
+                    },
+                    "value": 3
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 87,
+                  "startFilePos": 141,
+                  "endLine": 3,
+                  "endTokenPos": 87,
+                  "endFilePos": 144
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 87,
+                    "startFilePos": 141,
+                    "endLine": 3,
+                    "endTokenPos": 87,
+                    "endFilePos": 144,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Mul",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 92,
+              "startFilePos": 149,
+              "endLine": 3,
+              "endTokenPos": 102,
+              "endFilePos": 159
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_Plus",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 93,
+                "startFilePos": 150,
+                "endLine": 3,
+                "endTokenPos": 97,
+                "endFilePos": 154
+              },
+              "left": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 93,
+                  "startFilePos": 150,
+                  "endLine": 3,
+                  "endTokenPos": 93,
+                  "endFilePos": 150,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 97,
+                  "startFilePos": 154,
+                  "endLine": 3,
+                  "endTokenPos": 97,
+                  "endFilePos": 154,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 102,
+                "startFilePos": 159,
+                "endLine": 3,
+                "endTokenPos": 102,
+                "endFilePos": 159,
+                "rawValue": "3",
+                "kind": 10
+              },
+              "value": 3
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 106,
+            "startFilePos": 163,
+            "endLine": 3,
+            "endTokenPos": 106,
+            "endFilePos": 169
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 106,
+              "startFilePos": 163,
+              "endLine": 3,
+              "endTokenPos": 106,
+              "endFilePos": 169
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 109,
+        "startFilePos": 172,
+        "endLine": 4,
+        "endTokenPos": 158,
+        "endFilePos": 250
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 112,
+            "startFilePos": 178,
+            "endLine": 4,
+            "endTokenPos": 153,
+            "endFilePos": 239
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 112,
+              "startFilePos": 178,
+              "endLine": 4,
+              "endTokenPos": 123,
+              "endFilePos": 196
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 112,
+                "startFilePos": 178,
+                "endLine": 4,
+                "endTokenPos": 112,
+                "endFilePos": 185
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 114,
+                  "startFilePos": 187,
+                  "endLine": 4,
+                  "endTokenPos": 122,
+                  "endFilePos": 195
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 114,
+                    "startFilePos": 187,
+                    "endLine": 4,
+                    "endTokenPos": 122,
+                    "endFilePos": 195
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Mul",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 114,
+                      "startFilePos": 187,
+                      "endLine": 4,
+                      "endTokenPos": 118,
+                      "endFilePos": 191
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 114,
+                        "startFilePos": 187,
+                        "endLine": 4,
+                        "endTokenPos": 114,
+                        "endFilePos": 187,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 118,
+                        "startFilePos": 191,
+                        "endLine": 4,
+                        "endTokenPos": 118,
+                        "endFilePos": 191,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 122,
+                      "startFilePos": 195,
+                      "endLine": 4,
+                      "endTokenPos": 122,
+                      "endFilePos": 195,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 127,
+              "startFilePos": 200,
+              "endLine": 4,
+              "endTokenPos": 141,
+              "endFilePos": 227
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 127,
+                "startFilePos": 200,
+                "endLine": 4,
+                "endTokenPos": 127,
+                "endFilePos": 210
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 129,
+                  "startFilePos": 212,
+                  "endLine": 4,
+                  "endTokenPos": 137,
+                  "endFilePos": 220
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 129,
+                    "startFilePos": 212,
+                    "endLine": 4,
+                    "endTokenPos": 137,
+                    "endFilePos": 220
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Mul",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 129,
+                      "startFilePos": 212,
+                      "endLine": 4,
+                      "endTokenPos": 133,
+                      "endFilePos": 216
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 129,
+                        "startFilePos": 212,
+                        "endLine": 4,
+                        "endTokenPos": 129,
+                        "endFilePos": 212,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 133,
+                        "startFilePos": 216,
+                        "endLine": 4,
+                        "endTokenPos": 133,
+                        "endFilePos": 216,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 137,
+                      "startFilePos": 220,
+                      "endLine": 4,
+                      "endTokenPos": 137,
+                      "endFilePos": 220,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 140,
+                  "startFilePos": 223,
+                  "endLine": 4,
+                  "endTokenPos": 140,
+                  "endFilePos": 226
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 140,
+                    "startFilePos": 223,
+                    "endLine": 4,
+                    "endTokenPos": 140,
+                    "endFilePos": 226,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 145,
+              "startFilePos": 231,
+              "endLine": 4,
+              "endTokenPos": 153,
+              "endFilePos": 239
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_Mul",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 145,
+                "startFilePos": 231,
+                "endLine": 4,
+                "endTokenPos": 149,
+                "endFilePos": 235
+              },
+              "left": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 145,
+                  "startFilePos": 231,
+                  "endLine": 4,
+                  "endTokenPos": 145,
+                  "endFilePos": 231,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 149,
+                  "startFilePos": 235,
+                  "endLine": 4,
+                  "endTokenPos": 149,
+                  "endFilePos": 235,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 153,
+                "startFilePos": 239,
+                "endLine": 4,
+                "endTokenPos": 153,
+                "endFilePos": 239,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 157,
+            "startFilePos": 243,
+            "endLine": 4,
+            "endTokenPos": 157,
+            "endFilePos": 249
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 157,
+              "startFilePos": 243,
+              "endLine": 4,
+              "endTokenPos": 157,
+              "endFilePos": 249
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 160,
+        "startFilePos": 252,
+        "endLine": 5,
+        "endTokenPos": 215,
+        "endFilePos": 336
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 163,
+            "startFilePos": 258,
+            "endLine": 5,
+            "endTokenPos": 210,
+            "endFilePos": 325
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 163,
+              "startFilePos": 258,
+              "endLine": 5,
+              "endTokenPos": 176,
+              "endFilePos": 278
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 163,
+                "startFilePos": 258,
+                "endLine": 5,
+                "endTokenPos": 163,
+                "endFilePos": 265
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 165,
+                  "startFilePos": 267,
+                  "endLine": 5,
+                  "endTokenPos": 175,
+                  "endFilePos": 277
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 165,
+                    "startFilePos": 267,
+                    "endLine": 5,
+                    "endTokenPos": 175,
+                    "endFilePos": 277
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 165,
+                      "startFilePos": 267,
+                      "endLine": 5,
+                      "endTokenPos": 165,
+                      "endFilePos": 267,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  },
+                  "right": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 170,
+                      "startFilePos": 272,
+                      "endLine": 5,
+                      "endTokenPos": 174,
+                      "endFilePos": 276
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 170,
+                        "startFilePos": 272,
+                        "endLine": 5,
+                        "endTokenPos": 170,
+                        "endFilePos": 272,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 174,
+                        "startFilePos": 276,
+                        "endLine": 5,
+                        "endTokenPos": 174,
+                        "endFilePos": 276,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    }
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 180,
+              "startFilePos": 282,
+              "endLine": 5,
+              "endTokenPos": 196,
+              "endFilePos": 311
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 180,
+                "startFilePos": 282,
+                "endLine": 5,
+                "endTokenPos": 180,
+                "endFilePos": 292
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 182,
+                  "startFilePos": 294,
+                  "endLine": 5,
+                  "endTokenPos": 192,
+                  "endFilePos": 304
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 182,
+                    "startFilePos": 294,
+                    "endLine": 5,
+                    "endTokenPos": 192,
+                    "endFilePos": 304
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 182,
+                      "startFilePos": 294,
+                      "endLine": 5,
+                      "endTokenPos": 182,
+                      "endFilePos": 294,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  },
+                  "right": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 187,
+                      "startFilePos": 299,
+                      "endLine": 5,
+                      "endTokenPos": 191,
+                      "endFilePos": 303
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 187,
+                        "startFilePos": 299,
+                        "endLine": 5,
+                        "endTokenPos": 187,
+                        "endFilePos": 299,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 191,
+                        "startFilePos": 303,
+                        "endLine": 5,
+                        "endTokenPos": 191,
+                        "endFilePos": 303,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    }
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 195,
+                  "startFilePos": 307,
+                  "endLine": 5,
+                  "endTokenPos": 195,
+                  "endFilePos": 310
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 195,
+                    "startFilePos": 307,
+                    "endLine": 5,
+                    "endTokenPos": 195,
+                    "endFilePos": 310,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Mul",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 200,
+              "startFilePos": 315,
+              "endLine": 5,
+              "endTokenPos": 210,
+              "endFilePos": 325
+            },
+            "left": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 200,
+                "startFilePos": 315,
+                "endLine": 5,
+                "endTokenPos": 200,
+                "endFilePos": 315,
+                "rawValue": "2",
+                "kind": 10
+              },
+              "value": 2
+            },
+            "right": {
+              "nodeType": "Expr_BinaryOp_Plus",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 205,
+                "startFilePos": 320,
+                "endLine": 5,
+                "endTokenPos": 209,
+                "endFilePos": 324
+              },
+              "left": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 205,
+                  "startFilePos": 320,
+                  "endLine": 5,
+                  "endTokenPos": 205,
+                  "endFilePos": 320,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 209,
+                  "startFilePos": 324,
+                  "endLine": 5,
+                  "endTokenPos": 209,
+                  "endFilePos": 324,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              }
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 214,
+            "startFilePos": 329,
+            "endLine": 5,
+            "endTokenPos": 214,
+            "endFilePos": 335
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 214,
+              "startFilePos": 329,
+              "endLine": 5,
+              "endTokenPos": 214,
+              "endFilePos": 335
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/bool_chain.php.json
+++ b/tests/json-ast/x/php/bool_chain.php.json
@@ -1,0 +1,779 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 5,
+        "endTokenPos": 22,
+        "endFilePos": 63
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 18
+        },
+        "name": "boom"
+      },
+      "params": [],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 9,
+            "startFilePos": 26,
+            "endLine": 3,
+            "endTokenPos": 15,
+            "endFilePos": 46
+          },
+          "exprs": [
+            {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 11,
+                "startFilePos": 31,
+                "endLine": 3,
+                "endTokenPos": 11,
+                "endFilePos": 36,
+                "kind": 2,
+                "rawValue": "\"boom\""
+              },
+              "value": "boom"
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 14,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 14,
+                "endFilePos": 45
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 14,
+                  "startFilePos": 39,
+                  "endLine": 3,
+                  "endTokenPos": 14,
+                  "endFilePos": 45
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        },
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 17,
+            "startFilePos": 50,
+            "endLine": 4,
+            "endTokenPos": 20,
+            "endFilePos": 61
+          },
+          "expr": {
+            "nodeType": "Expr_ConstFetch",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 19,
+              "startFilePos": 57,
+              "endLine": 4,
+              "endTokenPos": 19,
+              "endFilePos": 60
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 19,
+                "startFilePos": 57,
+                "endLine": 4,
+                "endTokenPos": 19,
+                "endFilePos": 60
+              },
+              "name": "true"
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 24,
+        "startFilePos": 65,
+        "endLine": 6,
+        "endTokenPos": 66,
+        "endFilePos": 129
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 27,
+            "startFilePos": 71,
+            "endLine": 6,
+            "endTokenPos": 61,
+            "endFilePos": 118
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_BooleanAnd",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 27,
+              "startFilePos": 71,
+              "endLine": 6,
+              "endTokenPos": 53,
+              "endFilePos": 99
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_BooleanAnd",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 27,
+                "startFilePos": 71,
+                "endLine": 6,
+                "endTokenPos": 43,
+                "endFilePos": 88
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Smaller",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 28,
+                  "startFilePos": 72,
+                  "endLine": 6,
+                  "endTokenPos": 32,
+                  "endFilePos": 76
+                },
+                "left": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 28,
+                    "startFilePos": 72,
+                    "endLine": 6,
+                    "endTokenPos": 28,
+                    "endFilePos": 72,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "right": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 32,
+                    "startFilePos": 76,
+                    "endLine": 6,
+                    "endTokenPos": 32,
+                    "endFilePos": 76,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                }
+              },
+              "right": {
+                "nodeType": "Expr_BinaryOp_Smaller",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 38,
+                  "startFilePos": 83,
+                  "endLine": 6,
+                  "endTokenPos": 42,
+                  "endFilePos": 87
+                },
+                "left": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 38,
+                    "startFilePos": 83,
+                    "endLine": 6,
+                    "endTokenPos": 38,
+                    "endFilePos": 83,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "right": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 42,
+                    "startFilePos": 87,
+                    "endLine": 6,
+                    "endTokenPos": 42,
+                    "endFilePos": 87,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                }
+              }
+            },
+            "right": {
+              "nodeType": "Expr_BinaryOp_Smaller",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 48,
+                "startFilePos": 94,
+                "endLine": 6,
+                "endTokenPos": 52,
+                "endFilePos": 98
+              },
+              "left": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 48,
+                  "startFilePos": 94,
+                  "endLine": 6,
+                  "endTokenPos": 48,
+                  "endFilePos": 94,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 52,
+                  "startFilePos": 98,
+                  "endLine": 6,
+                  "endTokenPos": 52,
+                  "endFilePos": 98,
+                  "rawValue": "4",
+                  "kind": 10
+                },
+                "value": 4
+              }
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 57,
+              "startFilePos": 103,
+              "endLine": 6,
+              "endTokenPos": 57,
+              "endFilePos": 108,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 61,
+              "startFilePos": 112,
+              "endLine": 6,
+              "endTokenPos": 61,
+              "endFilePos": 118,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 65,
+            "startFilePos": 122,
+            "endLine": 6,
+            "endTokenPos": 65,
+            "endFilePos": 128
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 65,
+              "startFilePos": 122,
+              "endLine": 6,
+              "endTokenPos": 65,
+              "endFilePos": 128
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 68,
+        "startFilePos": 131,
+        "endLine": 7,
+        "endTokenPos": 106,
+        "endFilePos": 194
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 71,
+            "startFilePos": 137,
+            "endLine": 7,
+            "endTokenPos": 101,
+            "endFilePos": 183
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_BooleanAnd",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 71,
+              "startFilePos": 137,
+              "endLine": 7,
+              "endTokenPos": 93,
+              "endFilePos": 164
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_BooleanAnd",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 71,
+                "startFilePos": 137,
+                "endLine": 7,
+                "endTokenPos": 87,
+                "endFilePos": 154
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Smaller",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 72,
+                  "startFilePos": 138,
+                  "endLine": 7,
+                  "endTokenPos": 76,
+                  "endFilePos": 142
+                },
+                "left": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 72,
+                    "startFilePos": 138,
+                    "endLine": 7,
+                    "endTokenPos": 72,
+                    "endFilePos": 138,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "right": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 76,
+                    "startFilePos": 142,
+                    "endLine": 7,
+                    "endTokenPos": 76,
+                    "endFilePos": 142,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                }
+              },
+              "right": {
+                "nodeType": "Expr_BinaryOp_Greater",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 82,
+                  "startFilePos": 149,
+                  "endLine": 7,
+                  "endTokenPos": 86,
+                  "endFilePos": 153
+                },
+                "left": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 82,
+                    "startFilePos": 149,
+                    "endLine": 7,
+                    "endTokenPos": 82,
+                    "endFilePos": 149,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "right": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 86,
+                    "startFilePos": 153,
+                    "endLine": 7,
+                    "endTokenPos": 86,
+                    "endFilePos": 153,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                }
+              }
+            },
+            "right": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 91,
+                "startFilePos": 159,
+                "endLine": 7,
+                "endTokenPos": 93,
+                "endFilePos": 164
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 91,
+                  "startFilePos": 159,
+                  "endLine": 7,
+                  "endTokenPos": 91,
+                  "endFilePos": 162
+                },
+                "name": "boom"
+              },
+              "args": []
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 97,
+              "startFilePos": 168,
+              "endLine": 7,
+              "endTokenPos": 97,
+              "endFilePos": 173,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 101,
+              "startFilePos": 177,
+              "endLine": 7,
+              "endTokenPos": 101,
+              "endFilePos": 183,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 105,
+            "startFilePos": 187,
+            "endLine": 7,
+            "endTokenPos": 105,
+            "endFilePos": 193
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 105,
+              "startFilePos": 187,
+              "endLine": 7,
+              "endTokenPos": 105,
+              "endFilePos": 193
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 108,
+        "startFilePos": 196,
+        "endLine": 8,
+        "endTokenPos": 156,
+        "endFilePos": 270
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 111,
+            "startFilePos": 202,
+            "endLine": 8,
+            "endTokenPos": 151,
+            "endFilePos": 259
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_BooleanAnd",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 111,
+              "startFilePos": 202,
+              "endLine": 8,
+              "endTokenPos": 143,
+              "endFilePos": 240
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_BooleanAnd",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 111,
+                "startFilePos": 202,
+                "endLine": 8,
+                "endTokenPos": 137,
+                "endFilePos": 230
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_BooleanAnd",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 111,
+                  "startFilePos": 202,
+                  "endLine": 8,
+                  "endTokenPos": 127,
+                  "endFilePos": 219
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Smaller",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 112,
+                    "startFilePos": 203,
+                    "endLine": 8,
+                    "endTokenPos": 116,
+                    "endFilePos": 207
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 112,
+                      "startFilePos": 203,
+                      "endLine": 8,
+                      "endTokenPos": 112,
+                      "endFilePos": 203,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 116,
+                      "startFilePos": 207,
+                      "endLine": 8,
+                      "endTokenPos": 116,
+                      "endFilePos": 207,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "right": {
+                  "nodeType": "Expr_BinaryOp_Smaller",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 122,
+                    "startFilePos": 214,
+                    "endLine": 8,
+                    "endTokenPos": 126,
+                    "endFilePos": 218
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 122,
+                      "startFilePos": 214,
+                      "endLine": 8,
+                      "endTokenPos": 122,
+                      "endFilePos": 214,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 126,
+                      "startFilePos": 218,
+                      "endLine": 8,
+                      "endTokenPos": 126,
+                      "endFilePos": 218,
+                      "rawValue": "3",
+                      "kind": 10
+                    },
+                    "value": 3
+                  }
+                }
+              },
+              "right": {
+                "nodeType": "Expr_BinaryOp_Greater",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 132,
+                  "startFilePos": 225,
+                  "endLine": 8,
+                  "endTokenPos": 136,
+                  "endFilePos": 229
+                },
+                "left": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 132,
+                    "startFilePos": 225,
+                    "endLine": 8,
+                    "endTokenPos": 132,
+                    "endFilePos": 225,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "right": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 136,
+                    "startFilePos": 229,
+                    "endLine": 8,
+                    "endTokenPos": 136,
+                    "endFilePos": 229,
+                    "rawValue": "4",
+                    "kind": 10
+                  },
+                  "value": 4
+                }
+              }
+            },
+            "right": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 141,
+                "startFilePos": 235,
+                "endLine": 8,
+                "endTokenPos": 143,
+                "endFilePos": 240
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 141,
+                  "startFilePos": 235,
+                  "endLine": 8,
+                  "endTokenPos": 141,
+                  "endFilePos": 238
+                },
+                "name": "boom"
+              },
+              "args": []
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 147,
+              "startFilePos": 244,
+              "endLine": 8,
+              "endTokenPos": 147,
+              "endFilePos": 249,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 151,
+              "startFilePos": 253,
+              "endLine": 8,
+              "endTokenPos": 151,
+              "endFilePos": 259,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 155,
+            "startFilePos": 263,
+            "endLine": 8,
+            "endTokenPos": 155,
+            "endFilePos": 269
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 155,
+              "startFilePos": 263,
+              "endLine": 8,
+              "endTokenPos": 155,
+              "endFilePos": 269
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/break_continue.php.json
+++ b/tests/json-ast/x/php/break_continue.php.json
@@ -1,0 +1,735 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 32,
+        "endFilePos": 44
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 31,
+          "endFilePos": 43
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 13
+          },
+          "name": "numbers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 17,
+            "endLine": 2,
+            "endTokenPos": 31,
+            "endFilePos": 43,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 18,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 21,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 21
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 21,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 24,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 24
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 24,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 24,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 15,
+                "startFilePos": 27,
+                "endLine": 2,
+                "endTokenPos": 15,
+                "endFilePos": 27
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 15,
+                  "startFilePos": 27,
+                  "endLine": 2,
+                  "endTokenPos": 15,
+                  "endFilePos": 27,
+                  "rawValue": "4",
+                  "kind": 10
+                },
+                "value": 4
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 18,
+                "startFilePos": 30,
+                "endLine": 2,
+                "endTokenPos": 18,
+                "endFilePos": 30
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 18,
+                  "startFilePos": 30,
+                  "endLine": 2,
+                  "endTokenPos": 18,
+                  "endFilePos": 30,
+                  "rawValue": "5",
+                  "kind": 10
+                },
+                "value": 5
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 21,
+                "startFilePos": 33,
+                "endLine": 2,
+                "endTokenPos": 21,
+                "endFilePos": 33
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 21,
+                  "startFilePos": 33,
+                  "endLine": 2,
+                  "endTokenPos": 21,
+                  "endFilePos": 33,
+                  "rawValue": "6",
+                  "kind": 10
+                },
+                "value": 6
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 24,
+                "startFilePos": 36,
+                "endLine": 2,
+                "endTokenPos": 24,
+                "endFilePos": 36
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 36,
+                  "endLine": 2,
+                  "endTokenPos": 24,
+                  "endFilePos": 36,
+                  "rawValue": "7",
+                  "kind": 10
+                },
+                "value": 7
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 27,
+                "startFilePos": 39,
+                "endLine": 2,
+                "endTokenPos": 27,
+                "endFilePos": 39
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 27,
+                  "startFilePos": 39,
+                  "endLine": 2,
+                  "endTokenPos": 27,
+                  "endFilePos": 39,
+                  "rawValue": "8",
+                  "kind": 10
+                },
+                "value": 8
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 30,
+                "startFilePos": 42,
+                "endLine": 2,
+                "endTokenPos": 30,
+                "endFilePos": 42
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 30,
+                  "startFilePos": 42,
+                  "endLine": 2,
+                  "endTokenPos": 30,
+                  "endFilePos": 42,
+                  "rawValue": "9",
+                  "kind": 10
+                },
+                "value": 9
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 34,
+        "startFilePos": 46,
+        "endLine": 11,
+        "endTokenPos": 119,
+        "endFilePos": 218
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 37,
+          "startFilePos": 55,
+          "endLine": 3,
+          "endTokenPos": 37,
+          "endFilePos": 62
+        },
+        "name": "numbers"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 41,
+          "startFilePos": 67,
+          "endLine": 3,
+          "endTokenPos": 41,
+          "endFilePos": 68
+        },
+        "name": "n"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 46,
+            "startFilePos": 75,
+            "endLine": 6,
+            "endTokenPos": 65,
+            "endFilePos": 106
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Equal",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 49,
+              "startFilePos": 79,
+              "endLine": 4,
+              "endTokenPos": 57,
+              "endFilePos": 89
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_Mod",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 49,
+                "startFilePos": 79,
+                "endLine": 4,
+                "endTokenPos": 53,
+                "endFilePos": 84
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 49,
+                  "startFilePos": 79,
+                  "endLine": 4,
+                  "endTokenPos": 49,
+                  "endFilePos": 80
+                },
+                "name": "n"
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 53,
+                  "startFilePos": 84,
+                  "endLine": 4,
+                  "endTokenPos": 53,
+                  "endFilePos": 84,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 57,
+                "startFilePos": 89,
+                "endLine": 4,
+                "endTokenPos": 57,
+                "endFilePos": 89,
+                "rawValue": "0",
+                "kind": 10
+              },
+              "value": 0
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Continue",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 62,
+                "startFilePos": 96,
+                "endLine": 5,
+                "endTokenPos": 63,
+                "endFilePos": 104
+              },
+              "num": null
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        },
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 67,
+            "startFilePos": 110,
+            "endLine": 9,
+            "endTokenPos": 82,
+            "endFilePos": 133
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Greater",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 70,
+              "startFilePos": 114,
+              "endLine": 7,
+              "endTokenPos": 74,
+              "endFilePos": 119
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 70,
+                "startFilePos": 114,
+                "endLine": 7,
+                "endTokenPos": 70,
+                "endFilePos": 115
+              },
+              "name": "n"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 74,
+                "startFilePos": 119,
+                "endLine": 7,
+                "endTokenPos": 74,
+                "endFilePos": 119,
+                "rawValue": "7",
+                "kind": 10
+              },
+              "value": 7
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Break",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 79,
+                "startFilePos": 126,
+                "endLine": 8,
+                "endTokenPos": 80,
+                "endFilePos": 131
+              },
+              "num": null
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        },
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 84,
+            "startFilePos": 137,
+            "endLine": 10,
+            "endTokenPos": 117,
+            "endFilePos": 216
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 86,
+                "startFilePos": 142,
+                "endLine": 10,
+                "endTokenPos": 113,
+                "endFilePos": 206
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 86,
+                  "startFilePos": 142,
+                  "endLine": 10,
+                  "endTokenPos": 90,
+                  "endFilePos": 160
+                },
+                "left": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 86,
+                    "startFilePos": 142,
+                    "endLine": 10,
+                    "endTokenPos": 86,
+                    "endFilePos": 154,
+                    "kind": 2,
+                    "rawValue": "\"odd number:\""
+                  },
+                  "value": "odd number:"
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 90,
+                    "startFilePos": 158,
+                    "endLine": 10,
+                    "endTokenPos": 90,
+                    "endFilePos": 160,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 95,
+                  "startFilePos": 165,
+                  "endLine": 10,
+                  "endTokenPos": 112,
+                  "endFilePos": 205
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 95,
+                    "startFilePos": 165,
+                    "endLine": 10,
+                    "endTokenPos": 98,
+                    "endFilePos": 176
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 95,
+                      "startFilePos": 165,
+                      "endLine": 10,
+                      "endTokenPos": 95,
+                      "endFilePos": 172
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 97,
+                        "startFilePos": 174,
+                        "endLine": 10,
+                        "endTokenPos": 97,
+                        "endFilePos": 175
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 97,
+                          "startFilePos": 174,
+                          "endLine": 10,
+                          "endTokenPos": 97,
+                          "endFilePos": 175
+                        },
+                        "name": "n"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 102,
+                    "startFilePos": 180,
+                    "endLine": 10,
+                    "endTokenPos": 108,
+                    "endFilePos": 200
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 102,
+                      "startFilePos": 180,
+                      "endLine": 10,
+                      "endTokenPos": 102,
+                      "endFilePos": 190
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 104,
+                        "startFilePos": 192,
+                        "endLine": 10,
+                        "endTokenPos": 104,
+                        "endFilePos": 193
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 104,
+                          "startFilePos": 192,
+                          "endLine": 10,
+                          "endTokenPos": 104,
+                          "endFilePos": 193
+                        },
+                        "name": "n"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 107,
+                        "startFilePos": 196,
+                        "endLine": 10,
+                        "endTokenPos": 107,
+                        "endFilePos": 199
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 107,
+                          "startFilePos": 196,
+                          "endLine": 10,
+                          "endTokenPos": 107,
+                          "endFilePos": 199,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 112,
+                    "startFilePos": 204,
+                    "endLine": 10,
+                    "endTokenPos": 112,
+                    "endFilePos": 205
+                  },
+                  "name": "n"
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 116,
+                "startFilePos": 209,
+                "endLine": 10,
+                "endTokenPos": 116,
+                "endFilePos": 215
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 116,
+                  "startFilePos": 209,
+                  "endLine": 10,
+                  "endTokenPos": 116,
+                  "endFilePos": 215
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/cast_string_to_int.php.json
+++ b/tests/json-ast/x/php/cast_string_to_int.php.json
@@ -1,0 +1,316 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 35,
+        "endFilePos": 99
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 30,
+            "endFilePos": 88
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 10,
+              "endFilePos": 35
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 34
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 9,
+                    "endFilePos": 34
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 26
+                    },
+                    "name": "intval"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 8,
+                        "endFilePos": 33
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 28,
+                          "endLine": 2,
+                          "endTokenPos": 8,
+                          "endFilePos": 33,
+                          "kind": 2,
+                          "rawValue": "\"1995\""
+                        },
+                        "value": "1995"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 14,
+              "startFilePos": 39,
+              "endLine": 2,
+              "endTokenPos": 23,
+              "endFilePos": 71
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 14,
+                "startFilePos": 39,
+                "endLine": 2,
+                "endTokenPos": 14,
+                "endFilePos": 49
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 16,
+                  "startFilePos": 51,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 64
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 16,
+                    "startFilePos": 51,
+                    "endLine": 2,
+                    "endTokenPos": 19,
+                    "endFilePos": 64
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 51,
+                      "endLine": 2,
+                      "endTokenPos": 16,
+                      "endFilePos": 56
+                    },
+                    "name": "intval"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 58,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 63
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 18,
+                          "startFilePos": 58,
+                          "endLine": 2,
+                          "endTokenPos": 18,
+                          "endFilePos": 63,
+                          "kind": 2,
+                          "rawValue": "\"1995\""
+                        },
+                        "value": "1995"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 67,
+                  "endLine": 2,
+                  "endTokenPos": 22,
+                  "endFilePos": 70
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 22,
+                    "startFilePos": 67,
+                    "endLine": 2,
+                    "endTokenPos": 22,
+                    "endFilePos": 70,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 27,
+              "startFilePos": 75,
+              "endLine": 2,
+              "endTokenPos": 30,
+              "endFilePos": 88
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 27,
+                "startFilePos": 75,
+                "endLine": 2,
+                "endTokenPos": 27,
+                "endFilePos": 80
+              },
+              "name": "intval"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 82,
+                  "endLine": 2,
+                  "endTokenPos": 29,
+                  "endFilePos": 87
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 29,
+                    "startFilePos": 82,
+                    "endLine": 2,
+                    "endTokenPos": 29,
+                    "endFilePos": 87,
+                    "kind": 2,
+                    "rawValue": "\"1995\""
+                  },
+                  "value": "1995"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 34,
+            "startFilePos": 92,
+            "endLine": 2,
+            "endTokenPos": 34,
+            "endFilePos": 98
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 34,
+              "startFilePos": 92,
+              "endLine": 2,
+              "endTokenPos": 34,
+              "endFilePos": 98
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/cast_struct.php.json
+++ b/tests/json-ast/x/php/cast_struct.php.json
@@ -1,0 +1,357 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 12,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 11,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "todo"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 11,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 21,
+                  "kind": 2,
+                  "rawValue": "\"title\""
+                },
+                "value": "title"
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 26,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 29,
+                  "kind": 2,
+                  "rawValue": "\"hi\""
+                },
+                "value": "hi"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 14,
+        "startFilePos": 33,
+        "endLine": 3,
+        "endTokenPos": 48,
+        "endFilePos": 126
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 17,
+            "startFilePos": 39,
+            "endLine": 3,
+            "endTokenPos": 43,
+            "endFilePos": 115
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 17,
+              "startFilePos": 39,
+              "endLine": 3,
+              "endTokenPos": 23,
+              "endFilePos": 62
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 17,
+                "endFilePos": 46
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 19,
+                  "startFilePos": 48,
+                  "endLine": 3,
+                  "endTokenPos": 22,
+                  "endFilePos": 61
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 19,
+                    "startFilePos": 48,
+                    "endLine": 3,
+                    "endTokenPos": 22,
+                    "endFilePos": 61
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 19,
+                      "startFilePos": 48,
+                      "endLine": 3,
+                      "endTokenPos": 19,
+                      "endFilePos": 52
+                    },
+                    "name": "todo"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 21,
+                      "startFilePos": 54,
+                      "endLine": 3,
+                      "endTokenPos": 21,
+                      "endFilePos": 60,
+                      "kind": 2,
+                      "rawValue": "\"title\""
+                    },
+                    "value": "title"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 27,
+              "startFilePos": 66,
+              "endLine": 3,
+              "endTokenPos": 36,
+              "endFilePos": 98
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 27,
+                "startFilePos": 66,
+                "endLine": 3,
+                "endTokenPos": 27,
+                "endFilePos": 76
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 29,
+                  "startFilePos": 78,
+                  "endLine": 3,
+                  "endTokenPos": 32,
+                  "endFilePos": 91
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 29,
+                    "startFilePos": 78,
+                    "endLine": 3,
+                    "endTokenPos": 32,
+                    "endFilePos": 91
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 29,
+                      "startFilePos": 78,
+                      "endLine": 3,
+                      "endTokenPos": 29,
+                      "endFilePos": 82
+                    },
+                    "name": "todo"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 31,
+                      "startFilePos": 84,
+                      "endLine": 3,
+                      "endTokenPos": 31,
+                      "endFilePos": 90,
+                      "kind": 2,
+                      "rawValue": "\"title\""
+                    },
+                    "value": "title"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 35,
+                  "startFilePos": 94,
+                  "endLine": 3,
+                  "endTokenPos": 35,
+                  "endFilePos": 97
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 35,
+                    "startFilePos": 94,
+                    "endLine": 3,
+                    "endTokenPos": 35,
+                    "endFilePos": 97,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 40,
+              "startFilePos": 102,
+              "endLine": 3,
+              "endTokenPos": 43,
+              "endFilePos": 115
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 40,
+                "startFilePos": 102,
+                "endLine": 3,
+                "endTokenPos": 40,
+                "endFilePos": 106
+              },
+              "name": "todo"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 42,
+                "startFilePos": 108,
+                "endLine": 3,
+                "endTokenPos": 42,
+                "endFilePos": 114,
+                "kind": 2,
+                "rawValue": "\"title\""
+              },
+              "value": "title"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 47,
+            "startFilePos": 119,
+            "endLine": 3,
+            "endTokenPos": 47,
+            "endFilePos": 125
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 47,
+              "startFilePos": 119,
+              "endLine": 3,
+              "endTokenPos": 47,
+              "endFilePos": 125
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/closure.php.json
+++ b/tests/json-ast/x/php/closure.php.json
@@ -1,0 +1,595 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 6,
+        "endTokenPos": 37,
+        "endFilePos": 85
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 23
+        },
+        "name": "makeAdder"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 25,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 26
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 25,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 26
+            },
+            "name": "n"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 10,
+            "startFilePos": 33,
+            "endLine": 5,
+            "endTokenPos": 35,
+            "endFilePos": 83
+          },
+          "expr": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 12,
+              "startFilePos": 40,
+              "endLine": 5,
+              "endTokenPos": 34,
+              "endFilePos": 82
+            },
+            "static": false,
+            "byRef": false,
+            "params": [
+              {
+                "nodeType": "Param",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 14,
+                  "startFilePos": 49,
+                  "endLine": 3,
+                  "endTokenPos": 14,
+                  "endFilePos": 50
+                },
+                "type": null,
+                "byRef": false,
+                "variadic": false,
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 14,
+                    "startFilePos": 49,
+                    "endLine": 3,
+                    "endTokenPos": 14,
+                    "endFilePos": 50
+                  },
+                  "name": "x"
+                },
+                "default": null,
+                "flags": 0,
+                "attrGroups": [],
+                "hooks": []
+              }
+            ],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 20,
+                  "startFilePos": 58,
+                  "endLine": 3,
+                  "endTokenPos": 20,
+                  "endFilePos": 59
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 20,
+                    "startFilePos": 58,
+                    "endLine": 3,
+                    "endTokenPos": 20,
+                    "endFilePos": 59
+                  },
+                  "name": "n"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 25,
+                  "startFilePos": 66,
+                  "endLine": 4,
+                  "endTokenPos": 32,
+                  "endFilePos": 80
+                },
+                "expr": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 27,
+                    "startFilePos": 73,
+                    "endLine": 4,
+                    "endTokenPos": 31,
+                    "endFilePos": 79
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 27,
+                      "startFilePos": 73,
+                      "endLine": 4,
+                      "endTokenPos": 27,
+                      "endFilePos": 74
+                    },
+                    "name": "x"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 31,
+                      "startFilePos": 78,
+                      "endLine": 4,
+                      "endTokenPos": 31,
+                      "endFilePos": 79
+                    },
+                    "name": "n"
+                  }
+                }
+              }
+            ],
+            "attrGroups": []
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 39,
+        "startFilePos": 87,
+        "endLine": 7,
+        "endTokenPos": 47,
+        "endFilePos": 109
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 7,
+          "startTokenPos": 39,
+          "startFilePos": 87,
+          "endLine": 7,
+          "endTokenPos": 46,
+          "endFilePos": 108
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 39,
+            "startFilePos": 87,
+            "endLine": 7,
+            "endTokenPos": 39,
+            "endFilePos": 92
+          },
+          "name": "add10"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 43,
+            "startFilePos": 96,
+            "endLine": 7,
+            "endTokenPos": 46,
+            "endFilePos": 108
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 43,
+              "startFilePos": 96,
+              "endLine": 7,
+              "endTokenPos": 43,
+              "endFilePos": 104
+            },
+            "name": "makeAdder"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 45,
+                "startFilePos": 106,
+                "endLine": 7,
+                "endTokenPos": 45,
+                "endFilePos": 107
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 45,
+                  "startFilePos": 106,
+                  "endLine": 7,
+                  "endTokenPos": 45,
+                  "endFilePos": 107,
+                  "rawValue": "10",
+                  "kind": 10
+                },
+                "value": 10
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 49,
+        "startFilePos": 111,
+        "endLine": 8,
+        "endTokenPos": 83,
+        "endFilePos": 189
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 52,
+            "startFilePos": 117,
+            "endLine": 8,
+            "endTokenPos": 78,
+            "endFilePos": 178
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 52,
+              "startFilePos": 117,
+              "endLine": 8,
+              "endTokenPos": 58,
+              "endFilePos": 135
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 52,
+                "startFilePos": 117,
+                "endLine": 8,
+                "endTokenPos": 52,
+                "endFilePos": 124
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 54,
+                  "startFilePos": 126,
+                  "endLine": 8,
+                  "endTokenPos": 57,
+                  "endFilePos": 134
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 54,
+                    "startFilePos": 126,
+                    "endLine": 8,
+                    "endTokenPos": 57,
+                    "endFilePos": 134
+                  },
+                  "name": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 54,
+                      "startFilePos": 126,
+                      "endLine": 8,
+                      "endTokenPos": 54,
+                      "endFilePos": 131
+                    },
+                    "name": "add10"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 56,
+                        "startFilePos": 133,
+                        "endLine": 8,
+                        "endTokenPos": 56,
+                        "endFilePos": 133
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 56,
+                          "startFilePos": 133,
+                          "endLine": 8,
+                          "endTokenPos": 56,
+                          "endFilePos": 133,
+                          "rawValue": "7",
+                          "kind": 10
+                        },
+                        "value": 7
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 62,
+              "startFilePos": 139,
+              "endLine": 8,
+              "endTokenPos": 71,
+              "endFilePos": 166
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 62,
+                "startFilePos": 139,
+                "endLine": 8,
+                "endTokenPos": 62,
+                "endFilePos": 149
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 64,
+                  "startFilePos": 151,
+                  "endLine": 8,
+                  "endTokenPos": 67,
+                  "endFilePos": 159
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 64,
+                    "startFilePos": 151,
+                    "endLine": 8,
+                    "endTokenPos": 67,
+                    "endFilePos": 159
+                  },
+                  "name": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 64,
+                      "startFilePos": 151,
+                      "endLine": 8,
+                      "endTokenPos": 64,
+                      "endFilePos": 156
+                    },
+                    "name": "add10"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 66,
+                        "startFilePos": 158,
+                        "endLine": 8,
+                        "endTokenPos": 66,
+                        "endFilePos": 158
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 66,
+                          "startFilePos": 158,
+                          "endLine": 8,
+                          "endTokenPos": 66,
+                          "endFilePos": 158,
+                          "rawValue": "7",
+                          "kind": 10
+                        },
+                        "value": 7
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 70,
+                  "startFilePos": 162,
+                  "endLine": 8,
+                  "endTokenPos": 70,
+                  "endFilePos": 165
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 70,
+                    "startFilePos": 162,
+                    "endLine": 8,
+                    "endTokenPos": 70,
+                    "endFilePos": 165,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 75,
+              "startFilePos": 170,
+              "endLine": 8,
+              "endTokenPos": 78,
+              "endFilePos": 178
+            },
+            "name": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 75,
+                "startFilePos": 170,
+                "endLine": 8,
+                "endTokenPos": 75,
+                "endFilePos": 175
+              },
+              "name": "add10"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 77,
+                  "startFilePos": 177,
+                  "endLine": 8,
+                  "endTokenPos": 77,
+                  "endFilePos": 177
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 77,
+                    "startFilePos": 177,
+                    "endLine": 8,
+                    "endTokenPos": 77,
+                    "endFilePos": 177,
+                    "rawValue": "7",
+                    "kind": 10
+                  },
+                  "value": 7
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 82,
+            "startFilePos": 182,
+            "endLine": 8,
+            "endTokenPos": 82,
+            "endFilePos": 188
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 82,
+              "startFilePos": 182,
+              "endLine": 8,
+              "endTokenPos": 82,
+              "endFilePos": 188
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/count_builtin.php.json
+++ b/tests/json-ast/x/php/count_builtin.php.json
@@ -1,0 +1,568 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 59,
+        "endFilePos": 105
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 54,
+            "endFilePos": 94
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 18,
+              "endFilePos": 37
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 36
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 17,
+                    "endFilePos": 36
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 25
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 27,
+                        "endLine": 2,
+                        "endTokenPos": 16,
+                        "endFilePos": 35
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 27,
+                          "endLine": 2,
+                          "endTokenPos": 16,
+                          "endFilePos": 35,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 9,
+                              "startFilePos": 28,
+                              "endLine": 2,
+                              "endTokenPos": 9,
+                              "endFilePos": 28
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 9,
+                                "startFilePos": 28,
+                                "endLine": 2,
+                                "endTokenPos": 9,
+                                "endFilePos": 28,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 12,
+                              "startFilePos": 31,
+                              "endLine": 2,
+                              "endTokenPos": 12,
+                              "endFilePos": 31
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 12,
+                                "startFilePos": 31,
+                                "endLine": 2,
+                                "endTokenPos": 12,
+                                "endFilePos": 31,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 15,
+                              "startFilePos": 34,
+                              "endLine": 2,
+                              "endTokenPos": 15,
+                              "endFilePos": 34
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 15,
+                                "startFilePos": 34,
+                                "endLine": 2,
+                                "endTokenPos": 15,
+                                "endFilePos": 34,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 22,
+              "startFilePos": 41,
+              "endLine": 2,
+              "endTokenPos": 39,
+              "endFilePos": 75
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 41,
+                "endLine": 2,
+                "endTokenPos": 22,
+                "endFilePos": 51
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 53,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 68
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 24,
+                    "startFilePos": 53,
+                    "endLine": 2,
+                    "endTokenPos": 35,
+                    "endFilePos": 68
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 24,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 24,
+                      "endFilePos": 57
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 26,
+                        "startFilePos": 59,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 67
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 26,
+                          "startFilePos": 59,
+                          "endLine": 2,
+                          "endTokenPos": 34,
+                          "endFilePos": 67,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 27,
+                              "startFilePos": 60,
+                              "endLine": 2,
+                              "endTokenPos": 27,
+                              "endFilePos": 60
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 27,
+                                "startFilePos": 60,
+                                "endLine": 2,
+                                "endTokenPos": 27,
+                                "endFilePos": 60,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 30,
+                              "startFilePos": 63,
+                              "endLine": 2,
+                              "endTokenPos": 30,
+                              "endFilePos": 63
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 30,
+                                "startFilePos": 63,
+                                "endLine": 2,
+                                "endTokenPos": 30,
+                                "endFilePos": 63,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 33,
+                              "startFilePos": 66,
+                              "endLine": 2,
+                              "endTokenPos": 33,
+                              "endFilePos": 66
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 33,
+                                "startFilePos": 66,
+                                "endLine": 2,
+                                "endTokenPos": 33,
+                                "endFilePos": 66,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 71,
+                  "endLine": 2,
+                  "endTokenPos": 38,
+                  "endFilePos": 74
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 38,
+                    "startFilePos": 71,
+                    "endLine": 2,
+                    "endTokenPos": 38,
+                    "endFilePos": 74,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 43,
+              "startFilePos": 79,
+              "endLine": 2,
+              "endTokenPos": 54,
+              "endFilePos": 94
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 43,
+                "startFilePos": 79,
+                "endLine": 2,
+                "endTokenPos": 43,
+                "endFilePos": 83
+              },
+              "name": "count"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 45,
+                  "startFilePos": 85,
+                  "endLine": 2,
+                  "endTokenPos": 53,
+                  "endFilePos": 93
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 45,
+                    "startFilePos": 85,
+                    "endLine": 2,
+                    "endTokenPos": 53,
+                    "endFilePos": 93,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 86,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 86
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 46,
+                          "startFilePos": 86,
+                          "endLine": 2,
+                          "endTokenPos": 46,
+                          "endFilePos": 86,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 49,
+                        "startFilePos": 89,
+                        "endLine": 2,
+                        "endTokenPos": 49,
+                        "endFilePos": 89
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 49,
+                          "startFilePos": 89,
+                          "endLine": 2,
+                          "endTokenPos": 49,
+                          "endFilePos": 89,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 52,
+                        "startFilePos": 92,
+                        "endLine": 2,
+                        "endTokenPos": 52,
+                        "endFilePos": 92
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 52,
+                          "startFilePos": 92,
+                          "endLine": 2,
+                          "endTokenPos": 52,
+                          "endFilePos": 92,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 58,
+            "startFilePos": 98,
+            "endLine": 2,
+            "endTokenPos": 58,
+            "endFilePos": 104
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 58,
+              "startFilePos": 98,
+              "endLine": 2,
+              "endTokenPos": 58,
+              "endFilePos": 104
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/cross_join.php.json
+++ b/tests/json-ast/x/php/cross_join.php.json
@@ -1,0 +1,2669 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 53,
+        "endFilePos": 115
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 52,
+          "endFilePos": 114
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 52,
+            "endFilePos": 114,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 82,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 113
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 82,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 113,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 83,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 86,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 91,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 91,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 94,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 99,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 104,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 55,
+        "startFilePos": 117,
+        "endLine": 3,
+        "endTokenPos": 128,
+        "endFilePos": 277
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 55,
+          "startFilePos": 117,
+          "endLine": 3,
+          "endTokenPos": 127,
+          "endFilePos": 276
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 117,
+            "endLine": 3,
+            "endTokenPos": 55,
+            "endFilePos": 123
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 59,
+            "startFilePos": 127,
+            "endLine": 3,
+            "endTokenPos": 127,
+            "endFilePos": 276,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 128,
+                "endLine": 3,
+                "endTokenPos": 80,
+                "endFilePos": 175
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 80,
+                  "endFilePos": 175,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 139
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 132,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 139,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 142,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 158
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 142,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 158,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 75,
+                      "startFilePos": 161,
+                      "endLine": 3,
+                      "endTokenPos": 79,
+                      "endFilePos": 174
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 75,
+                        "startFilePos": 161,
+                        "endLine": 3,
+                        "endTokenPos": 75,
+                        "endFilePos": 167,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 79,
+                        "startFilePos": 172,
+                        "endLine": 3,
+                        "endTokenPos": 79,
+                        "endFilePos": 174,
+                        "rawValue": "250",
+                        "kind": 10
+                      },
+                      "value": 250
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 83,
+                "startFilePos": 178,
+                "endLine": 3,
+                "endTokenPos": 103,
+                "endFilePos": 225
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 83,
+                  "startFilePos": 178,
+                  "endLine": 3,
+                  "endTokenPos": 103,
+                  "endFilePos": 225,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 179,
+                      "endLine": 3,
+                      "endTokenPos": 88,
+                      "endFilePos": 189
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 84,
+                        "startFilePos": 179,
+                        "endLine": 3,
+                        "endTokenPos": 84,
+                        "endFilePos": 182,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 88,
+                        "startFilePos": 187,
+                        "endLine": 3,
+                        "endTokenPos": 88,
+                        "endFilePos": 189,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 91,
+                      "startFilePos": 192,
+                      "endLine": 3,
+                      "endTokenPos": 95,
+                      "endFilePos": 208
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 91,
+                        "startFilePos": 192,
+                        "endLine": 3,
+                        "endTokenPos": 91,
+                        "endFilePos": 203,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 95,
+                        "startFilePos": 208,
+                        "endLine": 3,
+                        "endTokenPos": 95,
+                        "endFilePos": 208,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 98,
+                      "startFilePos": 211,
+                      "endLine": 3,
+                      "endTokenPos": 102,
+                      "endFilePos": 224
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 98,
+                        "startFilePos": 211,
+                        "endLine": 3,
+                        "endTokenPos": 98,
+                        "endFilePos": 217,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 102,
+                        "startFilePos": 222,
+                        "endLine": 3,
+                        "endTokenPos": 102,
+                        "endFilePos": 224,
+                        "rawValue": "125",
+                        "kind": 10
+                      },
+                      "value": 125
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 106,
+                "startFilePos": 228,
+                "endLine": 3,
+                "endTokenPos": 126,
+                "endFilePos": 275
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 106,
+                  "startFilePos": 228,
+                  "endLine": 3,
+                  "endTokenPos": 126,
+                  "endFilePos": 275,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 107,
+                      "startFilePos": 229,
+                      "endLine": 3,
+                      "endTokenPos": 111,
+                      "endFilePos": 239
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 107,
+                        "startFilePos": 229,
+                        "endLine": 3,
+                        "endTokenPos": 107,
+                        "endFilePos": 232,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 111,
+                        "startFilePos": 237,
+                        "endLine": 3,
+                        "endTokenPos": 111,
+                        "endFilePos": 239,
+                        "rawValue": "102",
+                        "kind": 10
+                      },
+                      "value": 102
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 114,
+                      "startFilePos": 242,
+                      "endLine": 3,
+                      "endTokenPos": 118,
+                      "endFilePos": 258
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 114,
+                        "startFilePos": 242,
+                        "endLine": 3,
+                        "endTokenPos": 114,
+                        "endFilePos": 253,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 118,
+                        "startFilePos": 258,
+                        "endLine": 3,
+                        "endTokenPos": 118,
+                        "endFilePos": 258,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 121,
+                      "startFilePos": 261,
+                      "endLine": 3,
+                      "endTokenPos": 125,
+                      "endFilePos": 274
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 121,
+                        "startFilePos": 261,
+                        "endLine": 3,
+                        "endTokenPos": 121,
+                        "endFilePos": 267,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 125,
+                        "startFilePos": 272,
+                        "endLine": 3,
+                        "endTokenPos": 125,
+                        "endFilePos": 274,
+                        "rawValue": "300",
+                        "kind": 10
+                      },
+                      "value": 300
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 130,
+        "startFilePos": 279,
+        "endLine": 4,
+        "endTokenPos": 136,
+        "endFilePos": 291
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 130,
+          "startFilePos": 279,
+          "endLine": 4,
+          "endTokenPos": 135,
+          "endFilePos": 290
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 130,
+            "startFilePos": 279,
+            "endLine": 4,
+            "endTokenPos": 130,
+            "endFilePos": 285
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 134,
+            "startFilePos": 289,
+            "endLine": 4,
+            "endTokenPos": 135,
+            "endFilePos": 290,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 138,
+        "startFilePos": 293,
+        "endLine": 9,
+        "endTokenPos": 212,
+        "endFilePos": 499
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 141,
+          "startFilePos": 302,
+          "endLine": 5,
+          "endTokenPos": 141,
+          "endFilePos": 308
+        },
+        "name": "orders"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 145,
+          "startFilePos": 313,
+          "endLine": 5,
+          "endTokenPos": 145,
+          "endFilePos": 314
+        },
+        "name": "o"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 150,
+            "startFilePos": 321,
+            "endLine": 8,
+            "endTokenPos": 210,
+            "endFilePos": 497
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 153,
+              "startFilePos": 330,
+              "endLine": 6,
+              "endTokenPos": 153,
+              "endFilePos": 339
+            },
+            "name": "customers"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 157,
+              "startFilePos": 344,
+              "endLine": 6,
+              "endTokenPos": 157,
+              "endFilePos": 345
+            },
+            "name": "c"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 162,
+                "startFilePos": 354,
+                "endLine": 7,
+                "endTokenPos": 208,
+                "endFilePos": 493
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 162,
+                  "startFilePos": 354,
+                  "endLine": 7,
+                  "endTokenPos": 207,
+                  "endFilePos": 492
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 162,
+                    "startFilePos": 354,
+                    "endLine": 7,
+                    "endTokenPos": 164,
+                    "endFilePos": 362
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 162,
+                      "startFilePos": 354,
+                      "endLine": 7,
+                      "endTokenPos": 162,
+                      "endFilePos": 360
+                    },
+                    "name": "result"
+                  },
+                  "dim": null
+                },
+                "expr": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 168,
+                    "startFilePos": 366,
+                    "endLine": 7,
+                    "endTokenPos": 207,
+                    "endFilePos": 492,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 169,
+                        "startFilePos": 367,
+                        "endLine": 7,
+                        "endTokenPos": 176,
+                        "endFilePos": 387
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 169,
+                          "startFilePos": 367,
+                          "endLine": 7,
+                          "endTokenPos": 169,
+                          "endFilePos": 375,
+                          "kind": 2,
+                          "rawValue": "\"orderId\""
+                        },
+                        "value": "orderId"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 173,
+                          "startFilePos": 380,
+                          "endLine": 7,
+                          "endTokenPos": 176,
+                          "endFilePos": 387
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 173,
+                            "startFilePos": 380,
+                            "endLine": 7,
+                            "endTokenPos": 173,
+                            "endFilePos": 381
+                          },
+                          "name": "o"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 175,
+                            "startFilePos": 383,
+                            "endLine": 7,
+                            "endTokenPos": 175,
+                            "endFilePos": 386,
+                            "kind": 2,
+                            "rawValue": "\"id\""
+                          },
+                          "value": "id"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 179,
+                        "startFilePos": 390,
+                        "endLine": 7,
+                        "endTokenPos": 186,
+                        "endFilePos": 426
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 179,
+                          "startFilePos": 390,
+                          "endLine": 7,
+                          "endTokenPos": 179,
+                          "endFilePos": 406,
+                          "kind": 2,
+                          "rawValue": "\"orderCustomerId\""
+                        },
+                        "value": "orderCustomerId"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 183,
+                          "startFilePos": 411,
+                          "endLine": 7,
+                          "endTokenPos": 186,
+                          "endFilePos": 426
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 183,
+                            "startFilePos": 411,
+                            "endLine": 7,
+                            "endTokenPos": 183,
+                            "endFilePos": 412
+                          },
+                          "name": "o"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 185,
+                            "startFilePos": 414,
+                            "endLine": 7,
+                            "endTokenPos": 185,
+                            "endFilePos": 425,
+                            "kind": 2,
+                            "rawValue": "\"customerId\""
+                          },
+                          "value": "customerId"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 189,
+                        "startFilePos": 429,
+                        "endLine": 7,
+                        "endTokenPos": 196,
+                        "endFilePos": 462
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 189,
+                          "startFilePos": 429,
+                          "endLine": 7,
+                          "endTokenPos": 189,
+                          "endFilePos": 448,
+                          "kind": 2,
+                          "rawValue": "\"pairedCustomerName\""
+                        },
+                        "value": "pairedCustomerName"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 193,
+                          "startFilePos": 453,
+                          "endLine": 7,
+                          "endTokenPos": 196,
+                          "endFilePos": 462
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 193,
+                            "startFilePos": 453,
+                            "endLine": 7,
+                            "endTokenPos": 193,
+                            "endFilePos": 454
+                          },
+                          "name": "c"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 195,
+                            "startFilePos": 456,
+                            "endLine": 7,
+                            "endTokenPos": 195,
+                            "endFilePos": 461,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 199,
+                        "startFilePos": 465,
+                        "endLine": 7,
+                        "endTokenPos": 206,
+                        "endFilePos": 491
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 199,
+                          "startFilePos": 465,
+                          "endLine": 7,
+                          "endTokenPos": 199,
+                          "endFilePos": 476,
+                          "kind": 2,
+                          "rawValue": "\"orderTotal\""
+                        },
+                        "value": "orderTotal"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 203,
+                          "startFilePos": 481,
+                          "endLine": 7,
+                          "endTokenPos": 206,
+                          "endFilePos": 491
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 203,
+                            "startFilePos": 481,
+                            "endLine": 7,
+                            "endTokenPos": 203,
+                            "endFilePos": 482
+                          },
+                          "name": "o"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 205,
+                            "startFilePos": 484,
+                            "endLine": 7,
+                            "endTokenPos": 205,
+                            "endFilePos": 490,
+                            "kind": 2,
+                            "rawValue": "\"total\""
+                          },
+                          "value": "total"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 11,
+        "startTokenPos": 214,
+        "startFilePos": 502,
+        "endLine": 11,
+        "endTokenPos": 220,
+        "endFilePos": 562
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 216,
+            "startFilePos": 507,
+            "endLine": 11,
+            "endTokenPos": 216,
+            "endFilePos": 552,
+            "kind": 2,
+            "rawValue": "\"--- Cross Join: All order-customer pairs ---\""
+          },
+          "value": "--- Cross Join: All order-customer pairs ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 219,
+            "startFilePos": 555,
+            "endLine": 11,
+            "endTokenPos": 219,
+            "endFilePos": 561
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 219,
+              "startFilePos": 555,
+              "endLine": 11,
+              "endTokenPos": 219,
+              "endFilePos": 561
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 12,
+        "startTokenPos": 222,
+        "startFilePos": 564,
+        "endLine": 14,
+        "endTokenPos": 410,
+        "endFilePos": 1141
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 12,
+          "startTokenPos": 225,
+          "startFilePos": 573,
+          "endLine": 12,
+          "endTokenPos": 225,
+          "endFilePos": 579
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 12,
+          "startTokenPos": 229,
+          "startFilePos": 584,
+          "endLine": 12,
+          "endTokenPos": 229,
+          "endFilePos": 589
+        },
+        "name": "entry"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 234,
+            "startFilePos": 596,
+            "endLine": 13,
+            "endTokenPos": 408,
+            "endFilePos": 1139
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 236,
+                "startFilePos": 601,
+                "endLine": 13,
+                "endTokenPos": 404,
+                "endFilePos": 1129
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 236,
+                  "startFilePos": 601,
+                  "endLine": 13,
+                  "endTokenPos": 372,
+                  "endFilePos": 1005
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 236,
+                    "startFilePos": 601,
+                    "endLine": 13,
+                    "endTokenPos": 368,
+                    "endFilePos": 999
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 236,
+                      "startFilePos": 601,
+                      "endLine": 13,
+                      "endTokenPos": 364,
+                      "endFilePos": 981
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 236,
+                        "startFilePos": 601,
+                        "endLine": 13,
+                        "endTokenPos": 360,
+                        "endFilePos": 975
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 236,
+                          "startFilePos": 601,
+                          "endLine": 13,
+                          "endTokenPos": 328,
+                          "endFilePos": 875
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 236,
+                            "startFilePos": 601,
+                            "endLine": 13,
+                            "endTokenPos": 324,
+                            "endFilePos": 869
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 236,
+                              "startFilePos": 601,
+                              "endLine": 13,
+                              "endTokenPos": 320,
+                              "endFilePos": 854
+                            },
+                            "left": {
+                              "nodeType": "Expr_BinaryOp_Concat",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 236,
+                                "startFilePos": 601,
+                                "endLine": 13,
+                                "endTokenPos": 316,
+                                "endFilePos": 848
+                              },
+                              "left": {
+                                "nodeType": "Expr_BinaryOp_Concat",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 236,
+                                  "startFilePos": 601,
+                                  "endLine": 13,
+                                  "endTokenPos": 284,
+                                  "endFilePos": 733
+                                },
+                                "left": {
+                                  "nodeType": "Expr_BinaryOp_Concat",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 236,
+                                    "startFilePos": 601,
+                                    "endLine": 13,
+                                    "endTokenPos": 280,
+                                    "endFilePos": 727
+                                  },
+                                  "left": {
+                                    "nodeType": "Expr_BinaryOp_Concat",
+                                    "attributes": {
+                                      "startLine": 13,
+                                      "startTokenPos": 236,
+                                      "startFilePos": 601,
+                                      "endLine": 13,
+                                      "endTokenPos": 276,
+                                      "endFilePos": 710
+                                    },
+                                    "left": {
+                                      "nodeType": "Expr_BinaryOp_Concat",
+                                      "attributes": {
+                                        "startLine": 13,
+                                        "startTokenPos": 236,
+                                        "startFilePos": 601,
+                                        "endLine": 13,
+                                        "endTokenPos": 272,
+                                        "endFilePos": 704
+                                      },
+                                      "left": {
+                                        "nodeType": "Expr_BinaryOp_Concat",
+                                        "attributes": {
+                                          "startLine": 13,
+                                          "startTokenPos": 236,
+                                          "startFilePos": 601,
+                                          "endLine": 13,
+                                          "endTokenPos": 240,
+                                          "endFilePos": 613
+                                        },
+                                        "left": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 236,
+                                            "startFilePos": 601,
+                                            "endLine": 13,
+                                            "endTokenPos": 236,
+                                            "endFilePos": 607,
+                                            "kind": 2,
+                                            "rawValue": "\"Order\""
+                                          },
+                                          "value": "Order"
+                                        },
+                                        "right": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 240,
+                                            "startFilePos": 611,
+                                            "endLine": 13,
+                                            "endTokenPos": 240,
+                                            "endFilePos": 613,
+                                            "kind": 2,
+                                            "rawValue": "\" \""
+                                          },
+                                          "value": " "
+                                        }
+                                      },
+                                      "right": {
+                                        "nodeType": "Expr_Ternary",
+                                        "attributes": {
+                                          "startLine": 13,
+                                          "startTokenPos": 245,
+                                          "startFilePos": 618,
+                                          "endLine": 13,
+                                          "endTokenPos": 271,
+                                          "endFilePos": 703
+                                        },
+                                        "cond": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 245,
+                                            "startFilePos": 618,
+                                            "endLine": 13,
+                                            "endTokenPos": 251,
+                                            "endFilePos": 644
+                                          },
+                                          "name": {
+                                            "nodeType": "Name",
+                                            "attributes": {
+                                              "startLine": 13,
+                                              "startTokenPos": 245,
+                                              "startFilePos": 618,
+                                              "endLine": 13,
+                                              "endTokenPos": 245,
+                                              "endFilePos": 625
+                                            },
+                                            "name": "is_float"
+                                          },
+                                          "args": [
+                                            {
+                                              "nodeType": "Arg",
+                                              "attributes": {
+                                                "startLine": 13,
+                                                "startTokenPos": 247,
+                                                "startFilePos": 627,
+                                                "endLine": 13,
+                                                "endTokenPos": 250,
+                                                "endFilePos": 643
+                                              },
+                                              "name": null,
+                                              "value": {
+                                                "nodeType": "Expr_ArrayDimFetch",
+                                                "attributes": {
+                                                  "startLine": 13,
+                                                  "startTokenPos": 247,
+                                                  "startFilePos": 627,
+                                                  "endLine": 13,
+                                                  "endTokenPos": 250,
+                                                  "endFilePos": 643
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 13,
+                                                    "startTokenPos": 247,
+                                                    "startFilePos": 627,
+                                                    "endLine": 13,
+                                                    "endTokenPos": 247,
+                                                    "endFilePos": 632
+                                                  },
+                                                  "name": "entry"
+                                                },
+                                                "dim": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 13,
+                                                    "startTokenPos": 249,
+                                                    "startFilePos": 634,
+                                                    "endLine": 13,
+                                                    "endTokenPos": 249,
+                                                    "endFilePos": 642,
+                                                    "kind": 2,
+                                                    "rawValue": "\"orderId\""
+                                                  },
+                                                  "value": "orderId"
+                                                }
+                                              },
+                                              "byRef": false,
+                                              "unpack": false
+                                            }
+                                          ]
+                                        },
+                                        "if": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 255,
+                                            "startFilePos": 648,
+                                            "endLine": 13,
+                                            "endTokenPos": 264,
+                                            "endFilePos": 683
+                                          },
+                                          "name": {
+                                            "nodeType": "Name",
+                                            "attributes": {
+                                              "startLine": 13,
+                                              "startTokenPos": 255,
+                                              "startFilePos": 648,
+                                              "endLine": 13,
+                                              "endTokenPos": 255,
+                                              "endFilePos": 658
+                                            },
+                                            "name": "json_encode"
+                                          },
+                                          "args": [
+                                            {
+                                              "nodeType": "Arg",
+                                              "attributes": {
+                                                "startLine": 13,
+                                                "startTokenPos": 257,
+                                                "startFilePos": 660,
+                                                "endLine": 13,
+                                                "endTokenPos": 260,
+                                                "endFilePos": 676
+                                              },
+                                              "name": null,
+                                              "value": {
+                                                "nodeType": "Expr_ArrayDimFetch",
+                                                "attributes": {
+                                                  "startLine": 13,
+                                                  "startTokenPos": 257,
+                                                  "startFilePos": 660,
+                                                  "endLine": 13,
+                                                  "endTokenPos": 260,
+                                                  "endFilePos": 676
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 13,
+                                                    "startTokenPos": 257,
+                                                    "startFilePos": 660,
+                                                    "endLine": 13,
+                                                    "endTokenPos": 257,
+                                                    "endFilePos": 665
+                                                  },
+                                                  "name": "entry"
+                                                },
+                                                "dim": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 13,
+                                                    "startTokenPos": 259,
+                                                    "startFilePos": 667,
+                                                    "endLine": 13,
+                                                    "endTokenPos": 259,
+                                                    "endFilePos": 675,
+                                                    "kind": 2,
+                                                    "rawValue": "\"orderId\""
+                                                  },
+                                                  "value": "orderId"
+                                                }
+                                              },
+                                              "byRef": false,
+                                              "unpack": false
+                                            },
+                                            {
+                                              "nodeType": "Arg",
+                                              "attributes": {
+                                                "startLine": 13,
+                                                "startTokenPos": 263,
+                                                "startFilePos": 679,
+                                                "endLine": 13,
+                                                "endTokenPos": 263,
+                                                "endFilePos": 682
+                                              },
+                                              "name": null,
+                                              "value": {
+                                                "nodeType": "Scalar_Int",
+                                                "attributes": {
+                                                  "startLine": 13,
+                                                  "startTokenPos": 263,
+                                                  "startFilePos": 679,
+                                                  "endLine": 13,
+                                                  "endTokenPos": 263,
+                                                  "endFilePos": 682,
+                                                  "rawValue": "1344",
+                                                  "kind": 10
+                                                },
+                                                "value": 1344
+                                              },
+                                              "byRef": false,
+                                              "unpack": false
+                                            }
+                                          ]
+                                        },
+                                        "else": {
+                                          "nodeType": "Expr_ArrayDimFetch",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 268,
+                                            "startFilePos": 687,
+                                            "endLine": 13,
+                                            "endTokenPos": 271,
+                                            "endFilePos": 703
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 13,
+                                              "startTokenPos": 268,
+                                              "startFilePos": 687,
+                                              "endLine": 13,
+                                              "endTokenPos": 268,
+                                              "endFilePos": 692
+                                            },
+                                            "name": "entry"
+                                          },
+                                          "dim": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 13,
+                                              "startTokenPos": 270,
+                                              "startFilePos": 694,
+                                              "endLine": 13,
+                                              "endTokenPos": 270,
+                                              "endFilePos": 702,
+                                              "kind": 2,
+                                              "rawValue": "\"orderId\""
+                                            },
+                                            "value": "orderId"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "right": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 13,
+                                        "startTokenPos": 276,
+                                        "startFilePos": 708,
+                                        "endLine": 13,
+                                        "endTokenPos": 276,
+                                        "endFilePos": 710,
+                                        "kind": 2,
+                                        "rawValue": "\" \""
+                                      },
+                                      "value": " "
+                                    }
+                                  },
+                                  "right": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 13,
+                                      "startTokenPos": 280,
+                                      "startFilePos": 714,
+                                      "endLine": 13,
+                                      "endTokenPos": 280,
+                                      "endFilePos": 727,
+                                      "kind": 2,
+                                      "rawValue": "\"(customerId:\""
+                                    },
+                                    "value": "(customerId:"
+                                  }
+                                },
+                                "right": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 284,
+                                    "startFilePos": 731,
+                                    "endLine": 13,
+                                    "endTokenPos": 284,
+                                    "endFilePos": 733,
+                                    "kind": 2,
+                                    "rawValue": "\" \""
+                                  },
+                                  "value": " "
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_Ternary",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 289,
+                                  "startFilePos": 738,
+                                  "endLine": 13,
+                                  "endTokenPos": 315,
+                                  "endFilePos": 847
+                                },
+                                "cond": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 289,
+                                    "startFilePos": 738,
+                                    "endLine": 13,
+                                    "endTokenPos": 295,
+                                    "endFilePos": 772
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 13,
+                                      "startTokenPos": 289,
+                                      "startFilePos": 738,
+                                      "endLine": 13,
+                                      "endTokenPos": 289,
+                                      "endFilePos": 745
+                                    },
+                                    "name": "is_float"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 13,
+                                        "startTokenPos": 291,
+                                        "startFilePos": 747,
+                                        "endLine": 13,
+                                        "endTokenPos": 294,
+                                        "endFilePos": 771
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 13,
+                                          "startTokenPos": 291,
+                                          "startFilePos": 747,
+                                          "endLine": 13,
+                                          "endTokenPos": 294,
+                                          "endFilePos": 771
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 291,
+                                            "startFilePos": 747,
+                                            "endLine": 13,
+                                            "endTokenPos": 291,
+                                            "endFilePos": 752
+                                          },
+                                          "name": "entry"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 293,
+                                            "startFilePos": 754,
+                                            "endLine": 13,
+                                            "endTokenPos": 293,
+                                            "endFilePos": 770,
+                                            "kind": 2,
+                                            "rawValue": "\"orderCustomerId\""
+                                          },
+                                          "value": "orderCustomerId"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "if": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 299,
+                                    "startFilePos": 776,
+                                    "endLine": 13,
+                                    "endTokenPos": 308,
+                                    "endFilePos": 819
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 13,
+                                      "startTokenPos": 299,
+                                      "startFilePos": 776,
+                                      "endLine": 13,
+                                      "endTokenPos": 299,
+                                      "endFilePos": 786
+                                    },
+                                    "name": "json_encode"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 13,
+                                        "startTokenPos": 301,
+                                        "startFilePos": 788,
+                                        "endLine": 13,
+                                        "endTokenPos": 304,
+                                        "endFilePos": 812
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 13,
+                                          "startTokenPos": 301,
+                                          "startFilePos": 788,
+                                          "endLine": 13,
+                                          "endTokenPos": 304,
+                                          "endFilePos": 812
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 301,
+                                            "startFilePos": 788,
+                                            "endLine": 13,
+                                            "endTokenPos": 301,
+                                            "endFilePos": 793
+                                          },
+                                          "name": "entry"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 13,
+                                            "startTokenPos": 303,
+                                            "startFilePos": 795,
+                                            "endLine": 13,
+                                            "endTokenPos": 303,
+                                            "endFilePos": 811,
+                                            "kind": 2,
+                                            "rawValue": "\"orderCustomerId\""
+                                          },
+                                          "value": "orderCustomerId"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 13,
+                                        "startTokenPos": 307,
+                                        "startFilePos": 815,
+                                        "endLine": 13,
+                                        "endTokenPos": 307,
+                                        "endFilePos": 818
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_Int",
+                                        "attributes": {
+                                          "startLine": 13,
+                                          "startTokenPos": 307,
+                                          "startFilePos": 815,
+                                          "endLine": 13,
+                                          "endTokenPos": 307,
+                                          "endFilePos": 818,
+                                          "rawValue": "1344",
+                                          "kind": 10
+                                        },
+                                        "value": 1344
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "else": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 312,
+                                    "startFilePos": 823,
+                                    "endLine": 13,
+                                    "endTokenPos": 315,
+                                    "endFilePos": 847
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 13,
+                                      "startTokenPos": 312,
+                                      "startFilePos": 823,
+                                      "endLine": 13,
+                                      "endTokenPos": 312,
+                                      "endFilePos": 828
+                                    },
+                                    "name": "entry"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 13,
+                                      "startTokenPos": 314,
+                                      "startFilePos": 830,
+                                      "endLine": 13,
+                                      "endTokenPos": 314,
+                                      "endFilePos": 846,
+                                      "kind": 2,
+                                      "rawValue": "\"orderCustomerId\""
+                                    },
+                                    "value": "orderCustomerId"
+                                  }
+                                }
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 320,
+                                "startFilePos": 852,
+                                "endLine": 13,
+                                "endTokenPos": 320,
+                                "endFilePos": 854,
+                                "kind": 2,
+                                "rawValue": "\" \""
+                              },
+                              "value": " "
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 324,
+                              "startFilePos": 858,
+                              "endLine": 13,
+                              "endTokenPos": 324,
+                              "endFilePos": 869,
+                              "kind": 2,
+                              "rawValue": "\", total: $\""
+                            },
+                            "value": ", total: $"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 328,
+                            "startFilePos": 873,
+                            "endLine": 13,
+                            "endTokenPos": 328,
+                            "endFilePos": 875,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_Ternary",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 333,
+                          "startFilePos": 880,
+                          "endLine": 13,
+                          "endTokenPos": 359,
+                          "endFilePos": 974
+                        },
+                        "cond": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 333,
+                            "startFilePos": 880,
+                            "endLine": 13,
+                            "endTokenPos": 339,
+                            "endFilePos": 909
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 333,
+                              "startFilePos": 880,
+                              "endLine": 13,
+                              "endTokenPos": 333,
+                              "endFilePos": 887
+                            },
+                            "name": "is_float"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 335,
+                                "startFilePos": 889,
+                                "endLine": 13,
+                                "endTokenPos": 338,
+                                "endFilePos": 908
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 335,
+                                  "startFilePos": 889,
+                                  "endLine": 13,
+                                  "endTokenPos": 338,
+                                  "endFilePos": 908
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 335,
+                                    "startFilePos": 889,
+                                    "endLine": 13,
+                                    "endTokenPos": 335,
+                                    "endFilePos": 894
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 337,
+                                    "startFilePos": 896,
+                                    "endLine": 13,
+                                    "endTokenPos": 337,
+                                    "endFilePos": 907,
+                                    "kind": 2,
+                                    "rawValue": "\"orderTotal\""
+                                  },
+                                  "value": "orderTotal"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "if": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 343,
+                            "startFilePos": 913,
+                            "endLine": 13,
+                            "endTokenPos": 352,
+                            "endFilePos": 951
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 343,
+                              "startFilePos": 913,
+                              "endLine": 13,
+                              "endTokenPos": 343,
+                              "endFilePos": 923
+                            },
+                            "name": "json_encode"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 345,
+                                "startFilePos": 925,
+                                "endLine": 13,
+                                "endTokenPos": 348,
+                                "endFilePos": 944
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 345,
+                                  "startFilePos": 925,
+                                  "endLine": 13,
+                                  "endTokenPos": 348,
+                                  "endFilePos": 944
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 345,
+                                    "startFilePos": 925,
+                                    "endLine": 13,
+                                    "endTokenPos": 345,
+                                    "endFilePos": 930
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 347,
+                                    "startFilePos": 932,
+                                    "endLine": 13,
+                                    "endTokenPos": 347,
+                                    "endFilePos": 943,
+                                    "kind": 2,
+                                    "rawValue": "\"orderTotal\""
+                                  },
+                                  "value": "orderTotal"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 351,
+                                "startFilePos": 947,
+                                "endLine": 13,
+                                "endTokenPos": 351,
+                                "endFilePos": 950
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 351,
+                                  "startFilePos": 947,
+                                  "endLine": 13,
+                                  "endTokenPos": 351,
+                                  "endFilePos": 950,
+                                  "rawValue": "1344",
+                                  "kind": 10
+                                },
+                                "value": 1344
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "else": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 356,
+                            "startFilePos": 955,
+                            "endLine": 13,
+                            "endTokenPos": 359,
+                            "endFilePos": 974
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 356,
+                              "startFilePos": 955,
+                              "endLine": 13,
+                              "endTokenPos": 356,
+                              "endFilePos": 960
+                            },
+                            "name": "entry"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 358,
+                              "startFilePos": 962,
+                              "endLine": 13,
+                              "endTokenPos": 358,
+                              "endFilePos": 973,
+                              "kind": 2,
+                              "rawValue": "\"orderTotal\""
+                            },
+                            "value": "orderTotal"
+                          }
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 364,
+                        "startFilePos": 979,
+                        "endLine": 13,
+                        "endTokenPos": 364,
+                        "endFilePos": 981,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 368,
+                      "startFilePos": 985,
+                      "endLine": 13,
+                      "endTokenPos": 368,
+                      "endFilePos": 999,
+                      "kind": 2,
+                      "rawValue": "\") paired with\""
+                    },
+                    "value": ") paired with"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 372,
+                    "startFilePos": 1003,
+                    "endLine": 13,
+                    "endTokenPos": 372,
+                    "endFilePos": 1005,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 377,
+                  "startFilePos": 1010,
+                  "endLine": 13,
+                  "endTokenPos": 403,
+                  "endFilePos": 1128
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 377,
+                    "startFilePos": 1010,
+                    "endLine": 13,
+                    "endTokenPos": 383,
+                    "endFilePos": 1047
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 377,
+                      "startFilePos": 1010,
+                      "endLine": 13,
+                      "endTokenPos": 377,
+                      "endFilePos": 1017
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 379,
+                        "startFilePos": 1019,
+                        "endLine": 13,
+                        "endTokenPos": 382,
+                        "endFilePos": 1046
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 379,
+                          "startFilePos": 1019,
+                          "endLine": 13,
+                          "endTokenPos": 382,
+                          "endFilePos": 1046
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 379,
+                            "startFilePos": 1019,
+                            "endLine": 13,
+                            "endTokenPos": 379,
+                            "endFilePos": 1024
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 381,
+                            "startFilePos": 1026,
+                            "endLine": 13,
+                            "endTokenPos": 381,
+                            "endFilePos": 1045,
+                            "kind": 2,
+                            "rawValue": "\"pairedCustomerName\""
+                          },
+                          "value": "pairedCustomerName"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 387,
+                    "startFilePos": 1051,
+                    "endLine": 13,
+                    "endTokenPos": 396,
+                    "endFilePos": 1097
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 387,
+                      "startFilePos": 1051,
+                      "endLine": 13,
+                      "endTokenPos": 387,
+                      "endFilePos": 1061
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 389,
+                        "startFilePos": 1063,
+                        "endLine": 13,
+                        "endTokenPos": 392,
+                        "endFilePos": 1090
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 389,
+                          "startFilePos": 1063,
+                          "endLine": 13,
+                          "endTokenPos": 392,
+                          "endFilePos": 1090
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 389,
+                            "startFilePos": 1063,
+                            "endLine": 13,
+                            "endTokenPos": 389,
+                            "endFilePos": 1068
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 391,
+                            "startFilePos": 1070,
+                            "endLine": 13,
+                            "endTokenPos": 391,
+                            "endFilePos": 1089,
+                            "kind": 2,
+                            "rawValue": "\"pairedCustomerName\""
+                          },
+                          "value": "pairedCustomerName"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 395,
+                        "startFilePos": 1093,
+                        "endLine": 13,
+                        "endTokenPos": 395,
+                        "endFilePos": 1096
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 395,
+                          "startFilePos": 1093,
+                          "endLine": 13,
+                          "endTokenPos": 395,
+                          "endFilePos": 1096,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 400,
+                    "startFilePos": 1101,
+                    "endLine": 13,
+                    "endTokenPos": 403,
+                    "endFilePos": 1128
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 400,
+                      "startFilePos": 1101,
+                      "endLine": 13,
+                      "endTokenPos": 400,
+                      "endFilePos": 1106
+                    },
+                    "name": "entry"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 402,
+                      "startFilePos": 1108,
+                      "endLine": 13,
+                      "endTokenPos": 402,
+                      "endFilePos": 1127,
+                      "kind": 2,
+                      "rawValue": "\"pairedCustomerName\""
+                    },
+                    "value": "pairedCustomerName"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 407,
+                "startFilePos": 1132,
+                "endLine": 13,
+                "endTokenPos": 407,
+                "endFilePos": 1138
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 407,
+                  "startFilePos": 1132,
+                  "endLine": 13,
+                  "endTokenPos": 407,
+                  "endFilePos": 1138
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/cross_join_filter.php.json
+++ b/tests/json-ast/x/php/cross_join_filter.php.json
@@ -1,0 +1,1197 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 23
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 22
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "nums"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 22,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 21,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 21
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 21,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 25,
+        "endLine": 3,
+        "endTokenPos": 26,
+        "endFilePos": 46
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 16,
+          "startFilePos": 25,
+          "endLine": 3,
+          "endTokenPos": 25,
+          "endFilePos": 45
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 16,
+            "startFilePos": 25,
+            "endLine": 3,
+            "endTokenPos": 16,
+            "endFilePos": 32
+          },
+          "name": "letters"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 20,
+            "startFilePos": 36,
+            "endLine": 3,
+            "endTokenPos": 25,
+            "endFilePos": 45,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 21,
+                "startFilePos": 37,
+                "endLine": 3,
+                "endTokenPos": 21,
+                "endFilePos": 39
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 21,
+                  "startFilePos": 37,
+                  "endLine": 3,
+                  "endTokenPos": 21,
+                  "endFilePos": 39,
+                  "kind": 2,
+                  "rawValue": "\"A\""
+                },
+                "value": "A"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 24,
+                "startFilePos": 42,
+                "endLine": 3,
+                "endTokenPos": 24,
+                "endFilePos": 44
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 24,
+                  "startFilePos": 42,
+                  "endLine": 3,
+                  "endTokenPos": 24,
+                  "endFilePos": 44,
+                  "kind": 2,
+                  "rawValue": "\"B\""
+                },
+                "value": "B"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 28,
+        "startFilePos": 48,
+        "endLine": 4,
+        "endTokenPos": 34,
+        "endFilePos": 59
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 28,
+          "startFilePos": 48,
+          "endLine": 4,
+          "endTokenPos": 33,
+          "endFilePos": 58
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 28,
+            "startFilePos": 48,
+            "endLine": 4,
+            "endTokenPos": 28,
+            "endFilePos": 53
+          },
+          "name": "pairs"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 32,
+            "startFilePos": 57,
+            "endLine": 4,
+            "endTokenPos": 33,
+            "endFilePos": 58,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 36,
+        "startFilePos": 61,
+        "endLine": 11,
+        "endTokenPos": 102,
+        "endFilePos": 188
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 39,
+          "startFilePos": 70,
+          "endLine": 5,
+          "endTokenPos": 39,
+          "endFilePos": 74
+        },
+        "name": "nums"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 43,
+          "startFilePos": 79,
+          "endLine": 5,
+          "endTokenPos": 43,
+          "endFilePos": 80
+        },
+        "name": "n"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 48,
+            "startFilePos": 87,
+            "endLine": 10,
+            "endTokenPos": 100,
+            "endFilePos": 186
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 51,
+              "startFilePos": 96,
+              "endLine": 6,
+              "endTokenPos": 51,
+              "endFilePos": 103
+            },
+            "name": "letters"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 55,
+              "startFilePos": 108,
+              "endLine": 6,
+              "endTokenPos": 55,
+              "endFilePos": 109
+            },
+            "name": "l"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_If",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 60,
+                "startFilePos": 118,
+                "endLine": 9,
+                "endTokenPos": 98,
+                "endFilePos": 182
+              },
+              "cond": {
+                "nodeType": "Expr_BinaryOp_Equal",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 63,
+                  "startFilePos": 122,
+                  "endLine": 7,
+                  "endTokenPos": 71,
+                  "endFilePos": 132
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Mod",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 63,
+                    "startFilePos": 122,
+                    "endLine": 7,
+                    "endTokenPos": 67,
+                    "endFilePos": 127
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 63,
+                      "startFilePos": 122,
+                      "endLine": 7,
+                      "endTokenPos": 63,
+                      "endFilePos": 123
+                    },
+                    "name": "n"
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 67,
+                      "startFilePos": 127,
+                      "endLine": 7,
+                      "endTokenPos": 67,
+                      "endFilePos": 127,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 71,
+                    "startFilePos": 132,
+                    "endLine": 7,
+                    "endTokenPos": 71,
+                    "endFilePos": 132,
+                    "rawValue": "0",
+                    "kind": 10
+                  },
+                  "value": 0
+                }
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_Expression",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 76,
+                    "startFilePos": 143,
+                    "endLine": 8,
+                    "endTokenPos": 96,
+                    "endFilePos": 176
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Assign",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 76,
+                      "startFilePos": 143,
+                      "endLine": 8,
+                      "endTokenPos": 95,
+                      "endFilePos": 175
+                    },
+                    "var": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 76,
+                        "startFilePos": 143,
+                        "endLine": 8,
+                        "endTokenPos": 78,
+                        "endFilePos": 150
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 76,
+                          "startFilePos": 143,
+                          "endLine": 8,
+                          "endTokenPos": 76,
+                          "endFilePos": 148
+                        },
+                        "name": "pairs"
+                      },
+                      "dim": null
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Array",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 82,
+                        "startFilePos": 154,
+                        "endLine": 8,
+                        "endTokenPos": 95,
+                        "endFilePos": 175,
+                        "kind": 2
+                      },
+                      "items": [
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 83,
+                            "startFilePos": 155,
+                            "endLine": 8,
+                            "endTokenPos": 87,
+                            "endFilePos": 163
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 83,
+                              "startFilePos": 155,
+                              "endLine": 8,
+                              "endTokenPos": 83,
+                              "endFilePos": 157,
+                              "kind": 2,
+                              "rawValue": "\"n\""
+                            },
+                            "value": "n"
+                          },
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 87,
+                              "startFilePos": 162,
+                              "endLine": 8,
+                              "endTokenPos": 87,
+                              "endFilePos": 163
+                            },
+                            "name": "n"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 90,
+                            "startFilePos": 166,
+                            "endLine": 8,
+                            "endTokenPos": 94,
+                            "endFilePos": 174
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 90,
+                              "startFilePos": 166,
+                              "endLine": 8,
+                              "endTokenPos": 90,
+                              "endFilePos": 168,
+                              "kind": 2,
+                              "rawValue": "\"l\""
+                            },
+                            "value": "l"
+                          },
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 94,
+                              "startFilePos": 173,
+                              "endLine": 8,
+                              "endTokenPos": 94,
+                              "endFilePos": 174
+                            },
+                            "name": "l"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "elseifs": [],
+              "else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 13,
+        "startTokenPos": 104,
+        "startFilePos": 191,
+        "endLine": 13,
+        "endTokenPos": 110,
+        "endFilePos": 225
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 106,
+            "startFilePos": 196,
+            "endLine": 13,
+            "endTokenPos": 106,
+            "endFilePos": 215,
+            "kind": 2,
+            "rawValue": "\"--- Even pairs ---\""
+          },
+          "value": "--- Even pairs ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 109,
+            "startFilePos": 218,
+            "endLine": 13,
+            "endTokenPos": 109,
+            "endFilePos": 224
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 109,
+              "startFilePos": 218,
+              "endLine": 13,
+              "endTokenPos": 109,
+              "endFilePos": 224
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 14,
+        "startTokenPos": 112,
+        "startFilePos": 227,
+        "endLine": 16,
+        "endTokenPos": 196,
+        "endFilePos": 395
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 14,
+          "startTokenPos": 115,
+          "startFilePos": 236,
+          "endLine": 14,
+          "endTokenPos": 115,
+          "endFilePos": 241
+        },
+        "name": "pairs"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 14,
+          "startTokenPos": 119,
+          "startFilePos": 246,
+          "endLine": 14,
+          "endTokenPos": 119,
+          "endFilePos": 247
+        },
+        "name": "p"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 124,
+            "startFilePos": 254,
+            "endLine": 15,
+            "endTokenPos": 194,
+            "endFilePos": 393
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 126,
+                "startFilePos": 259,
+                "endLine": 15,
+                "endTokenPos": 190,
+                "endFilePos": 383
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 126,
+                  "startFilePos": 259,
+                  "endLine": 15,
+                  "endTokenPos": 158,
+                  "endFilePos": 322
+                },
+                "left": {
+                  "nodeType": "Expr_Ternary",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 127,
+                    "startFilePos": 260,
+                    "endLine": 15,
+                    "endTokenPos": 153,
+                    "endFilePos": 315
+                  },
+                  "cond": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 127,
+                      "startFilePos": 260,
+                      "endLine": 15,
+                      "endTokenPos": 133,
+                      "endFilePos": 276
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 127,
+                        "startFilePos": 260,
+                        "endLine": 15,
+                        "endTokenPos": 127,
+                        "endFilePos": 267
+                      },
+                      "name": "is_float"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 129,
+                          "startFilePos": 269,
+                          "endLine": 15,
+                          "endTokenPos": 132,
+                          "endFilePos": 275
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 129,
+                            "startFilePos": 269,
+                            "endLine": 15,
+                            "endTokenPos": 132,
+                            "endFilePos": 275
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 129,
+                              "startFilePos": 269,
+                              "endLine": 15,
+                              "endTokenPos": 129,
+                              "endFilePos": 270
+                            },
+                            "name": "p"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 131,
+                              "startFilePos": 272,
+                              "endLine": 15,
+                              "endTokenPos": 131,
+                              "endFilePos": 274,
+                              "kind": 2,
+                              "rawValue": "\"n\""
+                            },
+                            "value": "n"
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "if": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 137,
+                      "startFilePos": 280,
+                      "endLine": 15,
+                      "endTokenPos": 146,
+                      "endFilePos": 305
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 137,
+                        "startFilePos": 280,
+                        "endLine": 15,
+                        "endTokenPos": 137,
+                        "endFilePos": 290
+                      },
+                      "name": "json_encode"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 139,
+                          "startFilePos": 292,
+                          "endLine": 15,
+                          "endTokenPos": 142,
+                          "endFilePos": 298
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 139,
+                            "startFilePos": 292,
+                            "endLine": 15,
+                            "endTokenPos": 142,
+                            "endFilePos": 298
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 139,
+                              "startFilePos": 292,
+                              "endLine": 15,
+                              "endTokenPos": 139,
+                              "endFilePos": 293
+                            },
+                            "name": "p"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 141,
+                              "startFilePos": 295,
+                              "endLine": 15,
+                              "endTokenPos": 141,
+                              "endFilePos": 297,
+                              "kind": 2,
+                              "rawValue": "\"n\""
+                            },
+                            "value": "n"
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 145,
+                          "startFilePos": 301,
+                          "endLine": 15,
+                          "endTokenPos": 145,
+                          "endFilePos": 304
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 145,
+                            "startFilePos": 301,
+                            "endLine": 15,
+                            "endTokenPos": 145,
+                            "endFilePos": 304,
+                            "rawValue": "1344",
+                            "kind": 10
+                          },
+                          "value": 1344
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "else": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 150,
+                      "startFilePos": 309,
+                      "endLine": 15,
+                      "endTokenPos": 153,
+                      "endFilePos": 315
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 150,
+                        "startFilePos": 309,
+                        "endLine": 15,
+                        "endTokenPos": 150,
+                        "endFilePos": 310
+                      },
+                      "name": "p"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 152,
+                        "startFilePos": 312,
+                        "endLine": 15,
+                        "endTokenPos": 152,
+                        "endFilePos": 314,
+                        "kind": 2,
+                        "rawValue": "\"n\""
+                      },
+                      "value": "n"
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 158,
+                    "startFilePos": 320,
+                    "endLine": 15,
+                    "endTokenPos": 158,
+                    "endFilePos": 322,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 163,
+                  "startFilePos": 327,
+                  "endLine": 15,
+                  "endTokenPos": 189,
+                  "endFilePos": 382
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 163,
+                    "startFilePos": 327,
+                    "endLine": 15,
+                    "endTokenPos": 169,
+                    "endFilePos": 343
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 163,
+                      "startFilePos": 327,
+                      "endLine": 15,
+                      "endTokenPos": 163,
+                      "endFilePos": 334
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 165,
+                        "startFilePos": 336,
+                        "endLine": 15,
+                        "endTokenPos": 168,
+                        "endFilePos": 342
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 165,
+                          "startFilePos": 336,
+                          "endLine": 15,
+                          "endTokenPos": 168,
+                          "endFilePos": 342
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 165,
+                            "startFilePos": 336,
+                            "endLine": 15,
+                            "endTokenPos": 165,
+                            "endFilePos": 337
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 167,
+                            "startFilePos": 339,
+                            "endLine": 15,
+                            "endTokenPos": 167,
+                            "endFilePos": 341,
+                            "kind": 2,
+                            "rawValue": "\"l\""
+                          },
+                          "value": "l"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 173,
+                    "startFilePos": 347,
+                    "endLine": 15,
+                    "endTokenPos": 182,
+                    "endFilePos": 372
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 173,
+                      "startFilePos": 347,
+                      "endLine": 15,
+                      "endTokenPos": 173,
+                      "endFilePos": 357
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 175,
+                        "startFilePos": 359,
+                        "endLine": 15,
+                        "endTokenPos": 178,
+                        "endFilePos": 365
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 175,
+                          "startFilePos": 359,
+                          "endLine": 15,
+                          "endTokenPos": 178,
+                          "endFilePos": 365
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 175,
+                            "startFilePos": 359,
+                            "endLine": 15,
+                            "endTokenPos": 175,
+                            "endFilePos": 360
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 177,
+                            "startFilePos": 362,
+                            "endLine": 15,
+                            "endTokenPos": 177,
+                            "endFilePos": 364,
+                            "kind": 2,
+                            "rawValue": "\"l\""
+                          },
+                          "value": "l"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 181,
+                        "startFilePos": 368,
+                        "endLine": 15,
+                        "endTokenPos": 181,
+                        "endFilePos": 371
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 181,
+                          "startFilePos": 368,
+                          "endLine": 15,
+                          "endTokenPos": 181,
+                          "endFilePos": 371,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 186,
+                    "startFilePos": 376,
+                    "endLine": 15,
+                    "endTokenPos": 189,
+                    "endFilePos": 382
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 186,
+                      "startFilePos": 376,
+                      "endLine": 15,
+                      "endTokenPos": 186,
+                      "endFilePos": 377
+                    },
+                    "name": "p"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 188,
+                      "startFilePos": 379,
+                      "endLine": 15,
+                      "endTokenPos": 188,
+                      "endFilePos": 381,
+                      "kind": 2,
+                      "rawValue": "\"l\""
+                    },
+                    "value": "l"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 193,
+                "startFilePos": 386,
+                "endLine": 15,
+                "endTokenPos": 193,
+                "endFilePos": 392
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 193,
+                  "startFilePos": 386,
+                  "endLine": 15,
+                  "endTokenPos": 193,
+                  "endFilePos": 392
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/cross_join_triple.php.json
+++ b/tests/json-ast/x/php/cross_join_triple.php.json
@@ -1,0 +1,1556 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 11,
+        "endFilePos": 20
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 10,
+          "endFilePos": 19
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "nums"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 10,
+            "endFilePos": 19,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 13,
+        "startFilePos": 22,
+        "endLine": 3,
+        "endTokenPos": 23,
+        "endFilePos": 43
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 13,
+          "startFilePos": 22,
+          "endLine": 3,
+          "endTokenPos": 22,
+          "endFilePos": 42
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 22,
+            "endLine": 3,
+            "endTokenPos": 13,
+            "endFilePos": 29
+          },
+          "name": "letters"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 17,
+            "startFilePos": 33,
+            "endLine": 3,
+            "endTokenPos": 22,
+            "endFilePos": 42,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 18,
+                "startFilePos": 34,
+                "endLine": 3,
+                "endTokenPos": 18,
+                "endFilePos": 36
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 18,
+                  "startFilePos": 34,
+                  "endLine": 3,
+                  "endTokenPos": 18,
+                  "endFilePos": 36,
+                  "kind": 2,
+                  "rawValue": "\"A\""
+                },
+                "value": "A"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 21,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 21,
+                "endFilePos": 41
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 21,
+                  "startFilePos": 39,
+                  "endLine": 3,
+                  "endTokenPos": 21,
+                  "endFilePos": 41,
+                  "kind": 2,
+                  "rawValue": "\"B\""
+                },
+                "value": "B"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 25,
+        "startFilePos": 45,
+        "endLine": 4,
+        "endTokenPos": 35,
+        "endFilePos": 67
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 25,
+          "startFilePos": 45,
+          "endLine": 4,
+          "endTokenPos": 34,
+          "endFilePos": 66
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 25,
+            "startFilePos": 45,
+            "endLine": 4,
+            "endTokenPos": 25,
+            "endFilePos": 50
+          },
+          "name": "bools"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 29,
+            "startFilePos": 54,
+            "endLine": 4,
+            "endTokenPos": 34,
+            "endFilePos": 66,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 30,
+                "startFilePos": 55,
+                "endLine": 4,
+                "endTokenPos": 30,
+                "endFilePos": 58
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 30,
+                  "startFilePos": 55,
+                  "endLine": 4,
+                  "endTokenPos": 30,
+                  "endFilePos": 58
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 30,
+                    "startFilePos": 55,
+                    "endLine": 4,
+                    "endTokenPos": 30,
+                    "endFilePos": 58
+                  },
+                  "name": "true"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 33,
+                "startFilePos": 61,
+                "endLine": 4,
+                "endTokenPos": 33,
+                "endFilePos": 65
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 33,
+                  "startFilePos": 61,
+                  "endLine": 4,
+                  "endTokenPos": 33,
+                  "endFilePos": 65
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 33,
+                    "startFilePos": 61,
+                    "endLine": 4,
+                    "endTokenPos": 33,
+                    "endFilePos": 65
+                  },
+                  "name": "false"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 37,
+        "startFilePos": 69,
+        "endLine": 5,
+        "endTokenPos": 43,
+        "endFilePos": 81
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 37,
+          "startFilePos": 69,
+          "endLine": 5,
+          "endTokenPos": 42,
+          "endFilePos": 80
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 37,
+            "startFilePos": 69,
+            "endLine": 5,
+            "endTokenPos": 37,
+            "endFilePos": 75
+          },
+          "name": "combos"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 41,
+            "startFilePos": 79,
+            "endLine": 5,
+            "endTokenPos": 42,
+            "endFilePos": 80,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 45,
+        "startFilePos": 83,
+        "endLine": 12,
+        "endTokenPos": 114,
+        "endFilePos": 228
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 48,
+          "startFilePos": 92,
+          "endLine": 6,
+          "endTokenPos": 48,
+          "endFilePos": 96
+        },
+        "name": "nums"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 52,
+          "startFilePos": 101,
+          "endLine": 6,
+          "endTokenPos": 52,
+          "endFilePos": 102
+        },
+        "name": "n"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 57,
+            "startFilePos": 109,
+            "endLine": 11,
+            "endTokenPos": 112,
+            "endFilePos": 226
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 60,
+              "startFilePos": 118,
+              "endLine": 7,
+              "endTokenPos": 60,
+              "endFilePos": 125
+            },
+            "name": "letters"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 64,
+              "startFilePos": 130,
+              "endLine": 7,
+              "endTokenPos": 64,
+              "endFilePos": 131
+            },
+            "name": "l"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Foreach",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 69,
+                "startFilePos": 140,
+                "endLine": 10,
+                "endTokenPos": 110,
+                "endFilePos": 222
+              },
+              "expr": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 72,
+                  "startFilePos": 149,
+                  "endLine": 8,
+                  "endTokenPos": 72,
+                  "endFilePos": 154
+                },
+                "name": "bools"
+              },
+              "keyVar": null,
+              "byRef": false,
+              "valueVar": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 76,
+                  "startFilePos": 159,
+                  "endLine": 8,
+                  "endTokenPos": 76,
+                  "endFilePos": 160
+                },
+                "name": "b"
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_Expression",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 81,
+                    "startFilePos": 171,
+                    "endLine": 9,
+                    "endTokenPos": 108,
+                    "endFilePos": 216
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Assign",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 81,
+                      "startFilePos": 171,
+                      "endLine": 9,
+                      "endTokenPos": 107,
+                      "endFilePos": 215
+                    },
+                    "var": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 81,
+                        "startFilePos": 171,
+                        "endLine": 9,
+                        "endTokenPos": 83,
+                        "endFilePos": 179
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 81,
+                          "startFilePos": 171,
+                          "endLine": 9,
+                          "endTokenPos": 81,
+                          "endFilePos": 177
+                        },
+                        "name": "combos"
+                      },
+                      "dim": null
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Array",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 87,
+                        "startFilePos": 183,
+                        "endLine": 9,
+                        "endTokenPos": 107,
+                        "endFilePos": 215,
+                        "kind": 2
+                      },
+                      "items": [
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 88,
+                            "startFilePos": 184,
+                            "endLine": 9,
+                            "endTokenPos": 92,
+                            "endFilePos": 192
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 88,
+                              "startFilePos": 184,
+                              "endLine": 9,
+                              "endTokenPos": 88,
+                              "endFilePos": 186,
+                              "kind": 2,
+                              "rawValue": "\"n\""
+                            },
+                            "value": "n"
+                          },
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 92,
+                              "startFilePos": 191,
+                              "endLine": 9,
+                              "endTokenPos": 92,
+                              "endFilePos": 192
+                            },
+                            "name": "n"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 95,
+                            "startFilePos": 195,
+                            "endLine": 9,
+                            "endTokenPos": 99,
+                            "endFilePos": 203
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 95,
+                              "startFilePos": 195,
+                              "endLine": 9,
+                              "endTokenPos": 95,
+                              "endFilePos": 197,
+                              "kind": 2,
+                              "rawValue": "\"l\""
+                            },
+                            "value": "l"
+                          },
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 99,
+                              "startFilePos": 202,
+                              "endLine": 9,
+                              "endTokenPos": 99,
+                              "endFilePos": 203
+                            },
+                            "name": "l"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 102,
+                            "startFilePos": 206,
+                            "endLine": 9,
+                            "endTokenPos": 106,
+                            "endFilePos": 214
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 102,
+                              "startFilePos": 206,
+                              "endLine": 9,
+                              "endTokenPos": 102,
+                              "endFilePos": 208,
+                              "kind": 2,
+                              "rawValue": "\"b\""
+                            },
+                            "value": "b"
+                          },
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 106,
+                              "startFilePos": 213,
+                              "endLine": 9,
+                              "endTokenPos": 106,
+                              "endFilePos": 214
+                            },
+                            "name": "b"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 14,
+        "startTokenPos": 116,
+        "startFilePos": 231,
+        "endLine": 14,
+        "endTokenPos": 122,
+        "endFilePos": 280
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 118,
+            "startFilePos": 236,
+            "endLine": 14,
+            "endTokenPos": 118,
+            "endFilePos": 270,
+            "kind": 2,
+            "rawValue": "\"--- Cross Join of three lists ---\""
+          },
+          "value": "--- Cross Join of three lists ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 121,
+            "startFilePos": 273,
+            "endLine": 14,
+            "endTokenPos": 121,
+            "endFilePos": 279
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 121,
+              "startFilePos": 273,
+              "endLine": 14,
+              "endTokenPos": 121,
+              "endFilePos": 279
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 15,
+        "startTokenPos": 124,
+        "startFilePos": 282,
+        "endLine": 17,
+        "endTokenPos": 244,
+        "endFilePos": 518
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 15,
+          "startTokenPos": 127,
+          "startFilePos": 291,
+          "endLine": 15,
+          "endTokenPos": 127,
+          "endFilePos": 297
+        },
+        "name": "combos"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 15,
+          "startTokenPos": 131,
+          "startFilePos": 302,
+          "endLine": 15,
+          "endTokenPos": 131,
+          "endFilePos": 303
+        },
+        "name": "c"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 136,
+            "startFilePos": 310,
+            "endLine": 16,
+            "endTokenPos": 242,
+            "endFilePos": 516
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 138,
+                "startFilePos": 315,
+                "endLine": 16,
+                "endTokenPos": 238,
+                "endFilePos": 506
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 138,
+                  "startFilePos": 315,
+                  "endLine": 16,
+                  "endTokenPos": 206,
+                  "endFilePos": 445
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 138,
+                    "startFilePos": 315,
+                    "endLine": 16,
+                    "endTokenPos": 202,
+                    "endFilePos": 439
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 138,
+                      "startFilePos": 315,
+                      "endLine": 16,
+                      "endTokenPos": 170,
+                      "endFilePos": 378
+                    },
+                    "left": {
+                      "nodeType": "Expr_Ternary",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 139,
+                        "startFilePos": 316,
+                        "endLine": 16,
+                        "endTokenPos": 165,
+                        "endFilePos": 371
+                      },
+                      "cond": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 139,
+                          "startFilePos": 316,
+                          "endLine": 16,
+                          "endTokenPos": 145,
+                          "endFilePos": 332
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 139,
+                            "startFilePos": 316,
+                            "endLine": 16,
+                            "endTokenPos": 139,
+                            "endFilePos": 323
+                          },
+                          "name": "is_float"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 141,
+                              "startFilePos": 325,
+                              "endLine": 16,
+                              "endTokenPos": 144,
+                              "endFilePos": 331
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 141,
+                                "startFilePos": 325,
+                                "endLine": 16,
+                                "endTokenPos": 144,
+                                "endFilePos": 331
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 141,
+                                  "startFilePos": 325,
+                                  "endLine": 16,
+                                  "endTokenPos": 141,
+                                  "endFilePos": 326
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 143,
+                                  "startFilePos": 328,
+                                  "endLine": 16,
+                                  "endTokenPos": 143,
+                                  "endFilePos": 330,
+                                  "kind": 2,
+                                  "rawValue": "\"n\""
+                                },
+                                "value": "n"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "if": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 149,
+                          "startFilePos": 336,
+                          "endLine": 16,
+                          "endTokenPos": 158,
+                          "endFilePos": 361
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 149,
+                            "startFilePos": 336,
+                            "endLine": 16,
+                            "endTokenPos": 149,
+                            "endFilePos": 346
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 151,
+                              "startFilePos": 348,
+                              "endLine": 16,
+                              "endTokenPos": 154,
+                              "endFilePos": 354
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 151,
+                                "startFilePos": 348,
+                                "endLine": 16,
+                                "endTokenPos": 154,
+                                "endFilePos": 354
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 151,
+                                  "startFilePos": 348,
+                                  "endLine": 16,
+                                  "endTokenPos": 151,
+                                  "endFilePos": 349
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 153,
+                                  "startFilePos": 351,
+                                  "endLine": 16,
+                                  "endTokenPos": 153,
+                                  "endFilePos": 353,
+                                  "kind": 2,
+                                  "rawValue": "\"n\""
+                                },
+                                "value": "n"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 157,
+                              "startFilePos": 357,
+                              "endLine": 16,
+                              "endTokenPos": 157,
+                              "endFilePos": 360
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 157,
+                                "startFilePos": 357,
+                                "endLine": 16,
+                                "endTokenPos": 157,
+                                "endFilePos": 360,
+                                "rawValue": "1344",
+                                "kind": 10
+                              },
+                              "value": 1344
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "else": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 162,
+                          "startFilePos": 365,
+                          "endLine": 16,
+                          "endTokenPos": 165,
+                          "endFilePos": 371
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 162,
+                            "startFilePos": 365,
+                            "endLine": 16,
+                            "endTokenPos": 162,
+                            "endFilePos": 366
+                          },
+                          "name": "c"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 164,
+                            "startFilePos": 368,
+                            "endLine": 16,
+                            "endTokenPos": 164,
+                            "endFilePos": 370,
+                            "kind": 2,
+                            "rawValue": "\"n\""
+                          },
+                          "value": "n"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 170,
+                        "startFilePos": 376,
+                        "endLine": 16,
+                        "endTokenPos": 170,
+                        "endFilePos": 378,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Expr_Ternary",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 175,
+                      "startFilePos": 383,
+                      "endLine": 16,
+                      "endTokenPos": 201,
+                      "endFilePos": 438
+                    },
+                    "cond": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 175,
+                        "startFilePos": 383,
+                        "endLine": 16,
+                        "endTokenPos": 181,
+                        "endFilePos": 399
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 175,
+                          "startFilePos": 383,
+                          "endLine": 16,
+                          "endTokenPos": 175,
+                          "endFilePos": 390
+                        },
+                        "name": "is_float"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 177,
+                            "startFilePos": 392,
+                            "endLine": 16,
+                            "endTokenPos": 180,
+                            "endFilePos": 398
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 177,
+                              "startFilePos": 392,
+                              "endLine": 16,
+                              "endTokenPos": 180,
+                              "endFilePos": 398
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 177,
+                                "startFilePos": 392,
+                                "endLine": 16,
+                                "endTokenPos": 177,
+                                "endFilePos": 393
+                              },
+                              "name": "c"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 179,
+                                "startFilePos": 395,
+                                "endLine": 16,
+                                "endTokenPos": 179,
+                                "endFilePos": 397,
+                                "kind": 2,
+                                "rawValue": "\"l\""
+                              },
+                              "value": "l"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "if": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 185,
+                        "startFilePos": 403,
+                        "endLine": 16,
+                        "endTokenPos": 194,
+                        "endFilePos": 428
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 185,
+                          "startFilePos": 403,
+                          "endLine": 16,
+                          "endTokenPos": 185,
+                          "endFilePos": 413
+                        },
+                        "name": "json_encode"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 187,
+                            "startFilePos": 415,
+                            "endLine": 16,
+                            "endTokenPos": 190,
+                            "endFilePos": 421
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 187,
+                              "startFilePos": 415,
+                              "endLine": 16,
+                              "endTokenPos": 190,
+                              "endFilePos": 421
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 187,
+                                "startFilePos": 415,
+                                "endLine": 16,
+                                "endTokenPos": 187,
+                                "endFilePos": 416
+                              },
+                              "name": "c"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 189,
+                                "startFilePos": 418,
+                                "endLine": 16,
+                                "endTokenPos": 189,
+                                "endFilePos": 420,
+                                "kind": 2,
+                                "rawValue": "\"l\""
+                              },
+                              "value": "l"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 193,
+                            "startFilePos": 424,
+                            "endLine": 16,
+                            "endTokenPos": 193,
+                            "endFilePos": 427
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 193,
+                              "startFilePos": 424,
+                              "endLine": 16,
+                              "endTokenPos": 193,
+                              "endFilePos": 427,
+                              "rawValue": "1344",
+                              "kind": 10
+                            },
+                            "value": 1344
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "else": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 198,
+                        "startFilePos": 432,
+                        "endLine": 16,
+                        "endTokenPos": 201,
+                        "endFilePos": 438
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 198,
+                          "startFilePos": 432,
+                          "endLine": 16,
+                          "endTokenPos": 198,
+                          "endFilePos": 433
+                        },
+                        "name": "c"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 200,
+                          "startFilePos": 435,
+                          "endLine": 16,
+                          "endTokenPos": 200,
+                          "endFilePos": 437,
+                          "kind": 2,
+                          "rawValue": "\"l\""
+                        },
+                        "value": "l"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 206,
+                    "startFilePos": 443,
+                    "endLine": 16,
+                    "endTokenPos": 206,
+                    "endFilePos": 445,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 211,
+                  "startFilePos": 450,
+                  "endLine": 16,
+                  "endTokenPos": 237,
+                  "endFilePos": 505
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 211,
+                    "startFilePos": 450,
+                    "endLine": 16,
+                    "endTokenPos": 217,
+                    "endFilePos": 466
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 211,
+                      "startFilePos": 450,
+                      "endLine": 16,
+                      "endTokenPos": 211,
+                      "endFilePos": 457
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 213,
+                        "startFilePos": 459,
+                        "endLine": 16,
+                        "endTokenPos": 216,
+                        "endFilePos": 465
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 213,
+                          "startFilePos": 459,
+                          "endLine": 16,
+                          "endTokenPos": 216,
+                          "endFilePos": 465
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 213,
+                            "startFilePos": 459,
+                            "endLine": 16,
+                            "endTokenPos": 213,
+                            "endFilePos": 460
+                          },
+                          "name": "c"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 215,
+                            "startFilePos": 462,
+                            "endLine": 16,
+                            "endTokenPos": 215,
+                            "endFilePos": 464,
+                            "kind": 2,
+                            "rawValue": "\"b\""
+                          },
+                          "value": "b"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 221,
+                    "startFilePos": 470,
+                    "endLine": 16,
+                    "endTokenPos": 230,
+                    "endFilePos": 495
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 221,
+                      "startFilePos": 470,
+                      "endLine": 16,
+                      "endTokenPos": 221,
+                      "endFilePos": 480
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 223,
+                        "startFilePos": 482,
+                        "endLine": 16,
+                        "endTokenPos": 226,
+                        "endFilePos": 488
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 223,
+                          "startFilePos": 482,
+                          "endLine": 16,
+                          "endTokenPos": 226,
+                          "endFilePos": 488
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 223,
+                            "startFilePos": 482,
+                            "endLine": 16,
+                            "endTokenPos": 223,
+                            "endFilePos": 483
+                          },
+                          "name": "c"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 225,
+                            "startFilePos": 485,
+                            "endLine": 16,
+                            "endTokenPos": 225,
+                            "endFilePos": 487,
+                            "kind": 2,
+                            "rawValue": "\"b\""
+                          },
+                          "value": "b"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 229,
+                        "startFilePos": 491,
+                        "endLine": 16,
+                        "endTokenPos": 229,
+                        "endFilePos": 494
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 229,
+                          "startFilePos": 491,
+                          "endLine": 16,
+                          "endTokenPos": 229,
+                          "endFilePos": 494,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 234,
+                    "startFilePos": 499,
+                    "endLine": 16,
+                    "endTokenPos": 237,
+                    "endFilePos": 505
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 234,
+                      "startFilePos": 499,
+                      "endLine": 16,
+                      "endTokenPos": 234,
+                      "endFilePos": 500
+                    },
+                    "name": "c"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 236,
+                      "startFilePos": 502,
+                      "endLine": 16,
+                      "endTokenPos": 236,
+                      "endFilePos": 504,
+                      "kind": 2,
+                      "rawValue": "\"b\""
+                    },
+                    "value": "b"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 241,
+                "startFilePos": 509,
+                "endLine": 16,
+                "endTokenPos": 241,
+                "endFilePos": 515
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 241,
+                  "startFilePos": 509,
+                  "endLine": 16,
+                  "endTokenPos": 241,
+                  "endFilePos": 515
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/dataset_sort_take_limit.php.json
+++ b/tests/json-ast/x/php/dataset_sort_take_limit.php.json
@@ -1,0 +1,1633 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 117,
+        "endFilePos": 294
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 116,
+          "endFilePos": 293
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 14
+          },
+          "name": "products"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 18,
+            "endLine": 2,
+            "endTokenPos": 116,
+            "endFilePos": 293,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 19,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 55
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 55,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 20,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 37
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 20,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 25,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 30,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"Laptop\""
+                      },
+                      "value": "Laptop"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 40,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 54
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 40,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 46,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 51,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 54,
+                        "rawValue": "1500",
+                        "kind": 10
+                      },
+                      "value": 1500
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 58,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 97
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 58,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 97,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 59,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 80
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 59,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 64,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 69,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 80,
+                        "kind": 2,
+                        "rawValue": "\"Smartphone\""
+                      },
+                      "value": "Smartphone"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 83,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 96
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 89,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 96,
+                        "rawValue": "900",
+                        "kind": 10
+                      },
+                      "value": 900
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 100,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 135
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 100,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 135,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 101,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 118
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 101,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 106,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 111,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 118,
+                        "kind": 2,
+                        "rawValue": "\"Tablet\""
+                      },
+                      "value": "Tablet"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 121,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 134
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 121,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 127,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 132,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 134,
+                        "rawValue": "600",
+                        "kind": 10
+                      },
+                      "value": 600
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 54,
+                "startFilePos": 138,
+                "endLine": 2,
+                "endTokenPos": 67,
+                "endFilePos": 174
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 54,
+                  "startFilePos": 138,
+                  "endLine": 2,
+                  "endTokenPos": 67,
+                  "endFilePos": 174,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 139,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 157
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 139,
+                        "endLine": 2,
+                        "endTokenPos": 55,
+                        "endFilePos": 144,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 59,
+                        "startFilePos": 149,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 157,
+                        "kind": 2,
+                        "rawValue": "\"Monitor\""
+                      },
+                      "value": "Monitor"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 62,
+                      "startFilePos": 160,
+                      "endLine": 2,
+                      "endTokenPos": 66,
+                      "endFilePos": 173
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 62,
+                        "startFilePos": 160,
+                        "endLine": 2,
+                        "endTokenPos": 62,
+                        "endFilePos": 166,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 66,
+                        "startFilePos": 171,
+                        "endLine": 2,
+                        "endTokenPos": 66,
+                        "endFilePos": 173,
+                        "rawValue": "300",
+                        "kind": 10
+                      },
+                      "value": 300
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 70,
+                "startFilePos": 177,
+                "endLine": 2,
+                "endTokenPos": 83,
+                "endFilePos": 214
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 70,
+                  "startFilePos": 177,
+                  "endLine": 2,
+                  "endTokenPos": 83,
+                  "endFilePos": 214,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 71,
+                      "startFilePos": 178,
+                      "endLine": 2,
+                      "endTokenPos": 75,
+                      "endFilePos": 197
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 71,
+                        "startFilePos": 178,
+                        "endLine": 2,
+                        "endTokenPos": 71,
+                        "endFilePos": 183,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 75,
+                        "startFilePos": 188,
+                        "endLine": 2,
+                        "endTokenPos": 75,
+                        "endFilePos": 197,
+                        "kind": 2,
+                        "rawValue": "\"Keyboard\""
+                      },
+                      "value": "Keyboard"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 78,
+                      "startFilePos": 200,
+                      "endLine": 2,
+                      "endTokenPos": 82,
+                      "endFilePos": 213
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 78,
+                        "startFilePos": 200,
+                        "endLine": 2,
+                        "endTokenPos": 78,
+                        "endFilePos": 206,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 82,
+                        "startFilePos": 211,
+                        "endLine": 2,
+                        "endTokenPos": 82,
+                        "endFilePos": 213,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 86,
+                "startFilePos": 217,
+                "endLine": 2,
+                "endTokenPos": 99,
+                "endFilePos": 250
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 86,
+                  "startFilePos": 217,
+                  "endLine": 2,
+                  "endTokenPos": 99,
+                  "endFilePos": 250,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 87,
+                      "startFilePos": 218,
+                      "endLine": 2,
+                      "endTokenPos": 91,
+                      "endFilePos": 234
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 87,
+                        "startFilePos": 218,
+                        "endLine": 2,
+                        "endTokenPos": 87,
+                        "endFilePos": 223,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 91,
+                        "startFilePos": 228,
+                        "endLine": 2,
+                        "endTokenPos": 91,
+                        "endFilePos": 234,
+                        "kind": 2,
+                        "rawValue": "\"Mouse\""
+                      },
+                      "value": "Mouse"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 94,
+                      "startFilePos": 237,
+                      "endLine": 2,
+                      "endTokenPos": 98,
+                      "endFilePos": 249
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 94,
+                        "startFilePos": 237,
+                        "endLine": 2,
+                        "endTokenPos": 94,
+                        "endFilePos": 243,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 98,
+                        "startFilePos": 248,
+                        "endLine": 2,
+                        "endTokenPos": 98,
+                        "endFilePos": 249,
+                        "rawValue": "50",
+                        "kind": 10
+                      },
+                      "value": 50
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 102,
+                "startFilePos": 253,
+                "endLine": 2,
+                "endTokenPos": 115,
+                "endFilePos": 292
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 102,
+                  "startFilePos": 253,
+                  "endLine": 2,
+                  "endTokenPos": 115,
+                  "endFilePos": 292,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 103,
+                      "startFilePos": 254,
+                      "endLine": 2,
+                      "endTokenPos": 107,
+                      "endFilePos": 275
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 103,
+                        "startFilePos": 254,
+                        "endLine": 2,
+                        "endTokenPos": 103,
+                        "endFilePos": 259,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 107,
+                        "startFilePos": 264,
+                        "endLine": 2,
+                        "endTokenPos": 107,
+                        "endFilePos": 275,
+                        "kind": 2,
+                        "rawValue": "\"Headphones\""
+                      },
+                      "value": "Headphones"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 110,
+                      "startFilePos": 278,
+                      "endLine": 2,
+                      "endTokenPos": 114,
+                      "endFilePos": 291
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 110,
+                        "startFilePos": 278,
+                        "endLine": 2,
+                        "endTokenPos": 110,
+                        "endFilePos": 284,
+                        "kind": 2,
+                        "rawValue": "\"price\""
+                      },
+                      "value": "price"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 114,
+                        "startFilePos": 289,
+                        "endLine": 2,
+                        "endTokenPos": 114,
+                        "endFilePos": 291,
+                        "rawValue": "200",
+                        "kind": 10
+                      },
+                      "value": 200
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 119,
+        "startFilePos": 296,
+        "endLine": 3,
+        "endTokenPos": 125,
+        "endFilePos": 311
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 119,
+          "startFilePos": 296,
+          "endLine": 3,
+          "endTokenPos": 124,
+          "endFilePos": 310
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 119,
+            "startFilePos": 296,
+            "endLine": 3,
+            "endTokenPos": 119,
+            "endFilePos": 305
+          },
+          "name": "expensive"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 123,
+            "startFilePos": 309,
+            "endLine": 3,
+            "endTokenPos": 124,
+            "endFilePos": 310,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 127,
+        "startFilePos": 313,
+        "endLine": 6,
+        "endTokenPos": 148,
+        "endFilePos": 362
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 130,
+          "startFilePos": 322,
+          "endLine": 4,
+          "endTokenPos": 130,
+          "endFilePos": 330
+        },
+        "name": "products"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 134,
+          "startFilePos": 335,
+          "endLine": 4,
+          "endTokenPos": 134,
+          "endFilePos": 336
+        },
+        "name": "p"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 139,
+            "startFilePos": 343,
+            "endLine": 5,
+            "endTokenPos": 146,
+            "endFilePos": 360
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 139,
+              "startFilePos": 343,
+              "endLine": 5,
+              "endTokenPos": 145,
+              "endFilePos": 359
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 139,
+                "startFilePos": 343,
+                "endLine": 5,
+                "endTokenPos": 141,
+                "endFilePos": 354
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 139,
+                  "startFilePos": 343,
+                  "endLine": 5,
+                  "endTokenPos": 139,
+                  "endFilePos": 352
+                },
+                "name": "expensive"
+              },
+              "dim": null
+            },
+            "expr": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 145,
+                "startFilePos": 358,
+                "endLine": 5,
+                "endTokenPos": 145,
+                "endFilePos": 359
+              },
+              "name": "p"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 150,
+        "startFilePos": 365,
+        "endLine": 8,
+        "endTokenPos": 156,
+        "endFilePos": 428
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 152,
+            "startFilePos": 370,
+            "endLine": 8,
+            "endTokenPos": 152,
+            "endFilePos": 418,
+            "kind": 2,
+            "rawValue": "\"--- Top products (excluding most expensive) ---\""
+          },
+          "value": "--- Top products (excluding most expensive) ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 155,
+            "startFilePos": 421,
+            "endLine": 8,
+            "endTokenPos": 155,
+            "endFilePos": 427
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 155,
+              "startFilePos": 421,
+              "endLine": 8,
+              "endTokenPos": 155,
+              "endFilePos": 427
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 9,
+        "startTokenPos": 158,
+        "startFilePos": 430,
+        "endLine": 11,
+        "endTokenPos": 250,
+        "endFilePos": 662
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 9,
+          "startTokenPos": 161,
+          "startFilePos": 439,
+          "endLine": 9,
+          "endTokenPos": 161,
+          "endFilePos": 448
+        },
+        "name": "expensive"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 9,
+          "startTokenPos": 165,
+          "startFilePos": 453,
+          "endLine": 9,
+          "endTokenPos": 165,
+          "endFilePos": 457
+        },
+        "name": "item"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 170,
+            "startFilePos": 464,
+            "endLine": 10,
+            "endTokenPos": 248,
+            "endFilePos": 660
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 172,
+                "startFilePos": 469,
+                "endLine": 10,
+                "endTokenPos": 244,
+                "endFilePos": 650
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 172,
+                  "startFilePos": 469,
+                  "endLine": 10,
+                  "endTokenPos": 212,
+                  "endFilePos": 568
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 172,
+                    "startFilePos": 469,
+                    "endLine": 10,
+                    "endTokenPos": 208,
+                    "endFilePos": 562
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 172,
+                      "startFilePos": 469,
+                      "endLine": 10,
+                      "endTokenPos": 204,
+                      "endFilePos": 550
+                    },
+                    "left": {
+                      "nodeType": "Expr_Ternary",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 173,
+                        "startFilePos": 470,
+                        "endLine": 10,
+                        "endTokenPos": 199,
+                        "endFilePos": 543
+                      },
+                      "cond": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 173,
+                          "startFilePos": 470,
+                          "endLine": 10,
+                          "endTokenPos": 179,
+                          "endFilePos": 492
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 173,
+                            "startFilePos": 470,
+                            "endLine": 10,
+                            "endTokenPos": 173,
+                            "endFilePos": 477
+                          },
+                          "name": "is_float"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 175,
+                              "startFilePos": 479,
+                              "endLine": 10,
+                              "endTokenPos": 178,
+                              "endFilePos": 491
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 175,
+                                "startFilePos": 479,
+                                "endLine": 10,
+                                "endTokenPos": 178,
+                                "endFilePos": 491
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 175,
+                                  "startFilePos": 479,
+                                  "endLine": 10,
+                                  "endTokenPos": 175,
+                                  "endFilePos": 483
+                                },
+                                "name": "item"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 177,
+                                  "startFilePos": 485,
+                                  "endLine": 10,
+                                  "endTokenPos": 177,
+                                  "endFilePos": 490,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "if": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 183,
+                          "startFilePos": 496,
+                          "endLine": 10,
+                          "endTokenPos": 192,
+                          "endFilePos": 527
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 183,
+                            "startFilePos": 496,
+                            "endLine": 10,
+                            "endTokenPos": 183,
+                            "endFilePos": 506
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 185,
+                              "startFilePos": 508,
+                              "endLine": 10,
+                              "endTokenPos": 188,
+                              "endFilePos": 520
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 185,
+                                "startFilePos": 508,
+                                "endLine": 10,
+                                "endTokenPos": 188,
+                                "endFilePos": 520
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 185,
+                                  "startFilePos": 508,
+                                  "endLine": 10,
+                                  "endTokenPos": 185,
+                                  "endFilePos": 512
+                                },
+                                "name": "item"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 187,
+                                  "startFilePos": 514,
+                                  "endLine": 10,
+                                  "endTokenPos": 187,
+                                  "endFilePos": 519,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 191,
+                              "startFilePos": 523,
+                              "endLine": 10,
+                              "endTokenPos": 191,
+                              "endFilePos": 526
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 191,
+                                "startFilePos": 523,
+                                "endLine": 10,
+                                "endTokenPos": 191,
+                                "endFilePos": 526,
+                                "rawValue": "1344",
+                                "kind": 10
+                              },
+                              "value": 1344
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "else": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 196,
+                          "startFilePos": 531,
+                          "endLine": 10,
+                          "endTokenPos": 199,
+                          "endFilePos": 543
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 196,
+                            "startFilePos": 531,
+                            "endLine": 10,
+                            "endTokenPos": 196,
+                            "endFilePos": 535
+                          },
+                          "name": "item"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 198,
+                            "startFilePos": 537,
+                            "endLine": 10,
+                            "endTokenPos": 198,
+                            "endFilePos": 542,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 204,
+                        "startFilePos": 548,
+                        "endLine": 10,
+                        "endTokenPos": 204,
+                        "endFilePos": 550,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 208,
+                      "startFilePos": 554,
+                      "endLine": 10,
+                      "endTokenPos": 208,
+                      "endFilePos": 562,
+                      "kind": 2,
+                      "rawValue": "\"costs $\""
+                    },
+                    "value": "costs $"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 212,
+                    "startFilePos": 566,
+                    "endLine": 10,
+                    "endTokenPos": 212,
+                    "endFilePos": 568,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 217,
+                  "startFilePos": 573,
+                  "endLine": 10,
+                  "endTokenPos": 243,
+                  "endFilePos": 649
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 217,
+                    "startFilePos": 573,
+                    "endLine": 10,
+                    "endTokenPos": 223,
+                    "endFilePos": 596
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 217,
+                      "startFilePos": 573,
+                      "endLine": 10,
+                      "endTokenPos": 217,
+                      "endFilePos": 580
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 219,
+                        "startFilePos": 582,
+                        "endLine": 10,
+                        "endTokenPos": 222,
+                        "endFilePos": 595
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 219,
+                          "startFilePos": 582,
+                          "endLine": 10,
+                          "endTokenPos": 222,
+                          "endFilePos": 595
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 219,
+                            "startFilePos": 582,
+                            "endLine": 10,
+                            "endTokenPos": 219,
+                            "endFilePos": 586
+                          },
+                          "name": "item"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 221,
+                            "startFilePos": 588,
+                            "endLine": 10,
+                            "endTokenPos": 221,
+                            "endFilePos": 594,
+                            "kind": 2,
+                            "rawValue": "\"price\""
+                          },
+                          "value": "price"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 227,
+                    "startFilePos": 600,
+                    "endLine": 10,
+                    "endTokenPos": 236,
+                    "endFilePos": 632
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 227,
+                      "startFilePos": 600,
+                      "endLine": 10,
+                      "endTokenPos": 227,
+                      "endFilePos": 610
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 229,
+                        "startFilePos": 612,
+                        "endLine": 10,
+                        "endTokenPos": 232,
+                        "endFilePos": 625
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 229,
+                          "startFilePos": 612,
+                          "endLine": 10,
+                          "endTokenPos": 232,
+                          "endFilePos": 625
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 229,
+                            "startFilePos": 612,
+                            "endLine": 10,
+                            "endTokenPos": 229,
+                            "endFilePos": 616
+                          },
+                          "name": "item"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 231,
+                            "startFilePos": 618,
+                            "endLine": 10,
+                            "endTokenPos": 231,
+                            "endFilePos": 624,
+                            "kind": 2,
+                            "rawValue": "\"price\""
+                          },
+                          "value": "price"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 235,
+                        "startFilePos": 628,
+                        "endLine": 10,
+                        "endTokenPos": 235,
+                        "endFilePos": 631
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 235,
+                          "startFilePos": 628,
+                          "endLine": 10,
+                          "endTokenPos": 235,
+                          "endFilePos": 631,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 240,
+                    "startFilePos": 636,
+                    "endLine": 10,
+                    "endTokenPos": 243,
+                    "endFilePos": 649
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 240,
+                      "startFilePos": 636,
+                      "endLine": 10,
+                      "endTokenPos": 240,
+                      "endFilePos": 640
+                    },
+                    "name": "item"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 242,
+                      "startFilePos": 642,
+                      "endLine": 10,
+                      "endTokenPos": 242,
+                      "endFilePos": 648,
+                      "kind": 2,
+                      "rawValue": "\"price\""
+                    },
+                    "value": "price"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 247,
+                "startFilePos": 653,
+                "endLine": 10,
+                "endTokenPos": 247,
+                "endFilePos": 659
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 247,
+                  "startFilePos": 653,
+                  "endLine": 10,
+                  "endTokenPos": 247,
+                  "endFilePos": 659
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/dataset_where_filter.php.json
+++ b/tests/json-ast/x/php/dataset_where_filter.php.json
@@ -1,0 +1,1711 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 69,
+        "endFilePos": 152
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 68,
+          "endFilePos": 151
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 68,
+            "endFilePos": 151,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 48
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 48,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 34
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 23,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 34,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 37,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 47
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 37,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 41,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 46,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 47,
+                        "rawValue": "30",
+                        "kind": 10
+                      },
+                      "value": 30
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 51,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 80
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 51,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 80,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 52,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 66
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 52,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 57,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 62,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 69,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 79
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 69,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 73,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 78,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 79,
+                        "rawValue": "15",
+                        "kind": 10
+                      },
+                      "value": 15
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 83,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 116
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 83,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 116,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 84,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 102
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 84,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 89,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 102,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 105,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 115
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 105,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 109,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 114,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 115,
+                        "rawValue": "65",
+                        "kind": 10
+                      },
+                      "value": 65
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 54,
+                "startFilePos": 119,
+                "endLine": 2,
+                "endTokenPos": 67,
+                "endFilePos": 150
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 54,
+                  "startFilePos": 119,
+                  "endLine": 2,
+                  "endTokenPos": 67,
+                  "endFilePos": 150,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 120,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 136
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 120,
+                        "endLine": 2,
+                        "endTokenPos": 55,
+                        "endFilePos": 125,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 59,
+                        "startFilePos": 130,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 136,
+                        "kind": 2,
+                        "rawValue": "\"Diana\""
+                      },
+                      "value": "Diana"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 62,
+                      "startFilePos": 139,
+                      "endLine": 2,
+                      "endTokenPos": 66,
+                      "endFilePos": 149
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 62,
+                        "startFilePos": 139,
+                        "endLine": 2,
+                        "endTokenPos": 62,
+                        "endFilePos": 143,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 66,
+                        "startFilePos": 148,
+                        "endLine": 2,
+                        "endTokenPos": 66,
+                        "endFilePos": 149,
+                        "rawValue": "45",
+                        "kind": 10
+                      },
+                      "value": 45
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 71,
+        "startFilePos": 154,
+        "endLine": 3,
+        "endTokenPos": 77,
+        "endFilePos": 166
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 71,
+          "startFilePos": 154,
+          "endLine": 3,
+          "endTokenPos": 76,
+          "endFilePos": 165
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 71,
+            "startFilePos": 154,
+            "endLine": 3,
+            "endTokenPos": 71,
+            "endFilePos": 160
+          },
+          "name": "adults"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 75,
+            "startFilePos": 164,
+            "endLine": 3,
+            "endTokenPos": 76,
+            "endFilePos": 165,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 79,
+        "startFilePos": 168,
+        "endLine": 8,
+        "endTokenPos": 150,
+        "endFilePos": 340
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 82,
+          "startFilePos": 177,
+          "endLine": 4,
+          "endTokenPos": 82,
+          "endFilePos": 183
+        },
+        "name": "people"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 86,
+          "startFilePos": 188,
+          "endLine": 4,
+          "endTokenPos": 86,
+          "endFilePos": 194
+        },
+        "name": "person"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 91,
+            "startFilePos": 201,
+            "endLine": 7,
+            "endTokenPos": 148,
+            "endFilePos": 338
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 94,
+              "startFilePos": 205,
+              "endLine": 5,
+              "endTokenPos": 101,
+              "endFilePos": 224
+            },
+            "left": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 94,
+                "startFilePos": 205,
+                "endLine": 5,
+                "endTokenPos": 97,
+                "endFilePos": 218
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 94,
+                  "startFilePos": 205,
+                  "endLine": 5,
+                  "endTokenPos": 94,
+                  "endFilePos": 211
+                },
+                "name": "person"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 96,
+                  "startFilePos": 213,
+                  "endLine": 5,
+                  "endTokenPos": 96,
+                  "endFilePos": 217,
+                  "kind": 2,
+                  "rawValue": "\"age\""
+                },
+                "value": "age"
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 101,
+                "startFilePos": 223,
+                "endLine": 5,
+                "endTokenPos": 101,
+                "endFilePos": 224,
+                "rawValue": "18",
+                "kind": 10
+              },
+              "value": 18
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 106,
+                "startFilePos": 233,
+                "endLine": 6,
+                "endTokenPos": 146,
+                "endFilePos": 334
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 106,
+                  "startFilePos": 233,
+                  "endLine": 6,
+                  "endTokenPos": 145,
+                  "endFilePos": 333
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 106,
+                    "startFilePos": 233,
+                    "endLine": 6,
+                    "endTokenPos": 108,
+                    "endFilePos": 241
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 106,
+                      "startFilePos": 233,
+                      "endLine": 6,
+                      "endTokenPos": 106,
+                      "endFilePos": 239
+                    },
+                    "name": "adults"
+                  },
+                  "dim": null
+                },
+                "expr": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 112,
+                    "startFilePos": 245,
+                    "endLine": 6,
+                    "endTokenPos": 145,
+                    "endFilePos": 333,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 113,
+                        "startFilePos": 246,
+                        "endLine": 6,
+                        "endTokenPos": 120,
+                        "endFilePos": 270
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 113,
+                          "startFilePos": 246,
+                          "endLine": 6,
+                          "endTokenPos": 113,
+                          "endFilePos": 251,
+                          "kind": 2,
+                          "rawValue": "\"name\""
+                        },
+                        "value": "name"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 117,
+                          "startFilePos": 256,
+                          "endLine": 6,
+                          "endTokenPos": 120,
+                          "endFilePos": 270
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 117,
+                            "startFilePos": 256,
+                            "endLine": 6,
+                            "endTokenPos": 117,
+                            "endFilePos": 262
+                          },
+                          "name": "person"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 119,
+                            "startFilePos": 264,
+                            "endLine": 6,
+                            "endTokenPos": 119,
+                            "endFilePos": 269,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 123,
+                        "startFilePos": 273,
+                        "endLine": 6,
+                        "endTokenPos": 130,
+                        "endFilePos": 295
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 123,
+                          "startFilePos": 273,
+                          "endLine": 6,
+                          "endTokenPos": 123,
+                          "endFilePos": 277,
+                          "kind": 2,
+                          "rawValue": "\"age\""
+                        },
+                        "value": "age"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 127,
+                          "startFilePos": 282,
+                          "endLine": 6,
+                          "endTokenPos": 130,
+                          "endFilePos": 295
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 127,
+                            "startFilePos": 282,
+                            "endLine": 6,
+                            "endTokenPos": 127,
+                            "endFilePos": 288
+                          },
+                          "name": "person"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 129,
+                            "startFilePos": 290,
+                            "endLine": 6,
+                            "endTokenPos": 129,
+                            "endFilePos": 294,
+                            "kind": 2,
+                            "rawValue": "\"age\""
+                          },
+                          "value": "age"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 133,
+                        "startFilePos": 298,
+                        "endLine": 6,
+                        "endTokenPos": 144,
+                        "endFilePos": 332
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 133,
+                          "startFilePos": 298,
+                          "endLine": 6,
+                          "endTokenPos": 133,
+                          "endFilePos": 308,
+                          "kind": 2,
+                          "rawValue": "\"is_senior\""
+                        },
+                        "value": "is_senior"
+                      },
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 137,
+                          "startFilePos": 313,
+                          "endLine": 6,
+                          "endTokenPos": 144,
+                          "endFilePos": 332
+                        },
+                        "left": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 137,
+                            "startFilePos": 313,
+                            "endLine": 6,
+                            "endTokenPos": 140,
+                            "endFilePos": 326
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 137,
+                              "startFilePos": 313,
+                              "endLine": 6,
+                              "endTokenPos": 137,
+                              "endFilePos": 319
+                            },
+                            "name": "person"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 139,
+                              "startFilePos": 321,
+                              "endLine": 6,
+                              "endTokenPos": 139,
+                              "endFilePos": 325,
+                              "kind": 2,
+                              "rawValue": "\"age\""
+                            },
+                            "value": "age"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 144,
+                            "startFilePos": 331,
+                            "endLine": 6,
+                            "endTokenPos": 144,
+                            "endFilePos": 332,
+                            "rawValue": "60",
+                            "kind": 10
+                          },
+                          "value": 60
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 152,
+        "startFilePos": 343,
+        "endLine": 10,
+        "endTokenPos": 158,
+        "endFilePos": 373
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 154,
+            "startFilePos": 348,
+            "endLine": 10,
+            "endTokenPos": 154,
+            "endFilePos": 363,
+            "kind": 2,
+            "rawValue": "\"--- Adults ---\""
+          },
+          "value": "--- Adults ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 157,
+            "startFilePos": 366,
+            "endLine": 10,
+            "endTokenPos": 157,
+            "endFilePos": 372
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 10,
+              "startTokenPos": 157,
+              "startFilePos": 366,
+              "endLine": 10,
+              "endTokenPos": 157,
+              "endFilePos": 372
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 11,
+        "startTokenPos": 160,
+        "startFilePos": 375,
+        "endLine": 13,
+        "endTokenPos": 273,
+        "endFilePos": 657
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 11,
+          "startTokenPos": 163,
+          "startFilePos": 384,
+          "endLine": 11,
+          "endTokenPos": 163,
+          "endFilePos": 390
+        },
+        "name": "adults"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 11,
+          "startTokenPos": 167,
+          "startFilePos": 395,
+          "endLine": 11,
+          "endTokenPos": 167,
+          "endFilePos": 401
+        },
+        "name": "person"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 172,
+            "startFilePos": 408,
+            "endLine": 12,
+            "endTokenPos": 271,
+            "endFilePos": 655
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 174,
+                "startFilePos": 413,
+                "endLine": 12,
+                "endTokenPos": 267,
+                "endFilePos": 645
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 174,
+                  "startFilePos": 413,
+                  "endLine": 12,
+                  "endTokenPos": 250,
+                  "endFilePos": 601
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 174,
+                    "startFilePos": 413,
+                    "endLine": 12,
+                    "endTokenPos": 246,
+                    "endFilePos": 595
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 174,
+                      "startFilePos": 413,
+                      "endLine": 12,
+                      "endTokenPos": 214,
+                      "endFilePos": 513
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 174,
+                        "startFilePos": 413,
+                        "endLine": 12,
+                        "endTokenPos": 210,
+                        "endFilePos": 507
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 174,
+                          "startFilePos": 413,
+                          "endLine": 12,
+                          "endTokenPos": 206,
+                          "endFilePos": 500
+                        },
+                        "left": {
+                          "nodeType": "Expr_Ternary",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 175,
+                            "startFilePos": 414,
+                            "endLine": 12,
+                            "endTokenPos": 201,
+                            "endFilePos": 493
+                          },
+                          "cond": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 175,
+                              "startFilePos": 414,
+                              "endLine": 12,
+                              "endTokenPos": 181,
+                              "endFilePos": 438
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 175,
+                                "startFilePos": 414,
+                                "endLine": 12,
+                                "endTokenPos": 175,
+                                "endFilePos": 421
+                              },
+                              "name": "is_float"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 177,
+                                  "startFilePos": 423,
+                                  "endLine": 12,
+                                  "endTokenPos": 180,
+                                  "endFilePos": 437
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 177,
+                                    "startFilePos": 423,
+                                    "endLine": 12,
+                                    "endTokenPos": 180,
+                                    "endFilePos": 437
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 177,
+                                      "startFilePos": 423,
+                                      "endLine": 12,
+                                      "endTokenPos": 177,
+                                      "endFilePos": 429
+                                    },
+                                    "name": "person"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 179,
+                                      "startFilePos": 431,
+                                      "endLine": 12,
+                                      "endTokenPos": 179,
+                                      "endFilePos": 436,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "if": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 185,
+                              "startFilePos": 442,
+                              "endLine": 12,
+                              "endTokenPos": 194,
+                              "endFilePos": 475
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 185,
+                                "startFilePos": 442,
+                                "endLine": 12,
+                                "endTokenPos": 185,
+                                "endFilePos": 452
+                              },
+                              "name": "json_encode"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 187,
+                                  "startFilePos": 454,
+                                  "endLine": 12,
+                                  "endTokenPos": 190,
+                                  "endFilePos": 468
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 187,
+                                    "startFilePos": 454,
+                                    "endLine": 12,
+                                    "endTokenPos": 190,
+                                    "endFilePos": 468
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 187,
+                                      "startFilePos": 454,
+                                      "endLine": 12,
+                                      "endTokenPos": 187,
+                                      "endFilePos": 460
+                                    },
+                                    "name": "person"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 189,
+                                      "startFilePos": 462,
+                                      "endLine": 12,
+                                      "endTokenPos": 189,
+                                      "endFilePos": 467,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 193,
+                                  "startFilePos": 471,
+                                  "endLine": 12,
+                                  "endTokenPos": 193,
+                                  "endFilePos": 474
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 193,
+                                    "startFilePos": 471,
+                                    "endLine": 12,
+                                    "endTokenPos": 193,
+                                    "endFilePos": 474,
+                                    "rawValue": "1344",
+                                    "kind": 10
+                                  },
+                                  "value": 1344
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "else": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 198,
+                              "startFilePos": 479,
+                              "endLine": 12,
+                              "endTokenPos": 201,
+                              "endFilePos": 493
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 198,
+                                "startFilePos": 479,
+                                "endLine": 12,
+                                "endTokenPos": 198,
+                                "endFilePos": 485
+                              },
+                              "name": "person"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 200,
+                                "startFilePos": 487,
+                                "endLine": 12,
+                                "endTokenPos": 200,
+                                "endFilePos": 492,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 206,
+                            "startFilePos": 498,
+                            "endLine": 12,
+                            "endTokenPos": 206,
+                            "endFilePos": 500,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 210,
+                          "startFilePos": 504,
+                          "endLine": 12,
+                          "endTokenPos": 210,
+                          "endFilePos": 507,
+                          "kind": 2,
+                          "rawValue": "\"is\""
+                        },
+                        "value": "is"
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 214,
+                        "startFilePos": 511,
+                        "endLine": 12,
+                        "endTokenPos": 214,
+                        "endFilePos": 513,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Expr_Ternary",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 219,
+                      "startFilePos": 518,
+                      "endLine": 12,
+                      "endTokenPos": 245,
+                      "endFilePos": 594
+                    },
+                    "cond": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 219,
+                        "startFilePos": 518,
+                        "endLine": 12,
+                        "endTokenPos": 225,
+                        "endFilePos": 541
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 219,
+                          "startFilePos": 518,
+                          "endLine": 12,
+                          "endTokenPos": 219,
+                          "endFilePos": 525
+                        },
+                        "name": "is_float"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 221,
+                            "startFilePos": 527,
+                            "endLine": 12,
+                            "endTokenPos": 224,
+                            "endFilePos": 540
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 221,
+                              "startFilePos": 527,
+                              "endLine": 12,
+                              "endTokenPos": 224,
+                              "endFilePos": 540
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 221,
+                                "startFilePos": 527,
+                                "endLine": 12,
+                                "endTokenPos": 221,
+                                "endFilePos": 533
+                              },
+                              "name": "person"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 223,
+                                "startFilePos": 535,
+                                "endLine": 12,
+                                "endTokenPos": 223,
+                                "endFilePos": 539,
+                                "kind": 2,
+                                "rawValue": "\"age\""
+                              },
+                              "value": "age"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "if": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 229,
+                        "startFilePos": 545,
+                        "endLine": 12,
+                        "endTokenPos": 238,
+                        "endFilePos": 577
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 229,
+                          "startFilePos": 545,
+                          "endLine": 12,
+                          "endTokenPos": 229,
+                          "endFilePos": 555
+                        },
+                        "name": "json_encode"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 231,
+                            "startFilePos": 557,
+                            "endLine": 12,
+                            "endTokenPos": 234,
+                            "endFilePos": 570
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 231,
+                              "startFilePos": 557,
+                              "endLine": 12,
+                              "endTokenPos": 234,
+                              "endFilePos": 570
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 231,
+                                "startFilePos": 557,
+                                "endLine": 12,
+                                "endTokenPos": 231,
+                                "endFilePos": 563
+                              },
+                              "name": "person"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 233,
+                                "startFilePos": 565,
+                                "endLine": 12,
+                                "endTokenPos": 233,
+                                "endFilePos": 569,
+                                "kind": 2,
+                                "rawValue": "\"age\""
+                              },
+                              "value": "age"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 237,
+                            "startFilePos": 573,
+                            "endLine": 12,
+                            "endTokenPos": 237,
+                            "endFilePos": 576
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 237,
+                              "startFilePos": 573,
+                              "endLine": 12,
+                              "endTokenPos": 237,
+                              "endFilePos": 576,
+                              "rawValue": "1344",
+                              "kind": 10
+                            },
+                            "value": 1344
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "else": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 242,
+                        "startFilePos": 581,
+                        "endLine": 12,
+                        "endTokenPos": 245,
+                        "endFilePos": 594
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 242,
+                          "startFilePos": 581,
+                          "endLine": 12,
+                          "endTokenPos": 242,
+                          "endFilePos": 587
+                        },
+                        "name": "person"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 244,
+                          "startFilePos": 589,
+                          "endLine": 12,
+                          "endTokenPos": 244,
+                          "endFilePos": 593,
+                          "kind": 2,
+                          "rawValue": "\"age\""
+                        },
+                        "value": "age"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 250,
+                    "startFilePos": 599,
+                    "endLine": 12,
+                    "endTokenPos": 250,
+                    "endFilePos": 601,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 255,
+                  "startFilePos": 606,
+                  "endLine": 12,
+                  "endTokenPos": 266,
+                  "endFilePos": 644
+                },
+                "cond": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 255,
+                    "startFilePos": 606,
+                    "endLine": 12,
+                    "endTokenPos": 258,
+                    "endFilePos": 625
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 255,
+                      "startFilePos": 606,
+                      "endLine": 12,
+                      "endTokenPos": 255,
+                      "endFilePos": 612
+                    },
+                    "name": "person"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 257,
+                      "startFilePos": 614,
+                      "endLine": 12,
+                      "endTokenPos": 257,
+                      "endFilePos": 624,
+                      "kind": 2,
+                      "rawValue": "\"is_senior\""
+                    },
+                    "value": "is_senior"
+                  }
+                },
+                "if": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 262,
+                    "startFilePos": 629,
+                    "endLine": 12,
+                    "endTokenPos": 262,
+                    "endFilePos": 639,
+                    "kind": 2,
+                    "rawValue": "\" (senior)\""
+                  },
+                  "value": " (senior)"
+                },
+                "else": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 266,
+                    "startFilePos": 643,
+                    "endLine": 12,
+                    "endTokenPos": 266,
+                    "endFilePos": 644,
+                    "kind": 2,
+                    "rawValue": "\"\""
+                  },
+                  "value": ""
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 270,
+                "startFilePos": 648,
+                "endLine": 12,
+                "endTokenPos": 270,
+                "endFilePos": 654
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 270,
+                  "startFilePos": 648,
+                  "endLine": 12,
+                  "endTokenPos": 270,
+                  "endFilePos": 654
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/exists_builtin.php.json
+++ b/tests/json-ast/x/php/exists_builtin.php.json
@@ -1,0 +1,568 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 11,
+        "endFilePos": 20
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 10,
+          "endFilePos": 19
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "data"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 10,
+            "endFilePos": 19,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 13,
+        "startFilePos": 22,
+        "endLine": 11,
+        "endTokenPos": 91,
+        "endFilePos": 182
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 13,
+          "startFilePos": 22,
+          "endLine": 11,
+          "endTokenPos": 90,
+          "endFilePos": 181
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 22,
+            "endLine": 3,
+            "endTokenPos": 13,
+            "endFilePos": 26
+          },
+          "name": "flag"
+        },
+        "expr": {
+          "nodeType": "Expr_BinaryOp_Greater",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 17,
+            "startFilePos": 30,
+            "endLine": 11,
+            "endTokenPos": 90,
+            "endFilePos": 181
+          },
+          "left": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 17,
+              "startFilePos": 30,
+              "endLine": 11,
+              "endTokenPos": 86,
+              "endFilePos": 177
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 30,
+                "endLine": 3,
+                "endTokenPos": 17,
+                "endFilePos": 34
+              },
+              "name": "count"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 19,
+                  "startFilePos": 36,
+                  "endLine": 11,
+                  "endTokenPos": 85,
+                  "endFilePos": 176
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 19,
+                    "startFilePos": 36,
+                    "endLine": 11,
+                    "endTokenPos": 85,
+                    "endFilePos": 176
+                  },
+                  "name": {
+                    "nodeType": "Expr_Closure",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 20,
+                      "startFilePos": 37,
+                      "endLine": 11,
+                      "endTokenPos": 82,
+                      "endFilePos": 173
+                    },
+                    "static": false,
+                    "byRef": false,
+                    "params": [],
+                    "uses": [
+                      {
+                        "nodeType": "ClosureUse",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 27,
+                          "startFilePos": 53,
+                          "endLine": 3,
+                          "endTokenPos": 27,
+                          "endFilePos": 57
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 27,
+                            "startFilePos": 53,
+                            "endLine": 3,
+                            "endTokenPos": 27,
+                            "endFilePos": 57
+                          },
+                          "name": "data"
+                        },
+                        "byRef": false
+                      }
+                    ],
+                    "returnType": null,
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 32,
+                          "startFilePos": 64,
+                          "endLine": 4,
+                          "endTokenPos": 38,
+                          "endFilePos": 76
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 32,
+                            "startFilePos": 64,
+                            "endLine": 4,
+                            "endTokenPos": 37,
+                            "endFilePos": 75
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 32,
+                              "startFilePos": 64,
+                              "endLine": 4,
+                              "endTokenPos": 32,
+                              "endFilePos": 70
+                            },
+                            "name": "result"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 36,
+                              "startFilePos": 74,
+                              "endLine": 4,
+                              "endTokenPos": 37,
+                              "endFilePos": 75,
+                              "kind": 2
+                            },
+                            "items": []
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Foreach",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 40,
+                          "startFilePos": 80,
+                          "endLine": 9,
+                          "endTokenPos": 75,
+                          "endFilePos": 153
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 43,
+                            "startFilePos": 89,
+                            "endLine": 5,
+                            "endTokenPos": 43,
+                            "endFilePos": 93
+                          },
+                          "name": "data"
+                        },
+                        "keyVar": null,
+                        "byRef": false,
+                        "valueVar": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 47,
+                            "startFilePos": 98,
+                            "endLine": 5,
+                            "endTokenPos": 47,
+                            "endFilePos": 99
+                          },
+                          "name": "x"
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_If",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 52,
+                              "startFilePos": 108,
+                              "endLine": 8,
+                              "endTokenPos": 73,
+                              "endFilePos": 149
+                            },
+                            "cond": {
+                              "nodeType": "Expr_BinaryOp_Equal",
+                              "attributes": {
+                                "startLine": 6,
+                                "startTokenPos": 55,
+                                "startFilePos": 112,
+                                "endLine": 6,
+                                "endTokenPos": 59,
+                                "endFilePos": 118
+                              },
+                              "left": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 55,
+                                  "startFilePos": 112,
+                                  "endLine": 6,
+                                  "endTokenPos": 55,
+                                  "endFilePos": 113
+                                },
+                                "name": "x"
+                              },
+                              "right": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 59,
+                                  "startFilePos": 118,
+                                  "endLine": 6,
+                                  "endTokenPos": 59,
+                                  "endFilePos": 118,
+                                  "rawValue": "1",
+                                  "kind": 10
+                                },
+                                "value": 1
+                              }
+                            },
+                            "stmts": [
+                              {
+                                "nodeType": "Stmt_Expression",
+                                "attributes": {
+                                  "startLine": 7,
+                                  "startTokenPos": 64,
+                                  "startFilePos": 129,
+                                  "endLine": 7,
+                                  "endTokenPos": 71,
+                                  "endFilePos": 143
+                                },
+                                "expr": {
+                                  "nodeType": "Expr_Assign",
+                                  "attributes": {
+                                    "startLine": 7,
+                                    "startTokenPos": 64,
+                                    "startFilePos": 129,
+                                    "endLine": 7,
+                                    "endTokenPos": 70,
+                                    "endFilePos": 142
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 7,
+                                      "startTokenPos": 64,
+                                      "startFilePos": 129,
+                                      "endLine": 7,
+                                      "endTokenPos": 66,
+                                      "endFilePos": 137
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 7,
+                                        "startTokenPos": 64,
+                                        "startFilePos": 129,
+                                        "endLine": 7,
+                                        "endTokenPos": 64,
+                                        "endFilePos": 135
+                                      },
+                                      "name": "result"
+                                    },
+                                    "dim": null
+                                  },
+                                  "expr": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 7,
+                                      "startTokenPos": 70,
+                                      "startFilePos": 141,
+                                      "endLine": 7,
+                                      "endTokenPos": 70,
+                                      "endFilePos": 142
+                                    },
+                                    "name": "x"
+                                  }
+                                }
+                              }
+                            ],
+                            "elseifs": [],
+                            "else": null
+                          }
+                        ]
+                      },
+                      {
+                        "nodeType": "Stmt_Return",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 77,
+                          "startFilePos": 157,
+                          "endLine": 10,
+                          "endTokenPos": 80,
+                          "endFilePos": 171
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 79,
+                            "startFilePos": 164,
+                            "endLine": 10,
+                            "endTokenPos": 79,
+                            "endFilePos": 170
+                          },
+                          "name": "result"
+                        }
+                      }
+                    ],
+                    "attrGroups": []
+                  },
+                  "args": []
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "right": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 90,
+              "startFilePos": 181,
+              "endLine": 11,
+              "endTokenPos": 90,
+              "endFilePos": 181,
+              "rawValue": "0",
+              "kind": 10
+            },
+            "value": 0
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 12,
+        "startTokenPos": 93,
+        "startFilePos": 184,
+        "endLine": 12,
+        "endTokenPos": 109,
+        "endFilePos": 224
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 96,
+            "startFilePos": 190,
+            "endLine": 12,
+            "endTokenPos": 104,
+            "endFilePos": 213
+          },
+          "cond": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 96,
+              "startFilePos": 190,
+              "endLine": 12,
+              "endTokenPos": 96,
+              "endFilePos": 194
+            },
+            "name": "flag"
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 100,
+              "startFilePos": 198,
+              "endLine": 12,
+              "endTokenPos": 100,
+              "endFilePos": 203,
+              "kind": 2,
+              "rawValue": "\"true\""
+            },
+            "value": "true"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 104,
+              "startFilePos": 207,
+              "endLine": 12,
+              "endTokenPos": 104,
+              "endFilePos": 213,
+              "kind": 2,
+              "rawValue": "\"false\""
+            },
+            "value": "false"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 108,
+            "startFilePos": 217,
+            "endLine": 12,
+            "endTokenPos": 108,
+            "endFilePos": 223
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 108,
+              "startFilePos": 217,
+              "endLine": 12,
+              "endTokenPos": 108,
+              "endFilePos": 223
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/for_list_collection.php.json
+++ b/tests/json-ast/x/php/for_list_collection.php.json
@@ -1,0 +1,318 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 48,
+        "endFilePos": 95
+      },
+      "expr": {
+        "nodeType": "Expr_Array",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 4,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 12,
+          "endFilePos": 23,
+          "kind": 2
+        },
+        "items": [
+          {
+            "nodeType": "ArrayItem",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 16,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 16
+            },
+            "key": null,
+            "value": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 5,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 5,
+                "endFilePos": 16,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            },
+            "byRef": false,
+            "unpack": false
+          },
+          {
+            "nodeType": "ArrayItem",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 19,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 19
+            },
+            "key": null,
+            "value": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 8,
+                "startFilePos": 19,
+                "endLine": 2,
+                "endTokenPos": 8,
+                "endFilePos": 19,
+                "rawValue": "2",
+                "kind": 10
+              },
+              "value": 2
+            },
+            "byRef": false,
+            "unpack": false
+          },
+          {
+            "nodeType": "ArrayItem",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 11,
+              "startFilePos": 22,
+              "endLine": 2,
+              "endTokenPos": 11,
+              "endFilePos": 22
+            },
+            "key": null,
+            "value": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 11,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 11,
+                "endFilePos": 22,
+                "rawValue": "3",
+                "kind": 10
+              },
+              "value": 3
+            },
+            "byRef": false,
+            "unpack": false
+          }
+        ]
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 16,
+          "startFilePos": 28,
+          "endLine": 2,
+          "endTokenPos": 16,
+          "endFilePos": 29
+        },
+        "name": "n"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 21,
+            "startFilePos": 36,
+            "endLine": 3,
+            "endTokenPos": 46,
+            "endFilePos": 93
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_Ternary",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 24,
+                "startFilePos": 42,
+                "endLine": 3,
+                "endTokenPos": 41,
+                "endFilePos": 82
+              },
+              "cond": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 24,
+                  "startFilePos": 42,
+                  "endLine": 3,
+                  "endTokenPos": 27,
+                  "endFilePos": 53
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 24,
+                    "startFilePos": 42,
+                    "endLine": 3,
+                    "endTokenPos": 24,
+                    "endFilePos": 49
+                  },
+                  "name": "is_float"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 26,
+                      "startFilePos": 51,
+                      "endLine": 3,
+                      "endTokenPos": 26,
+                      "endFilePos": 52
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 26,
+                        "startFilePos": 51,
+                        "endLine": 3,
+                        "endTokenPos": 26,
+                        "endFilePos": 52
+                      },
+                      "name": "n"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "if": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 31,
+                  "startFilePos": 57,
+                  "endLine": 3,
+                  "endTokenPos": 37,
+                  "endFilePos": 77
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 31,
+                    "startFilePos": 57,
+                    "endLine": 3,
+                    "endTokenPos": 31,
+                    "endFilePos": 67
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 33,
+                      "startFilePos": 69,
+                      "endLine": 3,
+                      "endTokenPos": 33,
+                      "endFilePos": 70
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 33,
+                        "startFilePos": 69,
+                        "endLine": 3,
+                        "endTokenPos": 33,
+                        "endFilePos": 70
+                      },
+                      "name": "n"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 73,
+                      "endLine": 3,
+                      "endTokenPos": 36,
+                      "endFilePos": 76
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 36,
+                        "startFilePos": 73,
+                        "endLine": 3,
+                        "endTokenPos": 36,
+                        "endFilePos": 76,
+                        "rawValue": "1344",
+                        "kind": 10
+                      },
+                      "value": 1344
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "else": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 41,
+                  "startFilePos": 81,
+                  "endLine": 3,
+                  "endTokenPos": 41,
+                  "endFilePos": 82
+                },
+                "name": "n"
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 45,
+                "startFilePos": 86,
+                "endLine": 3,
+                "endTokenPos": 45,
+                "endFilePos": 92
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 45,
+                  "startFilePos": 86,
+                  "endLine": 3,
+                  "endTokenPos": 45,
+                  "endFilePos": 92
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/for_loop.php.json
+++ b/tests/json-ast/x/php/for_loop.php.json
@@ -1,0 +1,309 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_For",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 51,
+        "endFilePos": 96
+      },
+      "init": [
+        {
+          "nodeType": "Expr_Assign",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 16
+          },
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 11,
+              "endLine": 2,
+              "endTokenPos": 4,
+              "endFilePos": 12
+            },
+            "name": "i"
+          },
+          "expr": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 16,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 16,
+              "rawValue": "1",
+              "kind": 10
+            },
+            "value": 1
+          }
+        }
+      ],
+      "cond": [
+        {
+          "nodeType": "Expr_BinaryOp_Smaller",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 11,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 15,
+            "endFilePos": 24
+          },
+          "left": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 11,
+              "startFilePos": 19,
+              "endLine": 2,
+              "endTokenPos": 11,
+              "endFilePos": 20
+            },
+            "name": "i"
+          },
+          "right": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 15,
+              "startFilePos": 24,
+              "endLine": 2,
+              "endTokenPos": 15,
+              "endFilePos": 24,
+              "rawValue": "4",
+              "kind": 10
+            },
+            "value": 4
+          }
+        }
+      ],
+      "loop": [
+        {
+          "nodeType": "Expr_PostInc",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 18,
+            "startFilePos": 27,
+            "endLine": 2,
+            "endTokenPos": 19,
+            "endFilePos": 30
+          },
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 18,
+              "startFilePos": 27,
+              "endLine": 2,
+              "endTokenPos": 18,
+              "endFilePos": 28
+            },
+            "name": "i"
+          }
+        }
+      ],
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 24,
+            "startFilePos": 37,
+            "endLine": 3,
+            "endTokenPos": 49,
+            "endFilePos": 94
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_Ternary",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 27,
+                "startFilePos": 43,
+                "endLine": 3,
+                "endTokenPos": 44,
+                "endFilePos": 83
+              },
+              "cond": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 27,
+                  "startFilePos": 43,
+                  "endLine": 3,
+                  "endTokenPos": 30,
+                  "endFilePos": 54
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 27,
+                    "startFilePos": 43,
+                    "endLine": 3,
+                    "endTokenPos": 27,
+                    "endFilePos": 50
+                  },
+                  "name": "is_float"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 29,
+                      "startFilePos": 52,
+                      "endLine": 3,
+                      "endTokenPos": 29,
+                      "endFilePos": 53
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 29,
+                        "startFilePos": 52,
+                        "endLine": 3,
+                        "endTokenPos": 29,
+                        "endFilePos": 53
+                      },
+                      "name": "i"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "if": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 34,
+                  "startFilePos": 58,
+                  "endLine": 3,
+                  "endTokenPos": 40,
+                  "endFilePos": 78
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 34,
+                    "startFilePos": 58,
+                    "endLine": 3,
+                    "endTokenPos": 34,
+                    "endFilePos": 68
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 70,
+                      "endLine": 3,
+                      "endTokenPos": 36,
+                      "endFilePos": 71
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 36,
+                        "startFilePos": 70,
+                        "endLine": 3,
+                        "endTokenPos": 36,
+                        "endFilePos": 71
+                      },
+                      "name": "i"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 39,
+                      "startFilePos": 74,
+                      "endLine": 3,
+                      "endTokenPos": 39,
+                      "endFilePos": 77
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 39,
+                        "startFilePos": 74,
+                        "endLine": 3,
+                        "endTokenPos": 39,
+                        "endFilePos": 77,
+                        "rawValue": "1344",
+                        "kind": 10
+                      },
+                      "value": 1344
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "else": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 82,
+                  "endLine": 3,
+                  "endTokenPos": 44,
+                  "endFilePos": 83
+                },
+                "name": "i"
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 48,
+                "startFilePos": 87,
+                "endLine": 3,
+                "endTokenPos": 48,
+                "endFilePos": 93
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 48,
+                  "startFilePos": 87,
+                  "endLine": 3,
+                  "endTokenPos": 48,
+                  "endFilePos": 93
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/for_map_collection.php.json
+++ b/tests/json-ast/x/php/for_map_collection.php.json
@@ -1,0 +1,401 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 19,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 18,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 18,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 14,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 24,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 29,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 21,
+        "startFilePos": 33,
+        "endLine": 5,
+        "endTokenPos": 63,
+        "endFilePos": 127
+      },
+      "expr": {
+        "nodeType": "Expr_FuncCall",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 24,
+          "startFilePos": 42,
+          "endLine": 3,
+          "endTokenPos": 27,
+          "endFilePos": 55
+        },
+        "name": {
+          "nodeType": "Name",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 24,
+            "startFilePos": 42,
+            "endLine": 3,
+            "endTokenPos": 24,
+            "endFilePos": 51
+          },
+          "name": "array_keys"
+        },
+        "args": [
+          {
+            "nodeType": "Arg",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 26,
+              "startFilePos": 53,
+              "endLine": 3,
+              "endTokenPos": 26,
+              "endFilePos": 54
+            },
+            "name": null,
+            "value": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 26,
+                "startFilePos": 53,
+                "endLine": 3,
+                "endTokenPos": 26,
+                "endFilePos": 54
+              },
+              "name": "m"
+            },
+            "byRef": false,
+            "unpack": false
+          }
+        ]
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 31,
+          "startFilePos": 60,
+          "endLine": 3,
+          "endTokenPos": 31,
+          "endFilePos": 61
+        },
+        "name": "k"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 36,
+            "startFilePos": 68,
+            "endLine": 4,
+            "endTokenPos": 61,
+            "endFilePos": 125
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_Ternary",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 39,
+                "startFilePos": 74,
+                "endLine": 4,
+                "endTokenPos": 56,
+                "endFilePos": 114
+              },
+              "cond": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 39,
+                  "startFilePos": 74,
+                  "endLine": 4,
+                  "endTokenPos": 42,
+                  "endFilePos": 85
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 39,
+                    "startFilePos": 74,
+                    "endLine": 4,
+                    "endTokenPos": 39,
+                    "endFilePos": 81
+                  },
+                  "name": "is_float"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 41,
+                      "startFilePos": 83,
+                      "endLine": 4,
+                      "endTokenPos": 41,
+                      "endFilePos": 84
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 41,
+                        "startFilePos": 83,
+                        "endLine": 4,
+                        "endTokenPos": 41,
+                        "endFilePos": 84
+                      },
+                      "name": "k"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "if": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 46,
+                  "startFilePos": 89,
+                  "endLine": 4,
+                  "endTokenPos": 52,
+                  "endFilePos": 109
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 46,
+                    "startFilePos": 89,
+                    "endLine": 4,
+                    "endTokenPos": 46,
+                    "endFilePos": 99
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 48,
+                      "startFilePos": 101,
+                      "endLine": 4,
+                      "endTokenPos": 48,
+                      "endFilePos": 102
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 48,
+                        "startFilePos": 101,
+                        "endLine": 4,
+                        "endTokenPos": 48,
+                        "endFilePos": 102
+                      },
+                      "name": "k"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 51,
+                      "startFilePos": 105,
+                      "endLine": 4,
+                      "endTokenPos": 51,
+                      "endFilePos": 108
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 51,
+                        "startFilePos": 105,
+                        "endLine": 4,
+                        "endTokenPos": 51,
+                        "endFilePos": 108,
+                        "rawValue": "1344",
+                        "kind": 10
+                      },
+                      "value": 1344
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "else": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 56,
+                  "startFilePos": 113,
+                  "endLine": 4,
+                  "endTokenPos": 56,
+                  "endFilePos": 114
+                },
+                "name": "k"
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 60,
+                "startFilePos": 118,
+                "endLine": 4,
+                "endTokenPos": 60,
+                "endFilePos": 124
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 60,
+                  "startFilePos": 118,
+                  "endLine": 4,
+                  "endTokenPos": 60,
+                  "endFilePos": 124
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/fun_call.php.json
+++ b/tests/json-ast/x/php/fun_call.php.json
@@ -1,0 +1,536 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 22,
+        "endFilePos": 47
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 17
+        },
+        "name": "add"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 20
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 19,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 20
+            },
+            "name": "a"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 8,
+            "startFilePos": 23,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 24
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 23,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 24
+            },
+            "name": "b"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 31,
+            "endLine": 3,
+            "endTokenPos": 20,
+            "endFilePos": 45
+          },
+          "expr": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 15,
+              "startFilePos": 38,
+              "endLine": 3,
+              "endTokenPos": 19,
+              "endFilePos": 44
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 15,
+                "startFilePos": 38,
+                "endLine": 3,
+                "endTokenPos": 15,
+                "endFilePos": 39
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 19,
+                "startFilePos": 43,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 44
+              },
+              "name": "b"
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 24,
+        "startFilePos": 49,
+        "endLine": 5,
+        "endTokenPos": 67,
+        "endFilePos": 127
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 27,
+            "startFilePos": 55,
+            "endLine": 5,
+            "endTokenPos": 62,
+            "endFilePos": 116
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 27,
+              "startFilePos": 55,
+              "endLine": 5,
+              "endTokenPos": 36,
+              "endFilePos": 73
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 27,
+                "startFilePos": 55,
+                "endLine": 5,
+                "endTokenPos": 27,
+                "endFilePos": 62
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 29,
+                  "startFilePos": 64,
+                  "endLine": 5,
+                  "endTokenPos": 35,
+                  "endFilePos": 72
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 29,
+                    "startFilePos": 64,
+                    "endLine": 5,
+                    "endTokenPos": 35,
+                    "endFilePos": 72
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 29,
+                      "startFilePos": 64,
+                      "endLine": 5,
+                      "endTokenPos": 29,
+                      "endFilePos": 66
+                    },
+                    "name": "add"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 31,
+                        "startFilePos": 68,
+                        "endLine": 5,
+                        "endTokenPos": 31,
+                        "endFilePos": 68
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 31,
+                          "startFilePos": 68,
+                          "endLine": 5,
+                          "endTokenPos": 31,
+                          "endFilePos": 68,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 34,
+                        "startFilePos": 71,
+                        "endLine": 5,
+                        "endTokenPos": 34,
+                        "endFilePos": 71
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 34,
+                          "startFilePos": 71,
+                          "endLine": 5,
+                          "endTokenPos": 34,
+                          "endFilePos": 71,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 40,
+              "startFilePos": 77,
+              "endLine": 5,
+              "endTokenPos": 52,
+              "endFilePos": 104
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 40,
+                "startFilePos": 77,
+                "endLine": 5,
+                "endTokenPos": 40,
+                "endFilePos": 87
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 42,
+                  "startFilePos": 89,
+                  "endLine": 5,
+                  "endTokenPos": 48,
+                  "endFilePos": 97
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 42,
+                    "startFilePos": 89,
+                    "endLine": 5,
+                    "endTokenPos": 48,
+                    "endFilePos": 97
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 42,
+                      "startFilePos": 89,
+                      "endLine": 5,
+                      "endTokenPos": 42,
+                      "endFilePos": 91
+                    },
+                    "name": "add"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 44,
+                        "startFilePos": 93,
+                        "endLine": 5,
+                        "endTokenPos": 44,
+                        "endFilePos": 93
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 44,
+                          "startFilePos": 93,
+                          "endLine": 5,
+                          "endTokenPos": 44,
+                          "endFilePos": 93,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 47,
+                        "startFilePos": 96,
+                        "endLine": 5,
+                        "endTokenPos": 47,
+                        "endFilePos": 96
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 47,
+                          "startFilePos": 96,
+                          "endLine": 5,
+                          "endTokenPos": 47,
+                          "endFilePos": 96,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 51,
+                  "startFilePos": 100,
+                  "endLine": 5,
+                  "endTokenPos": 51,
+                  "endFilePos": 103
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 51,
+                    "startFilePos": 100,
+                    "endLine": 5,
+                    "endTokenPos": 51,
+                    "endFilePos": 103,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 56,
+              "startFilePos": 108,
+              "endLine": 5,
+              "endTokenPos": 62,
+              "endFilePos": 116
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 56,
+                "startFilePos": 108,
+                "endLine": 5,
+                "endTokenPos": 56,
+                "endFilePos": 110
+              },
+              "name": "add"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 58,
+                  "startFilePos": 112,
+                  "endLine": 5,
+                  "endTokenPos": 58,
+                  "endFilePos": 112
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 58,
+                    "startFilePos": 112,
+                    "endLine": 5,
+                    "endTokenPos": 58,
+                    "endFilePos": 112,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 61,
+                  "startFilePos": 115,
+                  "endLine": 5,
+                  "endTokenPos": 61,
+                  "endFilePos": 115
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 61,
+                    "startFilePos": 115,
+                    "endLine": 5,
+                    "endTokenPos": 61,
+                    "endFilePos": 115,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 66,
+            "startFilePos": 120,
+            "endLine": 5,
+            "endTokenPos": 66,
+            "endFilePos": 126
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 66,
+              "startFilePos": 120,
+              "endLine": 5,
+              "endTokenPos": 66,
+              "endFilePos": 126
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/fun_expr_in_let.php.json
+++ b/tests/json-ast/x/php/fun_expr_in_let.php.json
@@ -1,0 +1,446 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 22,
+        "endFilePos": 50
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 4,
+          "endTokenPos": 21,
+          "endFilePos": 49
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "square"
+        },
+        "expr": {
+          "nodeType": "Expr_Closure",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 4,
+            "endTokenPos": 21,
+            "endFilePos": 49
+          },
+          "static": false,
+          "byRef": false,
+          "params": [
+            {
+              "nodeType": "Param",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 7,
+                "startFilePos": 25,
+                "endLine": 2,
+                "endTokenPos": 7,
+                "endFilePos": 26
+              },
+              "type": null,
+              "byRef": false,
+              "variadic": false,
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 7,
+                  "startFilePos": 25,
+                  "endLine": 2,
+                  "endTokenPos": 7,
+                  "endFilePos": 26
+                },
+                "name": "x"
+              },
+              "default": null,
+              "flags": 0,
+              "attrGroups": [],
+              "hooks": []
+            }
+          ],
+          "uses": [],
+          "returnType": null,
+          "stmts": [
+            {
+              "nodeType": "Stmt_Return",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 12,
+                "startFilePos": 33,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 47
+              },
+              "expr": {
+                "nodeType": "Expr_BinaryOp_Mul",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 14,
+                  "startFilePos": 40,
+                  "endLine": 3,
+                  "endTokenPos": 18,
+                  "endFilePos": 46
+                },
+                "left": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 14,
+                    "startFilePos": 40,
+                    "endLine": 3,
+                    "endTokenPos": 14,
+                    "endFilePos": 41
+                  },
+                  "name": "x"
+                },
+                "right": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 18,
+                    "startFilePos": 45,
+                    "endLine": 3,
+                    "endTokenPos": 18,
+                    "endFilePos": 46
+                  },
+                  "name": "x"
+                }
+              }
+            }
+          ],
+          "attrGroups": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 24,
+        "startFilePos": 52,
+        "endLine": 5,
+        "endTokenPos": 58,
+        "endFilePos": 133
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 27,
+            "startFilePos": 58,
+            "endLine": 5,
+            "endTokenPos": 53,
+            "endFilePos": 122
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 27,
+              "startFilePos": 58,
+              "endLine": 5,
+              "endTokenPos": 33,
+              "endFilePos": 77
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 27,
+                "startFilePos": 58,
+                "endLine": 5,
+                "endTokenPos": 27,
+                "endFilePos": 65
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 29,
+                  "startFilePos": 67,
+                  "endLine": 5,
+                  "endTokenPos": 32,
+                  "endFilePos": 76
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 29,
+                    "startFilePos": 67,
+                    "endLine": 5,
+                    "endTokenPos": 32,
+                    "endFilePos": 76
+                  },
+                  "name": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 29,
+                      "startFilePos": 67,
+                      "endLine": 5,
+                      "endTokenPos": 29,
+                      "endFilePos": 73
+                    },
+                    "name": "square"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 31,
+                        "startFilePos": 75,
+                        "endLine": 5,
+                        "endTokenPos": 31,
+                        "endFilePos": 75
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 31,
+                          "startFilePos": 75,
+                          "endLine": 5,
+                          "endTokenPos": 31,
+                          "endFilePos": 75,
+                          "rawValue": "6",
+                          "kind": 10
+                        },
+                        "value": 6
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 37,
+              "startFilePos": 81,
+              "endLine": 5,
+              "endTokenPos": 46,
+              "endFilePos": 109
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 37,
+                "startFilePos": 81,
+                "endLine": 5,
+                "endTokenPos": 37,
+                "endFilePos": 91
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 39,
+                  "startFilePos": 93,
+                  "endLine": 5,
+                  "endTokenPos": 42,
+                  "endFilePos": 102
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 39,
+                    "startFilePos": 93,
+                    "endLine": 5,
+                    "endTokenPos": 42,
+                    "endFilePos": 102
+                  },
+                  "name": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 39,
+                      "startFilePos": 93,
+                      "endLine": 5,
+                      "endTokenPos": 39,
+                      "endFilePos": 99
+                    },
+                    "name": "square"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 41,
+                        "startFilePos": 101,
+                        "endLine": 5,
+                        "endTokenPos": 41,
+                        "endFilePos": 101
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 41,
+                          "startFilePos": 101,
+                          "endLine": 5,
+                          "endTokenPos": 41,
+                          "endFilePos": 101,
+                          "rawValue": "6",
+                          "kind": 10
+                        },
+                        "value": 6
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 45,
+                  "startFilePos": 105,
+                  "endLine": 5,
+                  "endTokenPos": 45,
+                  "endFilePos": 108
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 45,
+                    "startFilePos": 105,
+                    "endLine": 5,
+                    "endTokenPos": 45,
+                    "endFilePos": 108,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 50,
+              "startFilePos": 113,
+              "endLine": 5,
+              "endTokenPos": 53,
+              "endFilePos": 122
+            },
+            "name": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 50,
+                "startFilePos": 113,
+                "endLine": 5,
+                "endTokenPos": 50,
+                "endFilePos": 119
+              },
+              "name": "square"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 52,
+                  "startFilePos": 121,
+                  "endLine": 5,
+                  "endTokenPos": 52,
+                  "endFilePos": 121
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 52,
+                    "startFilePos": 121,
+                    "endLine": 5,
+                    "endTokenPos": 52,
+                    "endFilePos": 121,
+                    "rawValue": "6",
+                    "kind": 10
+                  },
+                  "value": 6
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 57,
+            "startFilePos": 126,
+            "endLine": 5,
+            "endTokenPos": 57,
+            "endFilePos": 132
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 57,
+              "startFilePos": 126,
+              "endLine": 5,
+              "endTokenPos": 57,
+              "endFilePos": 132
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/fun_three_args.php.json
+++ b/tests/json-ast/x/php/fun_three_args.php.json
@@ -1,0 +1,673 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 29,
+        "endFilePos": 57
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 18
+        },
+        "name": "sum3"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 20,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 21
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 20,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 21
+            },
+            "name": "a"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 8,
+            "startFilePos": 24,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 25
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 24,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 25
+            },
+            "name": "b"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 11,
+            "startFilePos": 28,
+            "endLine": 2,
+            "endTokenPos": 11,
+            "endFilePos": 29
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 11,
+              "startFilePos": 28,
+              "endLine": 2,
+              "endTokenPos": 11,
+              "endFilePos": 29
+            },
+            "name": "c"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 16,
+            "startFilePos": 36,
+            "endLine": 3,
+            "endTokenPos": 27,
+            "endFilePos": 55
+          },
+          "expr": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 18,
+              "startFilePos": 43,
+              "endLine": 3,
+              "endTokenPos": 26,
+              "endFilePos": 54
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_Plus",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 18,
+                "startFilePos": 43,
+                "endLine": 3,
+                "endTokenPos": 22,
+                "endFilePos": 49
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 18,
+                  "startFilePos": 43,
+                  "endLine": 3,
+                  "endTokenPos": 18,
+                  "endFilePos": 44
+                },
+                "name": "a"
+              },
+              "right": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 22,
+                  "startFilePos": 48,
+                  "endLine": 3,
+                  "endTokenPos": 22,
+                  "endFilePos": 49
+                },
+                "name": "b"
+              }
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 26,
+                "startFilePos": 53,
+                "endLine": 3,
+                "endTokenPos": 26,
+                "endFilePos": 54
+              },
+              "name": "c"
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 31,
+        "startFilePos": 59,
+        "endLine": 5,
+        "endTokenPos": 83,
+        "endFilePos": 149
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 34,
+            "startFilePos": 65,
+            "endLine": 5,
+            "endTokenPos": 78,
+            "endFilePos": 138
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 34,
+              "startFilePos": 65,
+              "endLine": 5,
+              "endTokenPos": 46,
+              "endFilePos": 87
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 34,
+                "startFilePos": 65,
+                "endLine": 5,
+                "endTokenPos": 34,
+                "endFilePos": 72
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 36,
+                  "startFilePos": 74,
+                  "endLine": 5,
+                  "endTokenPos": 45,
+                  "endFilePos": 86
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 36,
+                    "startFilePos": 74,
+                    "endLine": 5,
+                    "endTokenPos": 45,
+                    "endFilePos": 86
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 36,
+                      "startFilePos": 74,
+                      "endLine": 5,
+                      "endTokenPos": 36,
+                      "endFilePos": 77
+                    },
+                    "name": "sum3"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 38,
+                        "startFilePos": 79,
+                        "endLine": 5,
+                        "endTokenPos": 38,
+                        "endFilePos": 79
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 38,
+                          "startFilePos": 79,
+                          "endLine": 5,
+                          "endTokenPos": 38,
+                          "endFilePos": 79,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 41,
+                        "startFilePos": 82,
+                        "endLine": 5,
+                        "endTokenPos": 41,
+                        "endFilePos": 82
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 41,
+                          "startFilePos": 82,
+                          "endLine": 5,
+                          "endTokenPos": 41,
+                          "endFilePos": 82,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 44,
+                        "startFilePos": 85,
+                        "endLine": 5,
+                        "endTokenPos": 44,
+                        "endFilePos": 85
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 44,
+                          "startFilePos": 85,
+                          "endLine": 5,
+                          "endTokenPos": 44,
+                          "endFilePos": 85,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 50,
+              "startFilePos": 91,
+              "endLine": 5,
+              "endTokenPos": 65,
+              "endFilePos": 122
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 50,
+                "startFilePos": 91,
+                "endLine": 5,
+                "endTokenPos": 50,
+                "endFilePos": 101
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 52,
+                  "startFilePos": 103,
+                  "endLine": 5,
+                  "endTokenPos": 61,
+                  "endFilePos": 115
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 52,
+                    "startFilePos": 103,
+                    "endLine": 5,
+                    "endTokenPos": 61,
+                    "endFilePos": 115
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 52,
+                      "startFilePos": 103,
+                      "endLine": 5,
+                      "endTokenPos": 52,
+                      "endFilePos": 106
+                    },
+                    "name": "sum3"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 54,
+                        "startFilePos": 108,
+                        "endLine": 5,
+                        "endTokenPos": 54,
+                        "endFilePos": 108
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 54,
+                          "startFilePos": 108,
+                          "endLine": 5,
+                          "endTokenPos": 54,
+                          "endFilePos": 108,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 57,
+                        "startFilePos": 111,
+                        "endLine": 5,
+                        "endTokenPos": 57,
+                        "endFilePos": 111
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 57,
+                          "startFilePos": 111,
+                          "endLine": 5,
+                          "endTokenPos": 57,
+                          "endFilePos": 111,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 60,
+                        "startFilePos": 114,
+                        "endLine": 5,
+                        "endTokenPos": 60,
+                        "endFilePos": 114
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 60,
+                          "startFilePos": 114,
+                          "endLine": 5,
+                          "endTokenPos": 60,
+                          "endFilePos": 114,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 64,
+                  "startFilePos": 118,
+                  "endLine": 5,
+                  "endTokenPos": 64,
+                  "endFilePos": 121
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 64,
+                    "startFilePos": 118,
+                    "endLine": 5,
+                    "endTokenPos": 64,
+                    "endFilePos": 121,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 69,
+              "startFilePos": 126,
+              "endLine": 5,
+              "endTokenPos": 78,
+              "endFilePos": 138
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 69,
+                "startFilePos": 126,
+                "endLine": 5,
+                "endTokenPos": 69,
+                "endFilePos": 129
+              },
+              "name": "sum3"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 71,
+                  "startFilePos": 131,
+                  "endLine": 5,
+                  "endTokenPos": 71,
+                  "endFilePos": 131
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 71,
+                    "startFilePos": 131,
+                    "endLine": 5,
+                    "endTokenPos": 71,
+                    "endFilePos": 131,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 74,
+                  "startFilePos": 134,
+                  "endLine": 5,
+                  "endTokenPos": 74,
+                  "endFilePos": 134
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 74,
+                    "startFilePos": 134,
+                    "endLine": 5,
+                    "endTokenPos": 74,
+                    "endFilePos": 134,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 77,
+                  "startFilePos": 137,
+                  "endLine": 5,
+                  "endTokenPos": 77,
+                  "endFilePos": 137
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 77,
+                    "startFilePos": 137,
+                    "endLine": 5,
+                    "endTokenPos": 77,
+                    "endFilePos": 137,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 82,
+            "startFilePos": 142,
+            "endLine": 5,
+            "endTokenPos": 82,
+            "endFilePos": 148
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 82,
+              "startFilePos": 142,
+              "endLine": 5,
+              "endTokenPos": 82,
+              "endFilePos": 148
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/go_auto.php.json
+++ b/tests/json-ast/x/php/go_auto.php.json
@@ -1,0 +1,1356 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 6,
+        "endTokenPos": 63,
+        "endFilePos": 231
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 6,
+          "endTokenPos": 62,
+          "endFilePos": 230
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 13
+          },
+          "name": "testpkg"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 17,
+            "endLine": 6,
+            "endTokenPos": 62,
+            "endFilePos": 230,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 18,
+                "endLine": 4,
+                "endTokenPos": 29,
+                "endFilePos": 64
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 22,
+                  "kind": 2,
+                  "rawValue": "\"Add\""
+                },
+                "value": "Add"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 27,
+                  "endLine": 4,
+                  "endTokenPos": 29,
+                  "endFilePos": 64
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 12,
+                      "startFilePos": 36,
+                      "endLine": 2,
+                      "endTokenPos": 12,
+                      "endFilePos": 37
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 12,
+                        "startFilePos": 36,
+                        "endLine": 2,
+                        "endTokenPos": 12,
+                        "endFilePos": 37
+                      },
+                      "name": "a"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  },
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 15,
+                      "startFilePos": 40,
+                      "endLine": 2,
+                      "endTokenPos": 15,
+                      "endFilePos": 41
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 15,
+                        "startFilePos": 40,
+                        "endLine": 2,
+                        "endTokenPos": 15,
+                        "endFilePos": 41
+                      },
+                      "name": "b"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 20,
+                      "startFilePos": 48,
+                      "endLine": 3,
+                      "endTokenPos": 27,
+                      "endFilePos": 62
+                    },
+                    "expr": {
+                      "nodeType": "Expr_BinaryOp_Plus",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 22,
+                        "startFilePos": 55,
+                        "endLine": 3,
+                        "endTokenPos": 26,
+                        "endFilePos": 61
+                      },
+                      "left": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 22,
+                          "startFilePos": 55,
+                          "endLine": 3,
+                          "endTokenPos": 22,
+                          "endFilePos": 56
+                        },
+                        "name": "a"
+                      },
+                      "right": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 26,
+                          "startFilePos": 60,
+                          "endLine": 3,
+                          "endTokenPos": 26,
+                          "endFilePos": 61
+                        },
+                        "name": "b"
+                      }
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 32,
+                "startFilePos": 67,
+                "endLine": 4,
+                "endTokenPos": 36,
+                "endFilePos": 78
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 32,
+                  "startFilePos": 67,
+                  "endLine": 4,
+                  "endTokenPos": 32,
+                  "endFilePos": 70,
+                  "kind": 2,
+                  "rawValue": "\"Pi\""
+                },
+                "value": "Pi"
+              },
+              "value": {
+                "nodeType": "Scalar_Float",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 36,
+                  "startFilePos": 75,
+                  "endLine": 4,
+                  "endTokenPos": 36,
+                  "endFilePos": 78,
+                  "rawValue": "3.14"
+                },
+                "value": 3.14
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 39,
+                "startFilePos": 81,
+                "endLine": 4,
+                "endTokenPos": 43,
+                "endFilePos": 94
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 39,
+                  "startFilePos": 81,
+                  "endLine": 4,
+                  "endTokenPos": 39,
+                  "endFilePos": 88,
+                  "kind": 2,
+                  "rawValue": "\"Answer\""
+                },
+                "value": "Answer"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 43,
+                  "startFilePos": 93,
+                  "endLine": 4,
+                  "endTokenPos": 43,
+                  "endFilePos": 94,
+                  "rawValue": "42",
+                  "kind": 10
+                },
+                "value": 42
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 46,
+                "startFilePos": 97,
+                "endLine": 6,
+                "endTokenPos": 61,
+                "endFilePos": 229
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 46,
+                  "startFilePos": 97,
+                  "endLine": 4,
+                  "endTokenPos": 46,
+                  "endFilePos": 118,
+                  "kind": 2,
+                  "rawValue": "\"FifteenPuzzleExample\""
+                },
+                "value": "FifteenPuzzleExample"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 50,
+                  "startFilePos": 123,
+                  "endLine": 6,
+                  "endTokenPos": 61,
+                  "endFilePos": 229
+                },
+                "static": false,
+                "byRef": false,
+                "params": [],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 56,
+                      "startFilePos": 138,
+                      "endLine": 5,
+                      "endTokenPos": 59,
+                      "endFilePos": 227
+                    },
+                    "expr": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 58,
+                        "startFilePos": 145,
+                        "endLine": 5,
+                        "endTokenPos": 58,
+                        "endFilePos": 226,
+                        "kind": 2,
+                        "rawValue": "\"Solution found in 52 moves: rrrulddluuuldrurdddrullulurrrddldluurddlulurruldrdrd\""
+                      },
+                      "value": "Solution found in 52 moves: rrrulddluuuldrurdddrullulurrrddldluurddlulurruldrdrd"
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 65,
+        "startFilePos": 233,
+        "endLine": 7,
+        "endTokenPos": 117,
+        "endFilePos": 347
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 68,
+            "startFilePos": 239,
+            "endLine": 7,
+            "endTokenPos": 112,
+            "endFilePos": 336
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 68,
+              "startFilePos": 239,
+              "endLine": 7,
+              "endTokenPos": 80,
+              "endFilePos": 269
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 68,
+                "startFilePos": 239,
+                "endLine": 7,
+                "endTokenPos": 68,
+                "endFilePos": 246
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 70,
+                  "startFilePos": 248,
+                  "endLine": 7,
+                  "endTokenPos": 79,
+                  "endFilePos": 268
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 70,
+                    "startFilePos": 248,
+                    "endLine": 7,
+                    "endTokenPos": 79,
+                    "endFilePos": 268
+                  },
+                  "name": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 70,
+                      "startFilePos": 248,
+                      "endLine": 7,
+                      "endTokenPos": 73,
+                      "endFilePos": 262
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 70,
+                        "startFilePos": 248,
+                        "endLine": 7,
+                        "endTokenPos": 70,
+                        "endFilePos": 255
+                      },
+                      "name": "testpkg"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 72,
+                        "startFilePos": 257,
+                        "endLine": 7,
+                        "endTokenPos": 72,
+                        "endFilePos": 261,
+                        "kind": 1,
+                        "rawValue": "'Add'"
+                      },
+                      "value": "Add"
+                    }
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 75,
+                        "startFilePos": 264,
+                        "endLine": 7,
+                        "endTokenPos": 75,
+                        "endFilePos": 264
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 75,
+                          "startFilePos": 264,
+                          "endLine": 7,
+                          "endTokenPos": 75,
+                          "endFilePos": 264,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 78,
+                        "startFilePos": 267,
+                        "endLine": 7,
+                        "endTokenPos": 78,
+                        "endFilePos": 267
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 78,
+                          "startFilePos": 267,
+                          "endLine": 7,
+                          "endTokenPos": 78,
+                          "endFilePos": 267,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 84,
+              "startFilePos": 273,
+              "endLine": 7,
+              "endTokenPos": 99,
+              "endFilePos": 312
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 84,
+                "startFilePos": 273,
+                "endLine": 7,
+                "endTokenPos": 84,
+                "endFilePos": 283
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 86,
+                  "startFilePos": 285,
+                  "endLine": 7,
+                  "endTokenPos": 95,
+                  "endFilePos": 305
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 86,
+                    "startFilePos": 285,
+                    "endLine": 7,
+                    "endTokenPos": 95,
+                    "endFilePos": 305
+                  },
+                  "name": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 86,
+                      "startFilePos": 285,
+                      "endLine": 7,
+                      "endTokenPos": 89,
+                      "endFilePos": 299
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 86,
+                        "startFilePos": 285,
+                        "endLine": 7,
+                        "endTokenPos": 86,
+                        "endFilePos": 292
+                      },
+                      "name": "testpkg"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 88,
+                        "startFilePos": 294,
+                        "endLine": 7,
+                        "endTokenPos": 88,
+                        "endFilePos": 298,
+                        "kind": 1,
+                        "rawValue": "'Add'"
+                      },
+                      "value": "Add"
+                    }
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 91,
+                        "startFilePos": 301,
+                        "endLine": 7,
+                        "endTokenPos": 91,
+                        "endFilePos": 301
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 91,
+                          "startFilePos": 301,
+                          "endLine": 7,
+                          "endTokenPos": 91,
+                          "endFilePos": 301,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 94,
+                        "startFilePos": 304,
+                        "endLine": 7,
+                        "endTokenPos": 94,
+                        "endFilePos": 304
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 94,
+                          "startFilePos": 304,
+                          "endLine": 7,
+                          "endTokenPos": 94,
+                          "endFilePos": 304,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 98,
+                  "startFilePos": 308,
+                  "endLine": 7,
+                  "endTokenPos": 98,
+                  "endFilePos": 311
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 98,
+                    "startFilePos": 308,
+                    "endLine": 7,
+                    "endTokenPos": 98,
+                    "endFilePos": 311,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 103,
+              "startFilePos": 316,
+              "endLine": 7,
+              "endTokenPos": 112,
+              "endFilePos": 336
+            },
+            "name": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 103,
+                "startFilePos": 316,
+                "endLine": 7,
+                "endTokenPos": 106,
+                "endFilePos": 330
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 103,
+                  "startFilePos": 316,
+                  "endLine": 7,
+                  "endTokenPos": 103,
+                  "endFilePos": 323
+                },
+                "name": "testpkg"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 105,
+                  "startFilePos": 325,
+                  "endLine": 7,
+                  "endTokenPos": 105,
+                  "endFilePos": 329,
+                  "kind": 1,
+                  "rawValue": "'Add'"
+                },
+                "value": "Add"
+              }
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 108,
+                  "startFilePos": 332,
+                  "endLine": 7,
+                  "endTokenPos": 108,
+                  "endFilePos": 332
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 108,
+                    "startFilePos": 332,
+                    "endLine": 7,
+                    "endTokenPos": 108,
+                    "endFilePos": 332,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 111,
+                  "startFilePos": 335,
+                  "endLine": 7,
+                  "endTokenPos": 111,
+                  "endFilePos": 335
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 111,
+                    "startFilePos": 335,
+                    "endLine": 7,
+                    "endTokenPos": 111,
+                    "endFilePos": 335,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 116,
+            "startFilePos": 340,
+            "endLine": 7,
+            "endTokenPos": 116,
+            "endFilePos": 346
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 116,
+              "startFilePos": 340,
+              "endLine": 7,
+              "endTokenPos": 116,
+              "endFilePos": 346
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 119,
+        "startFilePos": 349,
+        "endLine": 8,
+        "endTokenPos": 153,
+        "endFilePos": 442
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 122,
+            "startFilePos": 355,
+            "endLine": 8,
+            "endTokenPos": 148,
+            "endFilePos": 431
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 122,
+              "startFilePos": 355,
+              "endLine": 8,
+              "endTokenPos": 128,
+              "endFilePos": 378
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 122,
+                "startFilePos": 355,
+                "endLine": 8,
+                "endTokenPos": 122,
+                "endFilePos": 362
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 124,
+                  "startFilePos": 364,
+                  "endLine": 8,
+                  "endTokenPos": 127,
+                  "endFilePos": 377
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 124,
+                    "startFilePos": 364,
+                    "endLine": 8,
+                    "endTokenPos": 127,
+                    "endFilePos": 377
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 124,
+                      "startFilePos": 364,
+                      "endLine": 8,
+                      "endTokenPos": 124,
+                      "endFilePos": 371
+                    },
+                    "name": "testpkg"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 126,
+                      "startFilePos": 373,
+                      "endLine": 8,
+                      "endTokenPos": 126,
+                      "endFilePos": 376,
+                      "kind": 2,
+                      "rawValue": "\"Pi\""
+                    },
+                    "value": "Pi"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 132,
+              "startFilePos": 382,
+              "endLine": 8,
+              "endTokenPos": 141,
+              "endFilePos": 414
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 132,
+                "startFilePos": 382,
+                "endLine": 8,
+                "endTokenPos": 132,
+                "endFilePos": 392
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 134,
+                  "startFilePos": 394,
+                  "endLine": 8,
+                  "endTokenPos": 137,
+                  "endFilePos": 407
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 134,
+                    "startFilePos": 394,
+                    "endLine": 8,
+                    "endTokenPos": 137,
+                    "endFilePos": 407
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 134,
+                      "startFilePos": 394,
+                      "endLine": 8,
+                      "endTokenPos": 134,
+                      "endFilePos": 401
+                    },
+                    "name": "testpkg"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 136,
+                      "startFilePos": 403,
+                      "endLine": 8,
+                      "endTokenPos": 136,
+                      "endFilePos": 406,
+                      "kind": 2,
+                      "rawValue": "\"Pi\""
+                    },
+                    "value": "Pi"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 140,
+                  "startFilePos": 410,
+                  "endLine": 8,
+                  "endTokenPos": 140,
+                  "endFilePos": 413
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 140,
+                    "startFilePos": 410,
+                    "endLine": 8,
+                    "endTokenPos": 140,
+                    "endFilePos": 413,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 145,
+              "startFilePos": 418,
+              "endLine": 8,
+              "endTokenPos": 148,
+              "endFilePos": 431
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 145,
+                "startFilePos": 418,
+                "endLine": 8,
+                "endTokenPos": 145,
+                "endFilePos": 425
+              },
+              "name": "testpkg"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 147,
+                "startFilePos": 427,
+                "endLine": 8,
+                "endTokenPos": 147,
+                "endFilePos": 430,
+                "kind": 2,
+                "rawValue": "\"Pi\""
+              },
+              "value": "Pi"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 152,
+            "startFilePos": 435,
+            "endLine": 8,
+            "endTokenPos": 152,
+            "endFilePos": 441
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 152,
+              "startFilePos": 435,
+              "endLine": 8,
+              "endTokenPos": 152,
+              "endFilePos": 441
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 9,
+        "startTokenPos": 155,
+        "startFilePos": 444,
+        "endLine": 9,
+        "endTokenPos": 189,
+        "endFilePos": 549
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 158,
+            "startFilePos": 450,
+            "endLine": 9,
+            "endTokenPos": 184,
+            "endFilePos": 538
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 158,
+              "startFilePos": 450,
+              "endLine": 9,
+              "endTokenPos": 164,
+              "endFilePos": 477
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 158,
+                "startFilePos": 450,
+                "endLine": 9,
+                "endTokenPos": 158,
+                "endFilePos": 457
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 160,
+                  "startFilePos": 459,
+                  "endLine": 9,
+                  "endTokenPos": 163,
+                  "endFilePos": 476
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 160,
+                    "startFilePos": 459,
+                    "endLine": 9,
+                    "endTokenPos": 163,
+                    "endFilePos": 476
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 160,
+                      "startFilePos": 459,
+                      "endLine": 9,
+                      "endTokenPos": 160,
+                      "endFilePos": 466
+                    },
+                    "name": "testpkg"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 162,
+                      "startFilePos": 468,
+                      "endLine": 9,
+                      "endTokenPos": 162,
+                      "endFilePos": 475,
+                      "kind": 2,
+                      "rawValue": "\"Answer\""
+                    },
+                    "value": "Answer"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 168,
+              "startFilePos": 481,
+              "endLine": 9,
+              "endTokenPos": 177,
+              "endFilePos": 517
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 168,
+                "startFilePos": 481,
+                "endLine": 9,
+                "endTokenPos": 168,
+                "endFilePos": 491
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 170,
+                  "startFilePos": 493,
+                  "endLine": 9,
+                  "endTokenPos": 173,
+                  "endFilePos": 510
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 170,
+                    "startFilePos": 493,
+                    "endLine": 9,
+                    "endTokenPos": 173,
+                    "endFilePos": 510
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 170,
+                      "startFilePos": 493,
+                      "endLine": 9,
+                      "endTokenPos": 170,
+                      "endFilePos": 500
+                    },
+                    "name": "testpkg"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 172,
+                      "startFilePos": 502,
+                      "endLine": 9,
+                      "endTokenPos": 172,
+                      "endFilePos": 509,
+                      "kind": 2,
+                      "rawValue": "\"Answer\""
+                    },
+                    "value": "Answer"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 176,
+                  "startFilePos": 513,
+                  "endLine": 9,
+                  "endTokenPos": 176,
+                  "endFilePos": 516
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 176,
+                    "startFilePos": 513,
+                    "endLine": 9,
+                    "endTokenPos": 176,
+                    "endFilePos": 516,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 181,
+              "startFilePos": 521,
+              "endLine": 9,
+              "endTokenPos": 184,
+              "endFilePos": 538
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 181,
+                "startFilePos": 521,
+                "endLine": 9,
+                "endTokenPos": 181,
+                "endFilePos": 528
+              },
+              "name": "testpkg"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 183,
+                "startFilePos": 530,
+                "endLine": 9,
+                "endTokenPos": 183,
+                "endFilePos": 537,
+                "kind": 2,
+                "rawValue": "\"Answer\""
+              },
+              "value": "Answer"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 188,
+            "startFilePos": 542,
+            "endLine": 9,
+            "endTokenPos": 188,
+            "endFilePos": 548
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 188,
+              "startFilePos": 542,
+              "endLine": 9,
+              "endTokenPos": 188,
+              "endFilePos": 548
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by.php.json
+++ b/tests/json-ast/x/php/group_by.php.json
@@ -1,0 +1,3676 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 143,
+        "endFilePos": 332
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 142,
+          "endFilePos": 331
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 142,
+            "endFilePos": 331,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 26,
+                "endFilePos": 67
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 26,
+                  "endFilePos": 67,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 34
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 23,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 34,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 37,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 47
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 37,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 41,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 46,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 47,
+                        "rawValue": "30",
+                        "kind": 10
+                      },
+                      "value": 30
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 50,
+                      "endLine": 2,
+                      "endTokenPos": 25,
+                      "endFilePos": 66
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 21,
+                        "startFilePos": 50,
+                        "endLine": 2,
+                        "endTokenPos": 21,
+                        "endFilePos": 55,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 60,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 29,
+                "startFilePos": 70,
+                "endLine": 2,
+                "endTokenPos": 49,
+                "endFilePos": 118
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 70,
+                  "endLine": 2,
+                  "endTokenPos": 49,
+                  "endFilePos": 118,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 71,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 85
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 71,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 76,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 81,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 85,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 37,
+                      "startFilePos": 88,
+                      "endLine": 2,
+                      "endTokenPos": 41,
+                      "endFilePos": 98
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 37,
+                        "startFilePos": 88,
+                        "endLine": 2,
+                        "endTokenPos": 37,
+                        "endFilePos": 92,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 41,
+                        "startFilePos": 97,
+                        "endLine": 2,
+                        "endTokenPos": 41,
+                        "endFilePos": 98,
+                        "rawValue": "15",
+                        "kind": 10
+                      },
+                      "value": 15
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 44,
+                      "startFilePos": 101,
+                      "endLine": 2,
+                      "endTokenPos": 48,
+                      "endFilePos": 117
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 44,
+                        "startFilePos": 101,
+                        "endLine": 2,
+                        "endTokenPos": 44,
+                        "endFilePos": 106,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 48,
+                        "startFilePos": 111,
+                        "endLine": 2,
+                        "endTokenPos": 48,
+                        "endFilePos": 117,
+                        "kind": 2,
+                        "rawValue": "\"Hanoi\""
+                      },
+                      "value": "Hanoi"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 52,
+                "startFilePos": 121,
+                "endLine": 2,
+                "endTokenPos": 72,
+                "endFilePos": 173
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 52,
+                  "startFilePos": 121,
+                  "endLine": 2,
+                  "endTokenPos": 72,
+                  "endFilePos": 173,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 53,
+                      "startFilePos": 122,
+                      "endLine": 2,
+                      "endTokenPos": 57,
+                      "endFilePos": 140
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 53,
+                        "startFilePos": 122,
+                        "endLine": 2,
+                        "endTokenPos": 53,
+                        "endFilePos": 127,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 57,
+                        "startFilePos": 132,
+                        "endLine": 2,
+                        "endTokenPos": 57,
+                        "endFilePos": 140,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 60,
+                      "startFilePos": 143,
+                      "endLine": 2,
+                      "endTokenPos": 64,
+                      "endFilePos": 153
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 60,
+                        "startFilePos": 143,
+                        "endLine": 2,
+                        "endTokenPos": 60,
+                        "endFilePos": 147,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 64,
+                        "startFilePos": 152,
+                        "endLine": 2,
+                        "endTokenPos": 64,
+                        "endFilePos": 153,
+                        "rawValue": "65",
+                        "kind": 10
+                      },
+                      "value": 65
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 67,
+                      "startFilePos": 156,
+                      "endLine": 2,
+                      "endTokenPos": 71,
+                      "endFilePos": 172
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 67,
+                        "startFilePos": 156,
+                        "endLine": 2,
+                        "endTokenPos": 67,
+                        "endFilePos": 161,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 71,
+                        "startFilePos": 166,
+                        "endLine": 2,
+                        "endTokenPos": 71,
+                        "endFilePos": 172,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 75,
+                "startFilePos": 176,
+                "endLine": 2,
+                "endTokenPos": 95,
+                "endFilePos": 226
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 75,
+                  "startFilePos": 176,
+                  "endLine": 2,
+                  "endTokenPos": 95,
+                  "endFilePos": 226,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 76,
+                      "startFilePos": 177,
+                      "endLine": 2,
+                      "endTokenPos": 80,
+                      "endFilePos": 193
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 76,
+                        "startFilePos": 177,
+                        "endLine": 2,
+                        "endTokenPos": 76,
+                        "endFilePos": 182,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 80,
+                        "startFilePos": 187,
+                        "endLine": 2,
+                        "endTokenPos": 80,
+                        "endFilePos": 193,
+                        "kind": 2,
+                        "rawValue": "\"Diana\""
+                      },
+                      "value": "Diana"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 83,
+                      "startFilePos": 196,
+                      "endLine": 2,
+                      "endTokenPos": 87,
+                      "endFilePos": 206
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 83,
+                        "startFilePos": 196,
+                        "endLine": 2,
+                        "endTokenPos": 83,
+                        "endFilePos": 200,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 87,
+                        "startFilePos": 205,
+                        "endLine": 2,
+                        "endTokenPos": 87,
+                        "endFilePos": 206,
+                        "rawValue": "45",
+                        "kind": 10
+                      },
+                      "value": 45
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 90,
+                      "startFilePos": 209,
+                      "endLine": 2,
+                      "endTokenPos": 94,
+                      "endFilePos": 225
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 90,
+                        "startFilePos": 209,
+                        "endLine": 2,
+                        "endTokenPos": 90,
+                        "endFilePos": 214,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 94,
+                        "startFilePos": 219,
+                        "endLine": 2,
+                        "endTokenPos": 94,
+                        "endFilePos": 225,
+                        "kind": 2,
+                        "rawValue": "\"Hanoi\""
+                      },
+                      "value": "Hanoi"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 98,
+                "startFilePos": 229,
+                "endLine": 2,
+                "endTokenPos": 118,
+                "endFilePos": 277
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 98,
+                  "startFilePos": 229,
+                  "endLine": 2,
+                  "endTokenPos": 118,
+                  "endFilePos": 277,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 99,
+                      "startFilePos": 230,
+                      "endLine": 2,
+                      "endTokenPos": 103,
+                      "endFilePos": 244
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 99,
+                        "startFilePos": 230,
+                        "endLine": 2,
+                        "endTokenPos": 99,
+                        "endFilePos": 235,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 103,
+                        "startFilePos": 240,
+                        "endLine": 2,
+                        "endTokenPos": 103,
+                        "endFilePos": 244,
+                        "kind": 2,
+                        "rawValue": "\"Eve\""
+                      },
+                      "value": "Eve"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 106,
+                      "startFilePos": 247,
+                      "endLine": 2,
+                      "endTokenPos": 110,
+                      "endFilePos": 257
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 106,
+                        "startFilePos": 247,
+                        "endLine": 2,
+                        "endTokenPos": 106,
+                        "endFilePos": 251,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 110,
+                        "startFilePos": 256,
+                        "endLine": 2,
+                        "endTokenPos": 110,
+                        "endFilePos": 257,
+                        "rawValue": "70",
+                        "kind": 10
+                      },
+                      "value": 70
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 113,
+                      "startFilePos": 260,
+                      "endLine": 2,
+                      "endTokenPos": 117,
+                      "endFilePos": 276
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 113,
+                        "startFilePos": 260,
+                        "endLine": 2,
+                        "endTokenPos": 113,
+                        "endFilePos": 265,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 117,
+                        "startFilePos": 270,
+                        "endLine": 2,
+                        "endTokenPos": 117,
+                        "endFilePos": 276,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 121,
+                "startFilePos": 280,
+                "endLine": 2,
+                "endTokenPos": 141,
+                "endFilePos": 330
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 121,
+                  "startFilePos": 280,
+                  "endLine": 2,
+                  "endTokenPos": 141,
+                  "endFilePos": 330,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 122,
+                      "startFilePos": 281,
+                      "endLine": 2,
+                      "endTokenPos": 126,
+                      "endFilePos": 297
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 122,
+                        "startFilePos": 281,
+                        "endLine": 2,
+                        "endTokenPos": 122,
+                        "endFilePos": 286,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 126,
+                        "startFilePos": 291,
+                        "endLine": 2,
+                        "endTokenPos": 126,
+                        "endFilePos": 297,
+                        "kind": 2,
+                        "rawValue": "\"Frank\""
+                      },
+                      "value": "Frank"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 129,
+                      "startFilePos": 300,
+                      "endLine": 2,
+                      "endTokenPos": 133,
+                      "endFilePos": 310
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 129,
+                        "startFilePos": 300,
+                        "endLine": 2,
+                        "endTokenPos": 129,
+                        "endFilePos": 304,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 133,
+                        "startFilePos": 309,
+                        "endLine": 2,
+                        "endTokenPos": 133,
+                        "endFilePos": 310,
+                        "rawValue": "22",
+                        "kind": 10
+                      },
+                      "value": 22
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 136,
+                      "startFilePos": 313,
+                      "endLine": 2,
+                      "endTokenPos": 140,
+                      "endFilePos": 329
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 136,
+                        "startFilePos": 313,
+                        "endLine": 2,
+                        "endTokenPos": 136,
+                        "endFilePos": 318,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 140,
+                        "startFilePos": 323,
+                        "endLine": 2,
+                        "endTokenPos": 140,
+                        "endFilePos": 329,
+                        "kind": 2,
+                        "rawValue": "\"Hanoi\""
+                      },
+                      "value": "Hanoi"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 145,
+        "startFilePos": 334,
+        "endLine": 30,
+        "endTokenPos": 461,
+        "endFilePos": 1062
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 145,
+          "startFilePos": 334,
+          "endLine": 30,
+          "endTokenPos": 460,
+          "endFilePos": 1061
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 145,
+            "startFilePos": 334,
+            "endLine": 3,
+            "endTokenPos": 145,
+            "endFilePos": 339
+          },
+          "name": "stats"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 149,
+            "startFilePos": 343,
+            "endLine": 30,
+            "endTokenPos": 460,
+            "endFilePos": 1061
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 150,
+              "startFilePos": 344,
+              "endLine": 30,
+              "endTokenPos": 457,
+              "endFilePos": 1058
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 157,
+                  "startFilePos": 360,
+                  "endLine": 3,
+                  "endTokenPos": 157,
+                  "endFilePos": 366
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 157,
+                    "startFilePos": 360,
+                    "endLine": 3,
+                    "endTokenPos": 157,
+                    "endFilePos": 366
+                  },
+                  "name": "people"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 162,
+                  "startFilePos": 373,
+                  "endLine": 4,
+                  "endTokenPos": 168,
+                  "endFilePos": 385
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 162,
+                    "startFilePos": 373,
+                    "endLine": 4,
+                    "endTokenPos": 167,
+                    "endFilePos": 384
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 162,
+                      "startFilePos": 373,
+                      "endLine": 4,
+                      "endTokenPos": 162,
+                      "endFilePos": 379
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 166,
+                      "startFilePos": 383,
+                      "endLine": 4,
+                      "endTokenPos": 167,
+                      "endFilePos": 384,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 170,
+                  "startFilePos": 389,
+                  "endLine": 12,
+                  "endTokenPos": 258,
+                  "endFilePos": 616
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 173,
+                    "startFilePos": 398,
+                    "endLine": 5,
+                    "endTokenPos": 173,
+                    "endFilePos": 404
+                  },
+                  "name": "people"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 177,
+                    "startFilePos": 409,
+                    "endLine": 5,
+                    "endTokenPos": 177,
+                    "endFilePos": 415
+                  },
+                  "name": "person"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 182,
+                      "startFilePos": 424,
+                      "endLine": 6,
+                      "endTokenPos": 190,
+                      "endFilePos": 446
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 182,
+                        "startFilePos": 424,
+                        "endLine": 6,
+                        "endTokenPos": 189,
+                        "endFilePos": 445
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 182,
+                          "startFilePos": 424,
+                          "endLine": 6,
+                          "endTokenPos": 182,
+                          "endFilePos": 427
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 186,
+                          "startFilePos": 431,
+                          "endLine": 6,
+                          "endTokenPos": 189,
+                          "endFilePos": 445
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 186,
+                            "startFilePos": 431,
+                            "endLine": 6,
+                            "endTokenPos": 186,
+                            "endFilePos": 437
+                          },
+                          "name": "person"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 188,
+                            "startFilePos": 439,
+                            "endLine": 6,
+                            "endTokenPos": 188,
+                            "endFilePos": 444,
+                            "kind": 2,
+                            "rawValue": "\"city\""
+                          },
+                          "value": "city"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 192,
+                      "startFilePos": 452,
+                      "endLine": 7,
+                      "endTokenPos": 200,
+                      "endFilePos": 474
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 192,
+                        "startFilePos": 452,
+                        "endLine": 7,
+                        "endTokenPos": 199,
+                        "endFilePos": 473
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 192,
+                          "startFilePos": 452,
+                          "endLine": 7,
+                          "endTokenPos": 192,
+                          "endFilePos": 453
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 196,
+                          "startFilePos": 457,
+                          "endLine": 7,
+                          "endTokenPos": 199,
+                          "endFilePos": 473
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 196,
+                            "startFilePos": 457,
+                            "endLine": 7,
+                            "endTokenPos": 196,
+                            "endFilePos": 467
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 198,
+                              "startFilePos": 469,
+                              "endLine": 7,
+                              "endTokenPos": 198,
+                              "endFilePos": 472
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 198,
+                                "startFilePos": 469,
+                                "endLine": 7,
+                                "endTokenPos": 198,
+                                "endFilePos": 472
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 202,
+                      "startFilePos": 480,
+                      "endLine": 10,
+                      "endTokenPos": 241,
+                      "endFilePos": 574
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 205,
+                        "startFilePos": 484,
+                        "endLine": 8,
+                        "endTokenPos": 212,
+                        "endFilePos": 513
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 206,
+                          "startFilePos": 485,
+                          "endLine": 8,
+                          "endTokenPos": 212,
+                          "endFilePos": 513
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 206,
+                            "startFilePos": 485,
+                            "endLine": 8,
+                            "endTokenPos": 206,
+                            "endFilePos": 500
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 208,
+                              "startFilePos": 502,
+                              "endLine": 8,
+                              "endTokenPos": 208,
+                              "endFilePos": 503
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 208,
+                                "startFilePos": 502,
+                                "endLine": 8,
+                                "endTokenPos": 208,
+                                "endFilePos": 503
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 211,
+                              "startFilePos": 506,
+                              "endLine": 8,
+                              "endTokenPos": 211,
+                              "endFilePos": 512
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 211,
+                                "startFilePos": 506,
+                                "endLine": 8,
+                                "endTokenPos": 211,
+                                "endFilePos": 512
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 217,
+                          "startFilePos": 524,
+                          "endLine": 9,
+                          "endTokenPos": 239,
+                          "endFilePos": 568
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 217,
+                            "startFilePos": 524,
+                            "endLine": 9,
+                            "endTokenPos": 238,
+                            "endFilePos": 567
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 217,
+                              "startFilePos": 524,
+                              "endLine": 9,
+                              "endTokenPos": 220,
+                              "endFilePos": 534
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 217,
+                                "startFilePos": 524,
+                                "endLine": 9,
+                                "endTokenPos": 217,
+                                "endFilePos": 530
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 219,
+                                "startFilePos": 532,
+                                "endLine": 9,
+                                "endTokenPos": 219,
+                                "endFilePos": 533
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 224,
+                              "startFilePos": 538,
+                              "endLine": 9,
+                              "endTokenPos": 238,
+                              "endFilePos": 567,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 225,
+                                  "startFilePos": 539,
+                                  "endLine": 9,
+                                  "endTokenPos": 229,
+                                  "endFilePos": 551
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 225,
+                                    "startFilePos": 539,
+                                    "endLine": 9,
+                                    "endTokenPos": 225,
+                                    "endFilePos": 543,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 229,
+                                    "startFilePos": 548,
+                                    "endLine": 9,
+                                    "endTokenPos": 229,
+                                    "endFilePos": 551
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 232,
+                                  "startFilePos": 554,
+                                  "endLine": 9,
+                                  "endTokenPos": 237,
+                                  "endFilePos": 566
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 232,
+                                    "startFilePos": 554,
+                                    "endLine": 9,
+                                    "endTokenPos": 232,
+                                    "endFilePos": 560,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 236,
+                                    "startFilePos": 565,
+                                    "endLine": 9,
+                                    "endTokenPos": 237,
+                                    "endFilePos": 566,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 243,
+                      "startFilePos": 580,
+                      "endLine": 11,
+                      "endTokenPos": 256,
+                      "endFilePos": 612
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 243,
+                        "startFilePos": 580,
+                        "endLine": 11,
+                        "endTokenPos": 255,
+                        "endFilePos": 611
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 243,
+                          "startFilePos": 580,
+                          "endLine": 11,
+                          "endTokenPos": 251,
+                          "endFilePos": 601
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 243,
+                            "startFilePos": 580,
+                            "endLine": 11,
+                            "endTokenPos": 249,
+                            "endFilePos": 599
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 243,
+                              "startFilePos": 580,
+                              "endLine": 11,
+                              "endTokenPos": 246,
+                              "endFilePos": 590
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 243,
+                                "startFilePos": 580,
+                                "endLine": 11,
+                                "endTokenPos": 243,
+                                "endFilePos": 586
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 245,
+                                "startFilePos": 588,
+                                "endLine": 11,
+                                "endTokenPos": 245,
+                                "endFilePos": 589
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 248,
+                              "startFilePos": 592,
+                              "endLine": 11,
+                              "endTokenPos": 248,
+                              "endFilePos": 598,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 255,
+                          "startFilePos": 605,
+                          "endLine": 11,
+                          "endTokenPos": 255,
+                          "endFilePos": 611
+                        },
+                        "name": "person"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 260,
+                  "startFilePos": 620,
+                  "endLine": 13,
+                  "endTokenPos": 266,
+                  "endFilePos": 632
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 260,
+                    "startFilePos": 620,
+                    "endLine": 13,
+                    "endTokenPos": 265,
+                    "endFilePos": 631
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 260,
+                      "startFilePos": 620,
+                      "endLine": 13,
+                      "endTokenPos": 260,
+                      "endFilePos": 626
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 264,
+                      "startFilePos": 630,
+                      "endLine": 13,
+                      "endTokenPos": 265,
+                      "endFilePos": 631,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 268,
+                  "startFilePos": 636,
+                  "endLine": 28,
+                  "endTokenPos": 450,
+                  "endFilePos": 1038
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 271,
+                    "startFilePos": 645,
+                    "endLine": 14,
+                    "endTokenPos": 271,
+                    "endFilePos": 651
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 275,
+                    "startFilePos": 656,
+                    "endLine": 14,
+                    "endTokenPos": 275,
+                    "endFilePos": 657
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 280,
+                      "startFilePos": 668,
+                      "endLine": 27,
+                      "endTokenPos": 448,
+                      "endFilePos": 1034
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 280,
+                        "startFilePos": 668,
+                        "endLine": 27,
+                        "endTokenPos": 447,
+                        "endFilePos": 1033
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 280,
+                          "startFilePos": 668,
+                          "endLine": 15,
+                          "endTokenPos": 282,
+                          "endFilePos": 676
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 280,
+                            "startFilePos": 668,
+                            "endLine": 15,
+                            "endTokenPos": 280,
+                            "endFilePos": 674
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 286,
+                          "startFilePos": 680,
+                          "endLine": 27,
+                          "endTokenPos": 447,
+                          "endFilePos": 1033,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 287,
+                              "startFilePos": 681,
+                              "endLine": 15,
+                              "endTokenPos": 294,
+                              "endFilePos": 699
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 287,
+                                "startFilePos": 681,
+                                "endLine": 15,
+                                "endTokenPos": 287,
+                                "endFilePos": 686,
+                                "kind": 2,
+                                "rawValue": "\"city\""
+                              },
+                              "value": "city"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 291,
+                                "startFilePos": 691,
+                                "endLine": 15,
+                                "endTokenPos": 294,
+                                "endFilePos": 699
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 291,
+                                  "startFilePos": 691,
+                                  "endLine": 15,
+                                  "endTokenPos": 291,
+                                  "endFilePos": 692
+                                },
+                                "name": "g"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 293,
+                                  "startFilePos": 694,
+                                  "endLine": 15,
+                                  "endTokenPos": 293,
+                                  "endFilePos": 698,
+                                  "kind": 2,
+                                  "rawValue": "\"key\""
+                                },
+                                "value": "key"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 297,
+                              "startFilePos": 702,
+                              "endLine": 15,
+                              "endTokenPos": 307,
+                              "endFilePos": 730
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 297,
+                                "startFilePos": 702,
+                                "endLine": 15,
+                                "endTokenPos": 297,
+                                "endFilePos": 708,
+                                "kind": 2,
+                                "rawValue": "\"count\""
+                              },
+                              "value": "count"
+                            },
+                            "value": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 301,
+                                "startFilePos": 713,
+                                "endLine": 15,
+                                "endTokenPos": 307,
+                                "endFilePos": 730
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 301,
+                                  "startFilePos": 713,
+                                  "endLine": 15,
+                                  "endTokenPos": 301,
+                                  "endFilePos": 717
+                                },
+                                "name": "count"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 303,
+                                    "startFilePos": 719,
+                                    "endLine": 15,
+                                    "endTokenPos": 306,
+                                    "endFilePos": 729
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 303,
+                                      "startFilePos": 719,
+                                      "endLine": 15,
+                                      "endTokenPos": 306,
+                                      "endFilePos": 729
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 303,
+                                        "startFilePos": 719,
+                                        "endLine": 15,
+                                        "endTokenPos": 303,
+                                        "endFilePos": 720
+                                      },
+                                      "name": "g"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 305,
+                                        "startFilePos": 722,
+                                        "endLine": 15,
+                                        "endTokenPos": 305,
+                                        "endFilePos": 728,
+                                        "kind": 2,
+                                        "rawValue": "\"items\""
+                                      },
+                                      "value": "items"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 310,
+                              "startFilePos": 733,
+                              "endLine": 27,
+                              "endTokenPos": 446,
+                              "endFilePos": 1032
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 310,
+                                "startFilePos": 733,
+                                "endLine": 15,
+                                "endTokenPos": 310,
+                                "endFilePos": 741,
+                                "kind": 2,
+                                "rawValue": "\"avg_age\""
+                              },
+                              "value": "avg_age"
+                            },
+                            "value": {
+                              "nodeType": "Expr_BinaryOp_Div",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 314,
+                                "startFilePos": 746,
+                                "endLine": 27,
+                                "endTokenPos": 446,
+                                "endFilePos": 1032
+                              },
+                              "left": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 314,
+                                  "startFilePos": 746,
+                                  "endLine": 21,
+                                  "endTokenPos": 378,
+                                  "endFilePos": 889
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 314,
+                                    "startFilePos": 746,
+                                    "endLine": 15,
+                                    "endTokenPos": 314,
+                                    "endFilePos": 754
+                                  },
+                                  "name": "array_sum"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 316,
+                                      "startFilePos": 756,
+                                      "endLine": 21,
+                                      "endTokenPos": 377,
+                                      "endFilePos": 888
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 316,
+                                        "startFilePos": 756,
+                                        "endLine": 21,
+                                        "endTokenPos": 377,
+                                        "endFilePos": 888
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 317,
+                                          "startFilePos": 757,
+                                          "endLine": 21,
+                                          "endTokenPos": 374,
+                                          "endFilePos": 885
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 324,
+                                              "startFilePos": 773,
+                                              "endLine": 15,
+                                              "endTokenPos": 324,
+                                              "endFilePos": 779
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 324,
+                                                "startFilePos": 773,
+                                                "endLine": 15,
+                                                "endTokenPos": 324,
+                                                "endFilePos": 779
+                                              },
+                                              "name": "person"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 327,
+                                              "startFilePos": 782,
+                                              "endLine": 15,
+                                              "endTokenPos": 327,
+                                              "endFilePos": 783
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 327,
+                                                "startFilePos": 782,
+                                                "endLine": 15,
+                                                "endTokenPos": 327,
+                                                "endFilePos": 783
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 16,
+                                              "startTokenPos": 332,
+                                              "startFilePos": 790,
+                                              "endLine": 16,
+                                              "endTokenPos": 338,
+                                              "endFilePos": 802
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 16,
+                                                "startTokenPos": 332,
+                                                "startFilePos": 790,
+                                                "endLine": 16,
+                                                "endTokenPos": 337,
+                                                "endFilePos": 801
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 16,
+                                                  "startTokenPos": 332,
+                                                  "startFilePos": 790,
+                                                  "endLine": 16,
+                                                  "endTokenPos": 332,
+                                                  "endFilePos": 796
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 16,
+                                                  "startTokenPos": 336,
+                                                  "startFilePos": 800,
+                                                  "endLine": 16,
+                                                  "endTokenPos": 337,
+                                                  "endFilePos": 801,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 17,
+                                              "startTokenPos": 340,
+                                              "startFilePos": 806,
+                                              "endLine": 19,
+                                              "endTokenPos": 367,
+                                              "endFilePos": 865
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 343,
+                                                "startFilePos": 815,
+                                                "endLine": 17,
+                                                "endTokenPos": 346,
+                                                "endFilePos": 825
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 343,
+                                                  "startFilePos": 815,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 343,
+                                                  "endFilePos": 816
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 345,
+                                                  "startFilePos": 818,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 345,
+                                                  "endFilePos": 824,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 350,
+                                                "startFilePos": 830,
+                                                "endLine": 17,
+                                                "endTokenPos": 350,
+                                                "endFilePos": 831
+                                              },
+                                              "name": "p"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 355,
+                                                  "startFilePos": 840,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 365,
+                                                  "endFilePos": 861
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 355,
+                                                    "startFilePos": 840,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 364,
+                                                    "endFilePos": 860
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 18,
+                                                      "startTokenPos": 355,
+                                                      "startFilePos": 840,
+                                                      "endLine": 18,
+                                                      "endTokenPos": 357,
+                                                      "endFilePos": 848
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 355,
+                                                        "startFilePos": 840,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 355,
+                                                        "endFilePos": 846
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 18,
+                                                      "startTokenPos": 361,
+                                                      "startFilePos": 852,
+                                                      "endLine": 18,
+                                                      "endTokenPos": 364,
+                                                      "endFilePos": 860
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 361,
+                                                        "startFilePos": 852,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 361,
+                                                        "endFilePos": 853
+                                                      },
+                                                      "name": "p"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 363,
+                                                        "startFilePos": 855,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 363,
+                                                        "endFilePos": 859,
+                                                        "kind": 2,
+                                                        "rawValue": "\"age\""
+                                                      },
+                                                      "value": "age"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 369,
+                                              "startFilePos": 869,
+                                              "endLine": 20,
+                                              "endTokenPos": 372,
+                                              "endFilePos": 883
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 371,
+                                                "startFilePos": 876,
+                                                "endLine": 20,
+                                                "endTokenPos": 371,
+                                                "endFilePos": 882
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              },
+                              "right": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 21,
+                                  "startTokenPos": 382,
+                                  "startFilePos": 893,
+                                  "endLine": 27,
+                                  "endTokenPos": 446,
+                                  "endFilePos": 1032
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 382,
+                                    "startFilePos": 893,
+                                    "endLine": 21,
+                                    "endTokenPos": 382,
+                                    "endFilePos": 897
+                                  },
+                                  "name": "count"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 384,
+                                      "startFilePos": 899,
+                                      "endLine": 27,
+                                      "endTokenPos": 445,
+                                      "endFilePos": 1031
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 384,
+                                        "startFilePos": 899,
+                                        "endLine": 27,
+                                        "endTokenPos": 445,
+                                        "endFilePos": 1031
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 385,
+                                          "startFilePos": 900,
+                                          "endLine": 27,
+                                          "endTokenPos": 442,
+                                          "endFilePos": 1028
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 21,
+                                              "startTokenPos": 392,
+                                              "startFilePos": 916,
+                                              "endLine": 21,
+                                              "endTokenPos": 392,
+                                              "endFilePos": 922
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 21,
+                                                "startTokenPos": 392,
+                                                "startFilePos": 916,
+                                                "endLine": 21,
+                                                "endTokenPos": 392,
+                                                "endFilePos": 922
+                                              },
+                                              "name": "person"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 21,
+                                              "startTokenPos": 395,
+                                              "startFilePos": 925,
+                                              "endLine": 21,
+                                              "endTokenPos": 395,
+                                              "endFilePos": 926
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 21,
+                                                "startTokenPos": 395,
+                                                "startFilePos": 925,
+                                                "endLine": 21,
+                                                "endTokenPos": 395,
+                                                "endFilePos": 926
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 22,
+                                              "startTokenPos": 400,
+                                              "startFilePos": 933,
+                                              "endLine": 22,
+                                              "endTokenPos": 406,
+                                              "endFilePos": 945
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 22,
+                                                "startTokenPos": 400,
+                                                "startFilePos": 933,
+                                                "endLine": 22,
+                                                "endTokenPos": 405,
+                                                "endFilePos": 944
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 22,
+                                                  "startTokenPos": 400,
+                                                  "startFilePos": 933,
+                                                  "endLine": 22,
+                                                  "endTokenPos": 400,
+                                                  "endFilePos": 939
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 22,
+                                                  "startTokenPos": 404,
+                                                  "startFilePos": 943,
+                                                  "endLine": 22,
+                                                  "endTokenPos": 405,
+                                                  "endFilePos": 944,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 23,
+                                              "startTokenPos": 408,
+                                              "startFilePos": 949,
+                                              "endLine": 25,
+                                              "endTokenPos": 435,
+                                              "endFilePos": 1008
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 411,
+                                                "startFilePos": 958,
+                                                "endLine": 23,
+                                                "endTokenPos": 414,
+                                                "endFilePos": 968
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 23,
+                                                  "startTokenPos": 411,
+                                                  "startFilePos": 958,
+                                                  "endLine": 23,
+                                                  "endTokenPos": 411,
+                                                  "endFilePos": 959
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 23,
+                                                  "startTokenPos": 413,
+                                                  "startFilePos": 961,
+                                                  "endLine": 23,
+                                                  "endTokenPos": 413,
+                                                  "endFilePos": 967,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 418,
+                                                "startFilePos": 973,
+                                                "endLine": 23,
+                                                "endTokenPos": 418,
+                                                "endFilePos": 974
+                                              },
+                                              "name": "p"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 24,
+                                                  "startTokenPos": 423,
+                                                  "startFilePos": 983,
+                                                  "endLine": 24,
+                                                  "endTokenPos": 433,
+                                                  "endFilePos": 1004
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 24,
+                                                    "startTokenPos": 423,
+                                                    "startFilePos": 983,
+                                                    "endLine": 24,
+                                                    "endTokenPos": 432,
+                                                    "endFilePos": 1003
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 24,
+                                                      "startTokenPos": 423,
+                                                      "startFilePos": 983,
+                                                      "endLine": 24,
+                                                      "endTokenPos": 425,
+                                                      "endFilePos": 991
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 24,
+                                                        "startTokenPos": 423,
+                                                        "startFilePos": 983,
+                                                        "endLine": 24,
+                                                        "endTokenPos": 423,
+                                                        "endFilePos": 989
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 24,
+                                                      "startTokenPos": 429,
+                                                      "startFilePos": 995,
+                                                      "endLine": 24,
+                                                      "endTokenPos": 432,
+                                                      "endFilePos": 1003
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 24,
+                                                        "startTokenPos": 429,
+                                                        "startFilePos": 995,
+                                                        "endLine": 24,
+                                                        "endTokenPos": 429,
+                                                        "endFilePos": 996
+                                                      },
+                                                      "name": "p"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 24,
+                                                        "startTokenPos": 431,
+                                                        "startFilePos": 998,
+                                                        "endLine": 24,
+                                                        "endTokenPos": 431,
+                                                        "endFilePos": 1002,
+                                                        "kind": 2,
+                                                        "rawValue": "\"age\""
+                                                      },
+                                                      "value": "age"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 26,
+                                              "startTokenPos": 437,
+                                              "startFilePos": 1012,
+                                              "endLine": 26,
+                                              "endTokenPos": 440,
+                                              "endFilePos": 1026
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 26,
+                                                "startTokenPos": 439,
+                                                "startFilePos": 1019,
+                                                "endLine": 26,
+                                                "endTokenPos": 439,
+                                                "endFilePos": 1025
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 452,
+                  "startFilePos": 1042,
+                  "endLine": 29,
+                  "endTokenPos": 455,
+                  "endFilePos": 1056
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 29,
+                    "startTokenPos": 454,
+                    "startFilePos": 1049,
+                    "endLine": 29,
+                    "endTokenPos": 454,
+                    "endFilePos": 1055
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 31,
+        "startTokenPos": 463,
+        "startFilePos": 1064,
+        "endLine": 31,
+        "endTokenPos": 469,
+        "endFilePos": 1110
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 31,
+            "startTokenPos": 465,
+            "startFilePos": 1069,
+            "endLine": 31,
+            "endTokenPos": 465,
+            "endFilePos": 1100,
+            "kind": 2,
+            "rawValue": "\"--- People grouped by city ---\""
+          },
+          "value": "--- People grouped by city ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 31,
+            "startTokenPos": 468,
+            "startFilePos": 1103,
+            "endLine": 31,
+            "endTokenPos": 468,
+            "endFilePos": 1109
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 31,
+              "startTokenPos": 468,
+              "startFilePos": 1103,
+              "endLine": 31,
+              "endTokenPos": 468,
+              "endFilePos": 1109
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 32,
+        "startTokenPos": 471,
+        "startFilePos": 1112,
+        "endLine": 34,
+        "endTokenPos": 607,
+        "endFilePos": 1428
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 32,
+          "startTokenPos": 474,
+          "startFilePos": 1121,
+          "endLine": 32,
+          "endTokenPos": 474,
+          "endFilePos": 1126
+        },
+        "name": "stats"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 32,
+          "startTokenPos": 478,
+          "startFilePos": 1131,
+          "endLine": 32,
+          "endTokenPos": 478,
+          "endFilePos": 1132
+        },
+        "name": "s"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 33,
+            "startTokenPos": 483,
+            "startFilePos": 1139,
+            "endLine": 33,
+            "endTokenPos": 605,
+            "endFilePos": 1426
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 485,
+                "startFilePos": 1144,
+                "endLine": 33,
+                "endTokenPos": 601,
+                "endFilePos": 1416
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 485,
+                  "startFilePos": 1144,
+                  "endLine": 33,
+                  "endTokenPos": 569,
+                  "endFilePos": 1337
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 485,
+                    "startFilePos": 1144,
+                    "endLine": 33,
+                    "endTokenPos": 565,
+                    "endFilePos": 1331
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 485,
+                      "startFilePos": 1144,
+                      "endLine": 33,
+                      "endTokenPos": 561,
+                      "endFilePos": 1315
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 485,
+                        "startFilePos": 1144,
+                        "endLine": 33,
+                        "endTokenPos": 557,
+                        "endFilePos": 1309
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 485,
+                          "startFilePos": 1144,
+                          "endLine": 33,
+                          "endTokenPos": 525,
+                          "endFilePos": 1236
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 485,
+                            "startFilePos": 1144,
+                            "endLine": 33,
+                            "endTokenPos": 521,
+                            "endFilePos": 1230
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 485,
+                              "startFilePos": 1144,
+                              "endLine": 33,
+                              "endTokenPos": 517,
+                              "endFilePos": 1216
+                            },
+                            "left": {
+                              "nodeType": "Expr_Ternary",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 486,
+                                "startFilePos": 1145,
+                                "endLine": 33,
+                                "endTokenPos": 512,
+                                "endFilePos": 1209
+                              },
+                              "cond": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 486,
+                                  "startFilePos": 1145,
+                                  "endLine": 33,
+                                  "endTokenPos": 492,
+                                  "endFilePos": 1164
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 486,
+                                    "startFilePos": 1145,
+                                    "endLine": 33,
+                                    "endTokenPos": 486,
+                                    "endFilePos": 1152
+                                  },
+                                  "name": "is_float"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 33,
+                                      "startTokenPos": 488,
+                                      "startFilePos": 1154,
+                                      "endLine": 33,
+                                      "endTokenPos": 491,
+                                      "endFilePos": 1163
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 488,
+                                        "startFilePos": 1154,
+                                        "endLine": 33,
+                                        "endTokenPos": 491,
+                                        "endFilePos": 1163
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 488,
+                                          "startFilePos": 1154,
+                                          "endLine": 33,
+                                          "endTokenPos": 488,
+                                          "endFilePos": 1155
+                                        },
+                                        "name": "s"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 490,
+                                          "startFilePos": 1157,
+                                          "endLine": 33,
+                                          "endTokenPos": 490,
+                                          "endFilePos": 1162,
+                                          "kind": 2,
+                                          "rawValue": "\"city\""
+                                        },
+                                        "value": "city"
+                                      }
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              },
+                              "if": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 496,
+                                  "startFilePos": 1168,
+                                  "endLine": 33,
+                                  "endTokenPos": 505,
+                                  "endFilePos": 1196
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 496,
+                                    "startFilePos": 1168,
+                                    "endLine": 33,
+                                    "endTokenPos": 496,
+                                    "endFilePos": 1178
+                                  },
+                                  "name": "json_encode"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 33,
+                                      "startTokenPos": 498,
+                                      "startFilePos": 1180,
+                                      "endLine": 33,
+                                      "endTokenPos": 501,
+                                      "endFilePos": 1189
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 498,
+                                        "startFilePos": 1180,
+                                        "endLine": 33,
+                                        "endTokenPos": 501,
+                                        "endFilePos": 1189
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 498,
+                                          "startFilePos": 1180,
+                                          "endLine": 33,
+                                          "endTokenPos": 498,
+                                          "endFilePos": 1181
+                                        },
+                                        "name": "s"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 500,
+                                          "startFilePos": 1183,
+                                          "endLine": 33,
+                                          "endTokenPos": 500,
+                                          "endFilePos": 1188,
+                                          "kind": 2,
+                                          "rawValue": "\"city\""
+                                        },
+                                        "value": "city"
+                                      }
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 33,
+                                      "startTokenPos": 504,
+                                      "startFilePos": 1192,
+                                      "endLine": 33,
+                                      "endTokenPos": 504,
+                                      "endFilePos": 1195
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Scalar_Int",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 504,
+                                        "startFilePos": 1192,
+                                        "endLine": 33,
+                                        "endTokenPos": 504,
+                                        "endFilePos": 1195,
+                                        "rawValue": "1344",
+                                        "kind": 10
+                                      },
+                                      "value": 1344
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              },
+                              "else": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 509,
+                                  "startFilePos": 1200,
+                                  "endLine": 33,
+                                  "endTokenPos": 512,
+                                  "endFilePos": 1209
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 509,
+                                    "startFilePos": 1200,
+                                    "endLine": 33,
+                                    "endTokenPos": 509,
+                                    "endFilePos": 1201
+                                  },
+                                  "name": "s"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 511,
+                                    "startFilePos": 1203,
+                                    "endLine": 33,
+                                    "endTokenPos": 511,
+                                    "endFilePos": 1208,
+                                    "kind": 2,
+                                    "rawValue": "\"city\""
+                                  },
+                                  "value": "city"
+                                }
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 517,
+                                "startFilePos": 1214,
+                                "endLine": 33,
+                                "endTokenPos": 517,
+                                "endFilePos": 1216,
+                                "kind": 2,
+                                "rawValue": "\" \""
+                              },
+                              "value": " "
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 521,
+                              "startFilePos": 1220,
+                              "endLine": 33,
+                              "endTokenPos": 521,
+                              "endFilePos": 1230,
+                              "kind": 2,
+                              "rawValue": "\": count =\""
+                            },
+                            "value": ": count ="
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 525,
+                            "startFilePos": 1234,
+                            "endLine": 33,
+                            "endTokenPos": 525,
+                            "endFilePos": 1236,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_Ternary",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 530,
+                          "startFilePos": 1241,
+                          "endLine": 33,
+                          "endTokenPos": 556,
+                          "endFilePos": 1308
+                        },
+                        "cond": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 530,
+                            "startFilePos": 1241,
+                            "endLine": 33,
+                            "endTokenPos": 536,
+                            "endFilePos": 1261
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 530,
+                              "startFilePos": 1241,
+                              "endLine": 33,
+                              "endTokenPos": 530,
+                              "endFilePos": 1248
+                            },
+                            "name": "is_float"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 532,
+                                "startFilePos": 1250,
+                                "endLine": 33,
+                                "endTokenPos": 535,
+                                "endFilePos": 1260
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 532,
+                                  "startFilePos": 1250,
+                                  "endLine": 33,
+                                  "endTokenPos": 535,
+                                  "endFilePos": 1260
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 532,
+                                    "startFilePos": 1250,
+                                    "endLine": 33,
+                                    "endTokenPos": 532,
+                                    "endFilePos": 1251
+                                  },
+                                  "name": "s"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 534,
+                                    "startFilePos": 1253,
+                                    "endLine": 33,
+                                    "endTokenPos": 534,
+                                    "endFilePos": 1259,
+                                    "kind": 2,
+                                    "rawValue": "\"count\""
+                                  },
+                                  "value": "count"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "if": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 540,
+                            "startFilePos": 1265,
+                            "endLine": 33,
+                            "endTokenPos": 549,
+                            "endFilePos": 1294
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 540,
+                              "startFilePos": 1265,
+                              "endLine": 33,
+                              "endTokenPos": 540,
+                              "endFilePos": 1275
+                            },
+                            "name": "json_encode"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 542,
+                                "startFilePos": 1277,
+                                "endLine": 33,
+                                "endTokenPos": 545,
+                                "endFilePos": 1287
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 542,
+                                  "startFilePos": 1277,
+                                  "endLine": 33,
+                                  "endTokenPos": 545,
+                                  "endFilePos": 1287
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 542,
+                                    "startFilePos": 1277,
+                                    "endLine": 33,
+                                    "endTokenPos": 542,
+                                    "endFilePos": 1278
+                                  },
+                                  "name": "s"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 544,
+                                    "startFilePos": 1280,
+                                    "endLine": 33,
+                                    "endTokenPos": 544,
+                                    "endFilePos": 1286,
+                                    "kind": 2,
+                                    "rawValue": "\"count\""
+                                  },
+                                  "value": "count"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 548,
+                                "startFilePos": 1290,
+                                "endLine": 33,
+                                "endTokenPos": 548,
+                                "endFilePos": 1293
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 548,
+                                  "startFilePos": 1290,
+                                  "endLine": 33,
+                                  "endTokenPos": 548,
+                                  "endFilePos": 1293,
+                                  "rawValue": "1344",
+                                  "kind": 10
+                                },
+                                "value": 1344
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "else": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 553,
+                            "startFilePos": 1298,
+                            "endLine": 33,
+                            "endTokenPos": 556,
+                            "endFilePos": 1308
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 553,
+                              "startFilePos": 1298,
+                              "endLine": 33,
+                              "endTokenPos": 553,
+                              "endFilePos": 1299
+                            },
+                            "name": "s"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 555,
+                              "startFilePos": 1301,
+                              "endLine": 33,
+                              "endTokenPos": 555,
+                              "endFilePos": 1307,
+                              "kind": 2,
+                              "rawValue": "\"count\""
+                            },
+                            "value": "count"
+                          }
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 561,
+                        "startFilePos": 1313,
+                        "endLine": 33,
+                        "endTokenPos": 561,
+                        "endFilePos": 1315,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 565,
+                      "startFilePos": 1319,
+                      "endLine": 33,
+                      "endTokenPos": 565,
+                      "endFilePos": 1331,
+                      "kind": 2,
+                      "rawValue": "\", avg_age =\""
+                    },
+                    "value": ", avg_age ="
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 569,
+                    "startFilePos": 1335,
+                    "endLine": 33,
+                    "endTokenPos": 569,
+                    "endFilePos": 1337,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 574,
+                  "startFilePos": 1342,
+                  "endLine": 33,
+                  "endTokenPos": 600,
+                  "endFilePos": 1415
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 574,
+                    "startFilePos": 1342,
+                    "endLine": 33,
+                    "endTokenPos": 580,
+                    "endFilePos": 1364
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 574,
+                      "startFilePos": 1342,
+                      "endLine": 33,
+                      "endTokenPos": 574,
+                      "endFilePos": 1349
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 576,
+                        "startFilePos": 1351,
+                        "endLine": 33,
+                        "endTokenPos": 579,
+                        "endFilePos": 1363
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 576,
+                          "startFilePos": 1351,
+                          "endLine": 33,
+                          "endTokenPos": 579,
+                          "endFilePos": 1363
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 576,
+                            "startFilePos": 1351,
+                            "endLine": 33,
+                            "endTokenPos": 576,
+                            "endFilePos": 1352
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 578,
+                            "startFilePos": 1354,
+                            "endLine": 33,
+                            "endTokenPos": 578,
+                            "endFilePos": 1362,
+                            "kind": 2,
+                            "rawValue": "\"avg_age\""
+                          },
+                          "value": "avg_age"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 584,
+                    "startFilePos": 1368,
+                    "endLine": 33,
+                    "endTokenPos": 593,
+                    "endFilePos": 1399
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 584,
+                      "startFilePos": 1368,
+                      "endLine": 33,
+                      "endTokenPos": 584,
+                      "endFilePos": 1378
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 586,
+                        "startFilePos": 1380,
+                        "endLine": 33,
+                        "endTokenPos": 589,
+                        "endFilePos": 1392
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 586,
+                          "startFilePos": 1380,
+                          "endLine": 33,
+                          "endTokenPos": 589,
+                          "endFilePos": 1392
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 586,
+                            "startFilePos": 1380,
+                            "endLine": 33,
+                            "endTokenPos": 586,
+                            "endFilePos": 1381
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 588,
+                            "startFilePos": 1383,
+                            "endLine": 33,
+                            "endTokenPos": 588,
+                            "endFilePos": 1391,
+                            "kind": 2,
+                            "rawValue": "\"avg_age\""
+                          },
+                          "value": "avg_age"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 592,
+                        "startFilePos": 1395,
+                        "endLine": 33,
+                        "endTokenPos": 592,
+                        "endFilePos": 1398
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 592,
+                          "startFilePos": 1395,
+                          "endLine": 33,
+                          "endTokenPos": 592,
+                          "endFilePos": 1398,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 597,
+                    "startFilePos": 1403,
+                    "endLine": 33,
+                    "endTokenPos": 600,
+                    "endFilePos": 1415
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 597,
+                      "startFilePos": 1403,
+                      "endLine": 33,
+                      "endTokenPos": 597,
+                      "endFilePos": 1404
+                    },
+                    "name": "s"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 599,
+                      "startFilePos": 1406,
+                      "endLine": 33,
+                      "endTokenPos": 599,
+                      "endFilePos": 1414,
+                      "kind": 2,
+                      "rawValue": "\"avg_age\""
+                    },
+                    "value": "avg_age"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 604,
+                "startFilePos": 1419,
+                "endLine": 33,
+                "endTokenPos": 604,
+                "endFilePos": 1425
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 604,
+                  "startFilePos": 1419,
+                  "endLine": 33,
+                  "endTokenPos": 604,
+                  "endFilePos": 1425
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_conditional_sum.php.json
+++ b/tests/json-ast/x/php/group_by_conditional_sum.php.json
@@ -1,0 +1,2880 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 74,
+        "endFilePos": 150
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 73,
+          "endFilePos": 149
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 11
+          },
+          "name": "items"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 15,
+            "endLine": 2,
+            "endTokenPos": 73,
+            "endFilePos": 149,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 26,
+                "endFilePos": 58
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 16,
+                  "endLine": 2,
+                  "endTokenPos": 26,
+                  "endFilePos": 58,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 17,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 28
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 17,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 21,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 26,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 28,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 31,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 41
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 31,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 35,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 40,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 41,
+                        "rawValue": "10",
+                        "kind": 10
+                      },
+                      "value": 10
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 44,
+                      "endLine": 2,
+                      "endTokenPos": 25,
+                      "endFilePos": 57
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 21,
+                        "startFilePos": 44,
+                        "endLine": 2,
+                        "endTokenPos": 21,
+                        "endFilePos": 49,
+                        "kind": 2,
+                        "rawValue": "\"flag\""
+                      },
+                      "value": "flag"
+                    },
+                    "value": {
+                      "nodeType": "Expr_ConstFetch",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 54,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 57
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 25,
+                          "startFilePos": 54,
+                          "endLine": 2,
+                          "endTokenPos": 25,
+                          "endFilePos": 57
+                        },
+                        "name": "true"
+                      }
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 29,
+                "startFilePos": 61,
+                "endLine": 2,
+                "endTokenPos": 49,
+                "endFilePos": 103
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 61,
+                  "endLine": 2,
+                  "endTokenPos": 49,
+                  "endFilePos": 103,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 62,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 73
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 62,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 71,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 73,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 37,
+                      "startFilePos": 76,
+                      "endLine": 2,
+                      "endTokenPos": 41,
+                      "endFilePos": 85
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 37,
+                        "startFilePos": 76,
+                        "endLine": 2,
+                        "endTokenPos": 37,
+                        "endFilePos": 80,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 41,
+                        "startFilePos": 85,
+                        "endLine": 2,
+                        "endTokenPos": 41,
+                        "endFilePos": 85,
+                        "rawValue": "5",
+                        "kind": 10
+                      },
+                      "value": 5
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 44,
+                      "startFilePos": 88,
+                      "endLine": 2,
+                      "endTokenPos": 48,
+                      "endFilePos": 102
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 44,
+                        "startFilePos": 88,
+                        "endLine": 2,
+                        "endTokenPos": 44,
+                        "endFilePos": 93,
+                        "kind": 2,
+                        "rawValue": "\"flag\""
+                      },
+                      "value": "flag"
+                    },
+                    "value": {
+                      "nodeType": "Expr_ConstFetch",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 48,
+                        "startFilePos": 98,
+                        "endLine": 2,
+                        "endTokenPos": 48,
+                        "endFilePos": 102
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 48,
+                          "startFilePos": 98,
+                          "endLine": 2,
+                          "endTokenPos": 48,
+                          "endFilePos": 102
+                        },
+                        "name": "false"
+                      }
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 52,
+                "startFilePos": 106,
+                "endLine": 2,
+                "endTokenPos": 72,
+                "endFilePos": 148
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 52,
+                  "startFilePos": 106,
+                  "endLine": 2,
+                  "endTokenPos": 72,
+                  "endFilePos": 148,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 53,
+                      "startFilePos": 107,
+                      "endLine": 2,
+                      "endTokenPos": 57,
+                      "endFilePos": 118
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 53,
+                        "startFilePos": 107,
+                        "endLine": 2,
+                        "endTokenPos": 53,
+                        "endFilePos": 111,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 57,
+                        "startFilePos": 116,
+                        "endLine": 2,
+                        "endTokenPos": 57,
+                        "endFilePos": 118,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 60,
+                      "startFilePos": 121,
+                      "endLine": 2,
+                      "endTokenPos": 64,
+                      "endFilePos": 131
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 60,
+                        "startFilePos": 121,
+                        "endLine": 2,
+                        "endTokenPos": 60,
+                        "endFilePos": 125,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 64,
+                        "startFilePos": 130,
+                        "endLine": 2,
+                        "endTokenPos": 64,
+                        "endFilePos": 131,
+                        "rawValue": "20",
+                        "kind": 10
+                      },
+                      "value": 20
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 67,
+                      "startFilePos": 134,
+                      "endLine": 2,
+                      "endTokenPos": 71,
+                      "endFilePos": 147
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 67,
+                        "startFilePos": 134,
+                        "endLine": 2,
+                        "endTokenPos": 67,
+                        "endFilePos": 139,
+                        "kind": 2,
+                        "rawValue": "\"flag\""
+                      },
+                      "value": "flag"
+                    },
+                    "value": {
+                      "nodeType": "Expr_ConstFetch",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 71,
+                        "startFilePos": 144,
+                        "endLine": 2,
+                        "endTokenPos": 71,
+                        "endFilePos": 147
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 71,
+                          "startFilePos": 144,
+                          "endLine": 2,
+                          "endTokenPos": 71,
+                          "endFilePos": 147
+                        },
+                        "name": "true"
+                      }
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 76,
+        "startFilePos": 152,
+        "endLine": 31,
+        "endTokenPos": 398,
+        "endFilePos": 860
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 76,
+          "startFilePos": 152,
+          "endLine": 31,
+          "endTokenPos": 397,
+          "endFilePos": 859
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 76,
+            "startFilePos": 152,
+            "endLine": 3,
+            "endTokenPos": 76,
+            "endFilePos": 158
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 80,
+            "startFilePos": 162,
+            "endLine": 31,
+            "endTokenPos": 397,
+            "endFilePos": 859
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 81,
+              "startFilePos": 163,
+              "endLine": 31,
+              "endTokenPos": 394,
+              "endFilePos": 856
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 88,
+                  "startFilePos": 179,
+                  "endLine": 3,
+                  "endTokenPos": 88,
+                  "endFilePos": 184
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 88,
+                    "startFilePos": 179,
+                    "endLine": 3,
+                    "endTokenPos": 88,
+                    "endFilePos": 184
+                  },
+                  "name": "items"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 93,
+                  "startFilePos": 191,
+                  "endLine": 4,
+                  "endTokenPos": 99,
+                  "endFilePos": 203
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 93,
+                    "startFilePos": 191,
+                    "endLine": 4,
+                    "endTokenPos": 98,
+                    "endFilePos": 202
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 93,
+                      "startFilePos": 191,
+                      "endLine": 4,
+                      "endTokenPos": 93,
+                      "endFilePos": 197
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 97,
+                      "startFilePos": 201,
+                      "endLine": 4,
+                      "endTokenPos": 98,
+                      "endFilePos": 202,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 101,
+                  "startFilePos": 207,
+                  "endLine": 12,
+                  "endTokenPos": 189,
+                  "endFilePos": 417
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 104,
+                    "startFilePos": 216,
+                    "endLine": 5,
+                    "endTokenPos": 104,
+                    "endFilePos": 221
+                  },
+                  "name": "items"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 108,
+                    "startFilePos": 226,
+                    "endLine": 5,
+                    "endTokenPos": 108,
+                    "endFilePos": 227
+                  },
+                  "name": "i"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 113,
+                      "startFilePos": 236,
+                      "endLine": 6,
+                      "endTokenPos": 121,
+                      "endFilePos": 252
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 113,
+                        "startFilePos": 236,
+                        "endLine": 6,
+                        "endTokenPos": 120,
+                        "endFilePos": 251
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 113,
+                          "startFilePos": 236,
+                          "endLine": 6,
+                          "endTokenPos": 113,
+                          "endFilePos": 239
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 117,
+                          "startFilePos": 243,
+                          "endLine": 6,
+                          "endTokenPos": 120,
+                          "endFilePos": 251
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 117,
+                            "startFilePos": 243,
+                            "endLine": 6,
+                            "endTokenPos": 117,
+                            "endFilePos": 244
+                          },
+                          "name": "i"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 119,
+                            "startFilePos": 246,
+                            "endLine": 6,
+                            "endTokenPos": 119,
+                            "endFilePos": 250,
+                            "kind": 2,
+                            "rawValue": "\"cat\""
+                          },
+                          "value": "cat"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 123,
+                      "startFilePos": 258,
+                      "endLine": 7,
+                      "endTokenPos": 131,
+                      "endFilePos": 280
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 123,
+                        "startFilePos": 258,
+                        "endLine": 7,
+                        "endTokenPos": 130,
+                        "endFilePos": 279
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 123,
+                          "startFilePos": 258,
+                          "endLine": 7,
+                          "endTokenPos": 123,
+                          "endFilePos": 259
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 127,
+                          "startFilePos": 263,
+                          "endLine": 7,
+                          "endTokenPos": 130,
+                          "endFilePos": 279
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 127,
+                            "startFilePos": 263,
+                            "endLine": 7,
+                            "endTokenPos": 127,
+                            "endFilePos": 273
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 129,
+                              "startFilePos": 275,
+                              "endLine": 7,
+                              "endTokenPos": 129,
+                              "endFilePos": 278
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 129,
+                                "startFilePos": 275,
+                                "endLine": 7,
+                                "endTokenPos": 129,
+                                "endFilePos": 278
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 133,
+                      "startFilePos": 286,
+                      "endLine": 10,
+                      "endTokenPos": 172,
+                      "endFilePos": 380
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 136,
+                        "startFilePos": 290,
+                        "endLine": 8,
+                        "endTokenPos": 143,
+                        "endFilePos": 319
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 137,
+                          "startFilePos": 291,
+                          "endLine": 8,
+                          "endTokenPos": 143,
+                          "endFilePos": 319
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 137,
+                            "startFilePos": 291,
+                            "endLine": 8,
+                            "endTokenPos": 137,
+                            "endFilePos": 306
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 139,
+                              "startFilePos": 308,
+                              "endLine": 8,
+                              "endTokenPos": 139,
+                              "endFilePos": 309
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 139,
+                                "startFilePos": 308,
+                                "endLine": 8,
+                                "endTokenPos": 139,
+                                "endFilePos": 309
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 142,
+                              "startFilePos": 312,
+                              "endLine": 8,
+                              "endTokenPos": 142,
+                              "endFilePos": 318
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 142,
+                                "startFilePos": 312,
+                                "endLine": 8,
+                                "endTokenPos": 142,
+                                "endFilePos": 318
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 148,
+                          "startFilePos": 330,
+                          "endLine": 9,
+                          "endTokenPos": 170,
+                          "endFilePos": 374
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 148,
+                            "startFilePos": 330,
+                            "endLine": 9,
+                            "endTokenPos": 169,
+                            "endFilePos": 373
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 148,
+                              "startFilePos": 330,
+                              "endLine": 9,
+                              "endTokenPos": 151,
+                              "endFilePos": 340
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 148,
+                                "startFilePos": 330,
+                                "endLine": 9,
+                                "endTokenPos": 148,
+                                "endFilePos": 336
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 150,
+                                "startFilePos": 338,
+                                "endLine": 9,
+                                "endTokenPos": 150,
+                                "endFilePos": 339
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 155,
+                              "startFilePos": 344,
+                              "endLine": 9,
+                              "endTokenPos": 169,
+                              "endFilePos": 373,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 156,
+                                  "startFilePos": 345,
+                                  "endLine": 9,
+                                  "endTokenPos": 160,
+                                  "endFilePos": 357
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 156,
+                                    "startFilePos": 345,
+                                    "endLine": 9,
+                                    "endTokenPos": 156,
+                                    "endFilePos": 349,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 160,
+                                    "startFilePos": 354,
+                                    "endLine": 9,
+                                    "endTokenPos": 160,
+                                    "endFilePos": 357
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 163,
+                                  "startFilePos": 360,
+                                  "endLine": 9,
+                                  "endTokenPos": 168,
+                                  "endFilePos": 372
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 163,
+                                    "startFilePos": 360,
+                                    "endLine": 9,
+                                    "endTokenPos": 163,
+                                    "endFilePos": 366,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 167,
+                                    "startFilePos": 371,
+                                    "endLine": 9,
+                                    "endTokenPos": 168,
+                                    "endFilePos": 372,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 174,
+                      "startFilePos": 386,
+                      "endLine": 11,
+                      "endTokenPos": 187,
+                      "endFilePos": 413
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 174,
+                        "startFilePos": 386,
+                        "endLine": 11,
+                        "endTokenPos": 186,
+                        "endFilePos": 412
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 174,
+                          "startFilePos": 386,
+                          "endLine": 11,
+                          "endTokenPos": 182,
+                          "endFilePos": 407
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 174,
+                            "startFilePos": 386,
+                            "endLine": 11,
+                            "endTokenPos": 180,
+                            "endFilePos": 405
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 174,
+                              "startFilePos": 386,
+                              "endLine": 11,
+                              "endTokenPos": 177,
+                              "endFilePos": 396
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 174,
+                                "startFilePos": 386,
+                                "endLine": 11,
+                                "endTokenPos": 174,
+                                "endFilePos": 392
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 176,
+                                "startFilePos": 394,
+                                "endLine": 11,
+                                "endTokenPos": 176,
+                                "endFilePos": 395
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 179,
+                              "startFilePos": 398,
+                              "endLine": 11,
+                              "endTokenPos": 179,
+                              "endFilePos": 404,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 186,
+                          "startFilePos": 411,
+                          "endLine": 11,
+                          "endTokenPos": 186,
+                          "endFilePos": 412
+                        },
+                        "name": "i"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 191,
+                  "startFilePos": 421,
+                  "endLine": 13,
+                  "endTokenPos": 195,
+                  "endFilePos": 435
+                },
+                "expr": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 191,
+                    "startFilePos": 421,
+                    "endLine": 13,
+                    "endTokenPos": 194,
+                    "endFilePos": 434
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 191,
+                      "startFilePos": 421,
+                      "endLine": 13,
+                      "endTokenPos": 191,
+                      "endFilePos": 425
+                    },
+                    "name": "ksort"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 193,
+                        "startFilePos": 427,
+                        "endLine": 13,
+                        "endTokenPos": 193,
+                        "endFilePos": 433
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 193,
+                          "startFilePos": 427,
+                          "endLine": 13,
+                          "endTokenPos": 193,
+                          "endFilePos": 433
+                        },
+                        "name": "groups"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 197,
+                  "startFilePos": 439,
+                  "endLine": 14,
+                  "endTokenPos": 203,
+                  "endFilePos": 451
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 197,
+                    "startFilePos": 439,
+                    "endLine": 14,
+                    "endTokenPos": 202,
+                    "endFilePos": 450
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 197,
+                      "startFilePos": 439,
+                      "endLine": 14,
+                      "endTokenPos": 197,
+                      "endFilePos": 445
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 201,
+                      "startFilePos": 449,
+                      "endLine": 14,
+                      "endTokenPos": 202,
+                      "endFilePos": 450,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 205,
+                  "startFilePos": 455,
+                  "endLine": 29,
+                  "endTokenPos": 387,
+                  "endFilePos": 836
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 208,
+                    "startFilePos": 464,
+                    "endLine": 15,
+                    "endTokenPos": 208,
+                    "endFilePos": 470
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 212,
+                    "startFilePos": 475,
+                    "endLine": 15,
+                    "endTokenPos": 212,
+                    "endFilePos": 476
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 217,
+                      "startFilePos": 487,
+                      "endLine": 28,
+                      "endTokenPos": 385,
+                      "endFilePos": 832
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 217,
+                        "startFilePos": 487,
+                        "endLine": 28,
+                        "endTokenPos": 384,
+                        "endFilePos": 831
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 217,
+                          "startFilePos": 487,
+                          "endLine": 16,
+                          "endTokenPos": 219,
+                          "endFilePos": 495
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 217,
+                            "startFilePos": 487,
+                            "endLine": 16,
+                            "endTokenPos": 217,
+                            "endFilePos": 493
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 223,
+                          "startFilePos": 499,
+                          "endLine": 28,
+                          "endTokenPos": 384,
+                          "endFilePos": 831,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 224,
+                              "startFilePos": 500,
+                              "endLine": 16,
+                              "endTokenPos": 231,
+                              "endFilePos": 517
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 224,
+                                "startFilePos": 500,
+                                "endLine": 16,
+                                "endTokenPos": 224,
+                                "endFilePos": 504,
+                                "kind": 2,
+                                "rawValue": "\"cat\""
+                              },
+                              "value": "cat"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 228,
+                                "startFilePos": 509,
+                                "endLine": 16,
+                                "endTokenPos": 231,
+                                "endFilePos": 517
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 228,
+                                  "startFilePos": 509,
+                                  "endLine": 16,
+                                  "endTokenPos": 228,
+                                  "endFilePos": 510
+                                },
+                                "name": "g"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 230,
+                                  "startFilePos": 512,
+                                  "endLine": 16,
+                                  "endTokenPos": 230,
+                                  "endFilePos": 516,
+                                  "kind": 2,
+                                  "rawValue": "\"key\""
+                                },
+                                "value": "key"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 234,
+                              "startFilePos": 520,
+                              "endLine": 28,
+                              "endTokenPos": 383,
+                              "endFilePos": 830
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 234,
+                                "startFilePos": 520,
+                                "endLine": 16,
+                                "endTokenPos": 234,
+                                "endFilePos": 526,
+                                "kind": 2,
+                                "rawValue": "\"share\""
+                              },
+                              "value": "share"
+                            },
+                            "value": {
+                              "nodeType": "Expr_BinaryOp_Div",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 238,
+                                "startFilePos": 531,
+                                "endLine": 28,
+                                "endTokenPos": 383,
+                                "endFilePos": 830
+                              },
+                              "left": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 238,
+                                  "startFilePos": 531,
+                                  "endLine": 22,
+                                  "endTokenPos": 315,
+                                  "endFilePos": 688
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 238,
+                                    "startFilePos": 531,
+                                    "endLine": 16,
+                                    "endTokenPos": 238,
+                                    "endFilePos": 539
+                                  },
+                                  "name": "array_sum"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 16,
+                                      "startTokenPos": 240,
+                                      "startFilePos": 541,
+                                      "endLine": 22,
+                                      "endTokenPos": 314,
+                                      "endFilePos": 687
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 16,
+                                        "startTokenPos": 240,
+                                        "startFilePos": 541,
+                                        "endLine": 22,
+                                        "endTokenPos": 314,
+                                        "endFilePos": 687
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 16,
+                                          "startTokenPos": 241,
+                                          "startFilePos": 542,
+                                          "endLine": 22,
+                                          "endTokenPos": 311,
+                                          "endFilePos": 684
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 16,
+                                              "startTokenPos": 248,
+                                              "startFilePos": 558,
+                                              "endLine": 16,
+                                              "endTokenPos": 248,
+                                              "endFilePos": 559
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 16,
+                                                "startTokenPos": 248,
+                                                "startFilePos": 558,
+                                                "endLine": 16,
+                                                "endTokenPos": 248,
+                                                "endFilePos": 559
+                                              },
+                                              "name": "i"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 16,
+                                              "startTokenPos": 251,
+                                              "startFilePos": 562,
+                                              "endLine": 16,
+                                              "endTokenPos": 251,
+                                              "endFilePos": 563
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 16,
+                                                "startTokenPos": 251,
+                                                "startFilePos": 562,
+                                                "endLine": 16,
+                                                "endTokenPos": 251,
+                                                "endFilePos": 563
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 17,
+                                              "startTokenPos": 256,
+                                              "startFilePos": 570,
+                                              "endLine": 17,
+                                              "endTokenPos": 262,
+                                              "endFilePos": 582
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 256,
+                                                "startFilePos": 570,
+                                                "endLine": 17,
+                                                "endTokenPos": 261,
+                                                "endFilePos": 581
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 256,
+                                                  "startFilePos": 570,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 256,
+                                                  "endFilePos": 576
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 260,
+                                                  "startFilePos": 580,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 261,
+                                                  "endFilePos": 581,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 18,
+                                              "startTokenPos": 264,
+                                              "startFilePos": 586,
+                                              "endLine": 20,
+                                              "endTokenPos": 304,
+                                              "endFilePos": 664
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 18,
+                                                "startTokenPos": 267,
+                                                "startFilePos": 595,
+                                                "endLine": 18,
+                                                "endTokenPos": 270,
+                                                "endFilePos": 605
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 267,
+                                                  "startFilePos": 595,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 267,
+                                                  "endFilePos": 596
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 269,
+                                                  "startFilePos": 598,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 269,
+                                                  "endFilePos": 604,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 18,
+                                                "startTokenPos": 274,
+                                                "startFilePos": 610,
+                                                "endLine": 18,
+                                                "endTokenPos": 274,
+                                                "endFilePos": 611
+                                              },
+                                              "name": "x"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 19,
+                                                  "startTokenPos": 279,
+                                                  "startFilePos": 620,
+                                                  "endLine": 19,
+                                                  "endTokenPos": 302,
+                                                  "endFilePos": 660
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 19,
+                                                    "startTokenPos": 279,
+                                                    "startFilePos": 620,
+                                                    "endLine": 19,
+                                                    "endTokenPos": 301,
+                                                    "endFilePos": 659
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 19,
+                                                      "startTokenPos": 279,
+                                                      "startFilePos": 620,
+                                                      "endLine": 19,
+                                                      "endTokenPos": 281,
+                                                      "endFilePos": 628
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 19,
+                                                        "startTokenPos": 279,
+                                                        "startFilePos": 620,
+                                                        "endLine": 19,
+                                                        "endTokenPos": 279,
+                                                        "endFilePos": 626
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_Ternary",
+                                                    "attributes": {
+                                                      "startLine": 19,
+                                                      "startTokenPos": 286,
+                                                      "startFilePos": 633,
+                                                      "endLine": 19,
+                                                      "endTokenPos": 300,
+                                                      "endFilePos": 658
+                                                    },
+                                                    "cond": {
+                                                      "nodeType": "Expr_ArrayDimFetch",
+                                                      "attributes": {
+                                                        "startLine": 19,
+                                                        "startTokenPos": 286,
+                                                        "startFilePos": 633,
+                                                        "endLine": 19,
+                                                        "endTokenPos": 289,
+                                                        "endFilePos": 642
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_Variable",
+                                                        "attributes": {
+                                                          "startLine": 19,
+                                                          "startTokenPos": 286,
+                                                          "startFilePos": 633,
+                                                          "endLine": 19,
+                                                          "endTokenPos": 286,
+                                                          "endFilePos": 634
+                                                        },
+                                                        "name": "x"
+                                                      },
+                                                      "dim": {
+                                                        "nodeType": "Scalar_String",
+                                                        "attributes": {
+                                                          "startLine": 19,
+                                                          "startTokenPos": 288,
+                                                          "startFilePos": 636,
+                                                          "endLine": 19,
+                                                          "endTokenPos": 288,
+                                                          "endFilePos": 641,
+                                                          "kind": 2,
+                                                          "rawValue": "\"flag\""
+                                                        },
+                                                        "value": "flag"
+                                                      }
+                                                    },
+                                                    "if": {
+                                                      "nodeType": "Expr_ArrayDimFetch",
+                                                      "attributes": {
+                                                        "startLine": 19,
+                                                        "startTokenPos": 293,
+                                                        "startFilePos": 646,
+                                                        "endLine": 19,
+                                                        "endTokenPos": 296,
+                                                        "endFilePos": 654
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_Variable",
+                                                        "attributes": {
+                                                          "startLine": 19,
+                                                          "startTokenPos": 293,
+                                                          "startFilePos": 646,
+                                                          "endLine": 19,
+                                                          "endTokenPos": 293,
+                                                          "endFilePos": 647
+                                                        },
+                                                        "name": "x"
+                                                      },
+                                                      "dim": {
+                                                        "nodeType": "Scalar_String",
+                                                        "attributes": {
+                                                          "startLine": 19,
+                                                          "startTokenPos": 295,
+                                                          "startFilePos": 649,
+                                                          "endLine": 19,
+                                                          "endTokenPos": 295,
+                                                          "endFilePos": 653,
+                                                          "kind": 2,
+                                                          "rawValue": "\"val\""
+                                                        },
+                                                        "value": "val"
+                                                      }
+                                                    },
+                                                    "else": {
+                                                      "nodeType": "Scalar_Int",
+                                                      "attributes": {
+                                                        "startLine": 19,
+                                                        "startTokenPos": 300,
+                                                        "startFilePos": 658,
+                                                        "endLine": 19,
+                                                        "endTokenPos": 300,
+                                                        "endFilePos": 658,
+                                                        "rawValue": "0",
+                                                        "kind": 10
+                                                      },
+                                                      "value": 0
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 21,
+                                              "startTokenPos": 306,
+                                              "startFilePos": 668,
+                                              "endLine": 21,
+                                              "endTokenPos": 309,
+                                              "endFilePos": 682
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 21,
+                                                "startTokenPos": 308,
+                                                "startFilePos": 675,
+                                                "endLine": 21,
+                                                "endTokenPos": 308,
+                                                "endFilePos": 681
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              },
+                              "right": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 319,
+                                  "startFilePos": 692,
+                                  "endLine": 28,
+                                  "endTokenPos": 383,
+                                  "endFilePos": 830
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 319,
+                                    "startFilePos": 692,
+                                    "endLine": 22,
+                                    "endTokenPos": 319,
+                                    "endFilePos": 700
+                                  },
+                                  "name": "array_sum"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 22,
+                                      "startTokenPos": 321,
+                                      "startFilePos": 702,
+                                      "endLine": 28,
+                                      "endTokenPos": 382,
+                                      "endFilePos": 829
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 22,
+                                        "startTokenPos": 321,
+                                        "startFilePos": 702,
+                                        "endLine": 28,
+                                        "endTokenPos": 382,
+                                        "endFilePos": 829
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 22,
+                                          "startTokenPos": 322,
+                                          "startFilePos": 703,
+                                          "endLine": 28,
+                                          "endTokenPos": 379,
+                                          "endFilePos": 826
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 22,
+                                              "startTokenPos": 329,
+                                              "startFilePos": 719,
+                                              "endLine": 22,
+                                              "endTokenPos": 329,
+                                              "endFilePos": 720
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 22,
+                                                "startTokenPos": 329,
+                                                "startFilePos": 719,
+                                                "endLine": 22,
+                                                "endTokenPos": 329,
+                                                "endFilePos": 720
+                                              },
+                                              "name": "i"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 22,
+                                              "startTokenPos": 332,
+                                              "startFilePos": 723,
+                                              "endLine": 22,
+                                              "endTokenPos": 332,
+                                              "endFilePos": 724
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 22,
+                                                "startTokenPos": 332,
+                                                "startFilePos": 723,
+                                                "endLine": 22,
+                                                "endTokenPos": 332,
+                                                "endFilePos": 724
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 23,
+                                              "startTokenPos": 337,
+                                              "startFilePos": 731,
+                                              "endLine": 23,
+                                              "endTokenPos": 343,
+                                              "endFilePos": 743
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 337,
+                                                "startFilePos": 731,
+                                                "endLine": 23,
+                                                "endTokenPos": 342,
+                                                "endFilePos": 742
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 23,
+                                                  "startTokenPos": 337,
+                                                  "startFilePos": 731,
+                                                  "endLine": 23,
+                                                  "endTokenPos": 337,
+                                                  "endFilePos": 737
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 23,
+                                                  "startTokenPos": 341,
+                                                  "startFilePos": 741,
+                                                  "endLine": 23,
+                                                  "endTokenPos": 342,
+                                                  "endFilePos": 742,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 24,
+                                              "startTokenPos": 345,
+                                              "startFilePos": 747,
+                                              "endLine": 26,
+                                              "endTokenPos": 372,
+                                              "endFilePos": 806
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 24,
+                                                "startTokenPos": 348,
+                                                "startFilePos": 756,
+                                                "endLine": 24,
+                                                "endTokenPos": 351,
+                                                "endFilePos": 766
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 24,
+                                                  "startTokenPos": 348,
+                                                  "startFilePos": 756,
+                                                  "endLine": 24,
+                                                  "endTokenPos": 348,
+                                                  "endFilePos": 757
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 24,
+                                                  "startTokenPos": 350,
+                                                  "startFilePos": 759,
+                                                  "endLine": 24,
+                                                  "endTokenPos": 350,
+                                                  "endFilePos": 765,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 24,
+                                                "startTokenPos": 355,
+                                                "startFilePos": 771,
+                                                "endLine": 24,
+                                                "endTokenPos": 355,
+                                                "endFilePos": 772
+                                              },
+                                              "name": "x"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 25,
+                                                  "startTokenPos": 360,
+                                                  "startFilePos": 781,
+                                                  "endLine": 25,
+                                                  "endTokenPos": 370,
+                                                  "endFilePos": 802
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 25,
+                                                    "startTokenPos": 360,
+                                                    "startFilePos": 781,
+                                                    "endLine": 25,
+                                                    "endTokenPos": 369,
+                                                    "endFilePos": 801
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 25,
+                                                      "startTokenPos": 360,
+                                                      "startFilePos": 781,
+                                                      "endLine": 25,
+                                                      "endTokenPos": 362,
+                                                      "endFilePos": 789
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 25,
+                                                        "startTokenPos": 360,
+                                                        "startFilePos": 781,
+                                                        "endLine": 25,
+                                                        "endTokenPos": 360,
+                                                        "endFilePos": 787
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 25,
+                                                      "startTokenPos": 366,
+                                                      "startFilePos": 793,
+                                                      "endLine": 25,
+                                                      "endTokenPos": 369,
+                                                      "endFilePos": 801
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 25,
+                                                        "startTokenPos": 366,
+                                                        "startFilePos": 793,
+                                                        "endLine": 25,
+                                                        "endTokenPos": 366,
+                                                        "endFilePos": 794
+                                                      },
+                                                      "name": "x"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 25,
+                                                        "startTokenPos": 368,
+                                                        "startFilePos": 796,
+                                                        "endLine": 25,
+                                                        "endTokenPos": 368,
+                                                        "endFilePos": 800,
+                                                        "kind": 2,
+                                                        "rawValue": "\"val\""
+                                                      },
+                                                      "value": "val"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 27,
+                                              "startTokenPos": 374,
+                                              "startFilePos": 810,
+                                              "endLine": 27,
+                                              "endTokenPos": 377,
+                                              "endFilePos": 824
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 27,
+                                                "startTokenPos": 376,
+                                                "startFilePos": 817,
+                                                "endLine": 27,
+                                                "endTokenPos": 376,
+                                                "endFilePos": 823
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 30,
+                  "startTokenPos": 389,
+                  "startFilePos": 840,
+                  "endLine": 30,
+                  "endTokenPos": 392,
+                  "endFilePos": 854
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 30,
+                    "startTokenPos": 391,
+                    "startFilePos": 847,
+                    "endLine": 30,
+                    "endTokenPos": 391,
+                    "endFilePos": 853
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 32,
+        "startTokenPos": 400,
+        "startFilePos": 862,
+        "endLine": 32,
+        "endTokenPos": 457,
+        "endFilePos": 1034
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 402,
+            "startFilePos": 867,
+            "endLine": 32,
+            "endTokenPos": 453,
+            "endFilePos": 1024
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 402,
+              "startFilePos": 867,
+              "endLine": 32,
+              "endTokenPos": 402,
+              "endFilePos": 877
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 404,
+                "startFilePos": 879,
+                "endLine": 32,
+                "endTokenPos": 404,
+                "endFilePos": 885
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 404,
+                  "startFilePos": 879,
+                  "endLine": 32,
+                  "endTokenPos": 404,
+                  "endFilePos": 885,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 407,
+                "startFilePos": 888,
+                "endLine": 32,
+                "endTokenPos": 407,
+                "endFilePos": 894
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 407,
+                  "startFilePos": 888,
+                  "endLine": 32,
+                  "endTokenPos": 407,
+                  "endFilePos": 894,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 410,
+                "startFilePos": 897,
+                "endLine": 32,
+                "endTokenPos": 452,
+                "endFilePos": 1023
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 410,
+                  "startFilePos": 897,
+                  "endLine": 32,
+                  "endTokenPos": 452,
+                  "endFilePos": 1023
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 32,
+                    "startTokenPos": 410,
+                    "startFilePos": 897,
+                    "endLine": 32,
+                    "endTokenPos": 410,
+                    "endFilePos": 907
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 412,
+                      "startFilePos": 909,
+                      "endLine": 32,
+                      "endTokenPos": 412,
+                      "endFilePos": 914
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 412,
+                        "startFilePos": 909,
+                        "endLine": 32,
+                        "endTokenPos": 412,
+                        "endFilePos": 914,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 415,
+                      "startFilePos": 917,
+                      "endLine": 32,
+                      "endTokenPos": 415,
+                      "endFilePos": 922
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 415,
+                        "startFilePos": 917,
+                        "endLine": 32,
+                        "endTokenPos": 415,
+                        "endFilePos": 922,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 418,
+                      "startFilePos": 925,
+                      "endLine": 32,
+                      "endTokenPos": 451,
+                      "endFilePos": 1022
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 418,
+                        "startFilePos": 925,
+                        "endLine": 32,
+                        "endTokenPos": 451,
+                        "endFilePos": 1022
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 32,
+                          "startTokenPos": 418,
+                          "startFilePos": 925,
+                          "endLine": 32,
+                          "endTokenPos": 418,
+                          "endFilePos": 935
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 32,
+                            "startTokenPos": 420,
+                            "startFilePos": 937,
+                            "endLine": 32,
+                            "endTokenPos": 420,
+                            "endFilePos": 940
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 32,
+                              "startTokenPos": 420,
+                              "startFilePos": 937,
+                              "endLine": 32,
+                              "endTokenPos": 420,
+                              "endFilePos": 940,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 32,
+                            "startTokenPos": 423,
+                            "startFilePos": 943,
+                            "endLine": 32,
+                            "endTokenPos": 423,
+                            "endFilePos": 945
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 32,
+                              "startTokenPos": 423,
+                              "startFilePos": 943,
+                              "endLine": 32,
+                              "endTokenPos": 423,
+                              "endFilePos": 945,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 32,
+                            "startTokenPos": 426,
+                            "startFilePos": 948,
+                            "endLine": 32,
+                            "endTokenPos": 450,
+                            "endFilePos": 1021
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 32,
+                              "startTokenPos": 426,
+                              "startFilePos": 948,
+                              "endLine": 32,
+                              "endTokenPos": 450,
+                              "endFilePos": 1021
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 32,
+                                "startTokenPos": 426,
+                                "startFilePos": 948,
+                                "endLine": 32,
+                                "endTokenPos": 426,
+                                "endFilePos": 958
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 32,
+                                  "startTokenPos": 428,
+                                  "startFilePos": 960,
+                                  "endLine": 32,
+                                  "endTokenPos": 428,
+                                  "endFilePos": 962
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 32,
+                                    "startTokenPos": 428,
+                                    "startFilePos": 960,
+                                    "endLine": 32,
+                                    "endTokenPos": 428,
+                                    "endFilePos": 962,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 32,
+                                  "startTokenPos": 431,
+                                  "startFilePos": 965,
+                                  "endLine": 32,
+                                  "endTokenPos": 431,
+                                  "endFilePos": 968
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 32,
+                                    "startTokenPos": 431,
+                                    "startFilePos": 965,
+                                    "endLine": 32,
+                                    "endTokenPos": 431,
+                                    "endFilePos": 968,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 32,
+                                  "startTokenPos": 434,
+                                  "startFilePos": 971,
+                                  "endLine": 32,
+                                  "endTokenPos": 449,
+                                  "endFilePos": 1020
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 32,
+                                    "startTokenPos": 434,
+                                    "startFilePos": 971,
+                                    "endLine": 32,
+                                    "endTokenPos": 449,
+                                    "endFilePos": 1020
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 32,
+                                      "startTokenPos": 434,
+                                      "startFilePos": 971,
+                                      "endLine": 32,
+                                      "endTokenPos": 434,
+                                      "endFilePos": 981
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 32,
+                                        "startTokenPos": 436,
+                                        "startFilePos": 983,
+                                        "endLine": 32,
+                                        "endTokenPos": 436,
+                                        "endFilePos": 985
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 32,
+                                          "startTokenPos": 436,
+                                          "startFilePos": 983,
+                                          "endLine": 32,
+                                          "endTokenPos": 436,
+                                          "endFilePos": 985,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 32,
+                                        "startTokenPos": 439,
+                                        "startFilePos": 988,
+                                        "endLine": 32,
+                                        "endTokenPos": 439,
+                                        "endFilePos": 991
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 32,
+                                          "startTokenPos": 439,
+                                          "startFilePos": 988,
+                                          "endLine": 32,
+                                          "endTokenPos": 439,
+                                          "endFilePos": 991,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 32,
+                                        "startTokenPos": 442,
+                                        "startFilePos": 994,
+                                        "endLine": 32,
+                                        "endTokenPos": 448,
+                                        "endFilePos": 1019
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 32,
+                                          "startTokenPos": 442,
+                                          "startFilePos": 994,
+                                          "endLine": 32,
+                                          "endTokenPos": 448,
+                                          "endFilePos": 1019
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 32,
+                                            "startTokenPos": 442,
+                                            "startFilePos": 994,
+                                            "endLine": 32,
+                                            "endTokenPos": 442,
+                                            "endFilePos": 1004
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 32,
+                                              "startTokenPos": 444,
+                                              "startFilePos": 1006,
+                                              "endLine": 32,
+                                              "endTokenPos": 444,
+                                              "endFilePos": 1012
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 32,
+                                                "startTokenPos": 444,
+                                                "startFilePos": 1006,
+                                                "endLine": 32,
+                                                "endTokenPos": 444,
+                                                "endFilePos": 1012
+                                              },
+                                              "name": "result"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 32,
+                                              "startTokenPos": 447,
+                                              "startFilePos": 1015,
+                                              "endLine": 32,
+                                              "endTokenPos": 447,
+                                              "endFilePos": 1018
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 32,
+                                                "startTokenPos": 447,
+                                                "startFilePos": 1015,
+                                                "endLine": 32,
+                                                "endTokenPos": 447,
+                                                "endFilePos": 1018,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 456,
+            "startFilePos": 1027,
+            "endLine": 32,
+            "endTokenPos": 456,
+            "endFilePos": 1033
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 456,
+              "startFilePos": 1027,
+              "endLine": 32,
+              "endTokenPos": 456,
+              "endFilePos": 1033
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_having.php.json
+++ b/tests/json-ast/x/php/group_by_having.php.json
@@ -1,0 +1,2175 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 117,
+        "endFilePos": 295
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 116,
+          "endFilePos": 294
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 116,
+            "endFilePos": 294,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 54
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 54,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 34
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 23,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 34,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 37,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 53
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 37,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 42,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 47,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 53,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 57,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 92
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 57,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 92,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 58,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 72
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 58,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 63,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 68,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 72,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 75,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 75,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 80,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 85,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 91,
+                        "kind": 2,
+                        "rawValue": "\"Hanoi\""
+                      },
+                      "value": "Hanoi"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 95,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 134
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 95,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 134,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 96,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 114
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 96,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 101,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 106,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 114,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 117,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 133
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 117,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 122,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 127,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 133,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 54,
+                "startFilePos": 137,
+                "endLine": 2,
+                "endTokenPos": 67,
+                "endFilePos": 174
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 54,
+                  "startFilePos": 137,
+                  "endLine": 2,
+                  "endTokenPos": 67,
+                  "endFilePos": 174,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 138,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 154
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 138,
+                        "endLine": 2,
+                        "endTokenPos": 55,
+                        "endFilePos": 143,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 59,
+                        "startFilePos": 148,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 154,
+                        "kind": 2,
+                        "rawValue": "\"Diana\""
+                      },
+                      "value": "Diana"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 62,
+                      "startFilePos": 157,
+                      "endLine": 2,
+                      "endTokenPos": 66,
+                      "endFilePos": 173
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 62,
+                        "startFilePos": 157,
+                        "endLine": 2,
+                        "endTokenPos": 62,
+                        "endFilePos": 162,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 66,
+                        "startFilePos": 167,
+                        "endLine": 2,
+                        "endTokenPos": 66,
+                        "endFilePos": 173,
+                        "kind": 2,
+                        "rawValue": "\"Hanoi\""
+                      },
+                      "value": "Hanoi"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 70,
+                "startFilePos": 177,
+                "endLine": 2,
+                "endTokenPos": 83,
+                "endFilePos": 212
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 70,
+                  "startFilePos": 177,
+                  "endLine": 2,
+                  "endTokenPos": 83,
+                  "endFilePos": 212,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 71,
+                      "startFilePos": 178,
+                      "endLine": 2,
+                      "endTokenPos": 75,
+                      "endFilePos": 192
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 71,
+                        "startFilePos": 178,
+                        "endLine": 2,
+                        "endTokenPos": 71,
+                        "endFilePos": 183,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 75,
+                        "startFilePos": 188,
+                        "endLine": 2,
+                        "endTokenPos": 75,
+                        "endFilePos": 192,
+                        "kind": 2,
+                        "rawValue": "\"Eve\""
+                      },
+                      "value": "Eve"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 78,
+                      "startFilePos": 195,
+                      "endLine": 2,
+                      "endTokenPos": 82,
+                      "endFilePos": 211
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 78,
+                        "startFilePos": 195,
+                        "endLine": 2,
+                        "endTokenPos": 78,
+                        "endFilePos": 200,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 82,
+                        "startFilePos": 205,
+                        "endLine": 2,
+                        "endTokenPos": 82,
+                        "endFilePos": 211,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 86,
+                "startFilePos": 215,
+                "endLine": 2,
+                "endTokenPos": 99,
+                "endFilePos": 252
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 86,
+                  "startFilePos": 215,
+                  "endLine": 2,
+                  "endTokenPos": 99,
+                  "endFilePos": 252,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 87,
+                      "startFilePos": 216,
+                      "endLine": 2,
+                      "endTokenPos": 91,
+                      "endFilePos": 232
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 87,
+                        "startFilePos": 216,
+                        "endLine": 2,
+                        "endTokenPos": 87,
+                        "endFilePos": 221,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 91,
+                        "startFilePos": 226,
+                        "endLine": 2,
+                        "endTokenPos": 91,
+                        "endFilePos": 232,
+                        "kind": 2,
+                        "rawValue": "\"Frank\""
+                      },
+                      "value": "Frank"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 94,
+                      "startFilePos": 235,
+                      "endLine": 2,
+                      "endTokenPos": 98,
+                      "endFilePos": 251
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 94,
+                        "startFilePos": 235,
+                        "endLine": 2,
+                        "endTokenPos": 94,
+                        "endFilePos": 240,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 98,
+                        "startFilePos": 245,
+                        "endLine": 2,
+                        "endTokenPos": 98,
+                        "endFilePos": 251,
+                        "kind": 2,
+                        "rawValue": "\"Hanoi\""
+                      },
+                      "value": "Hanoi"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 102,
+                "startFilePos": 255,
+                "endLine": 2,
+                "endTokenPos": 115,
+                "endFilePos": 293
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 102,
+                  "startFilePos": 255,
+                  "endLine": 2,
+                  "endTokenPos": 115,
+                  "endFilePos": 293,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 103,
+                      "startFilePos": 256,
+                      "endLine": 2,
+                      "endTokenPos": 107,
+                      "endFilePos": 273
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 103,
+                        "startFilePos": 256,
+                        "endLine": 2,
+                        "endTokenPos": 103,
+                        "endFilePos": 261,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 107,
+                        "startFilePos": 266,
+                        "endLine": 2,
+                        "endTokenPos": 107,
+                        "endFilePos": 273,
+                        "kind": 2,
+                        "rawValue": "\"George\""
+                      },
+                      "value": "George"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 110,
+                      "startFilePos": 276,
+                      "endLine": 2,
+                      "endTokenPos": 114,
+                      "endFilePos": 292
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 110,
+                        "startFilePos": 276,
+                        "endLine": 2,
+                        "endTokenPos": 110,
+                        "endFilePos": 281,
+                        "kind": 2,
+                        "rawValue": "\"city\""
+                      },
+                      "value": "city"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 114,
+                        "startFilePos": 286,
+                        "endLine": 2,
+                        "endTokenPos": 114,
+                        "endFilePos": 292,
+                        "kind": 2,
+                        "rawValue": "\"Paris\""
+                      },
+                      "value": "Paris"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 119,
+        "startFilePos": 297,
+        "endLine": 20,
+        "endTokenPos": 316,
+        "endFilePos": 745
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 119,
+          "startFilePos": 297,
+          "endLine": 20,
+          "endTokenPos": 315,
+          "endFilePos": 744
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 119,
+            "startFilePos": 297,
+            "endLine": 3,
+            "endTokenPos": 119,
+            "endFilePos": 300
+          },
+          "name": "big"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 123,
+            "startFilePos": 304,
+            "endLine": 20,
+            "endTokenPos": 315,
+            "endFilePos": 744
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 124,
+              "startFilePos": 305,
+              "endLine": 20,
+              "endTokenPos": 312,
+              "endFilePos": 741
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 131,
+                  "startFilePos": 321,
+                  "endLine": 3,
+                  "endTokenPos": 131,
+                  "endFilePos": 327
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 131,
+                    "startFilePos": 321,
+                    "endLine": 3,
+                    "endTokenPos": 131,
+                    "endFilePos": 327
+                  },
+                  "name": "people"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 136,
+                  "startFilePos": 334,
+                  "endLine": 4,
+                  "endTokenPos": 142,
+                  "endFilePos": 346
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 136,
+                    "startFilePos": 334,
+                    "endLine": 4,
+                    "endTokenPos": 141,
+                    "endFilePos": 345
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 136,
+                      "startFilePos": 334,
+                      "endLine": 4,
+                      "endTokenPos": 136,
+                      "endFilePos": 340
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 140,
+                      "startFilePos": 344,
+                      "endLine": 4,
+                      "endTokenPos": 141,
+                      "endFilePos": 345,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 144,
+                  "startFilePos": 350,
+                  "endLine": 12,
+                  "endTokenPos": 232,
+                  "endFilePos": 562
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 147,
+                    "startFilePos": 359,
+                    "endLine": 5,
+                    "endTokenPos": 147,
+                    "endFilePos": 365
+                  },
+                  "name": "people"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 151,
+                    "startFilePos": 370,
+                    "endLine": 5,
+                    "endTokenPos": 151,
+                    "endFilePos": 371
+                  },
+                  "name": "p"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 156,
+                      "startFilePos": 380,
+                      "endLine": 6,
+                      "endTokenPos": 164,
+                      "endFilePos": 397
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 156,
+                        "startFilePos": 380,
+                        "endLine": 6,
+                        "endTokenPos": 163,
+                        "endFilePos": 396
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 156,
+                          "startFilePos": 380,
+                          "endLine": 6,
+                          "endTokenPos": 156,
+                          "endFilePos": 383
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 160,
+                          "startFilePos": 387,
+                          "endLine": 6,
+                          "endTokenPos": 163,
+                          "endFilePos": 396
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 160,
+                            "startFilePos": 387,
+                            "endLine": 6,
+                            "endTokenPos": 160,
+                            "endFilePos": 388
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 162,
+                            "startFilePos": 390,
+                            "endLine": 6,
+                            "endTokenPos": 162,
+                            "endFilePos": 395,
+                            "kind": 2,
+                            "rawValue": "\"city\""
+                          },
+                          "value": "city"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 166,
+                      "startFilePos": 403,
+                      "endLine": 7,
+                      "endTokenPos": 174,
+                      "endFilePos": 425
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 166,
+                        "startFilePos": 403,
+                        "endLine": 7,
+                        "endTokenPos": 173,
+                        "endFilePos": 424
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 166,
+                          "startFilePos": 403,
+                          "endLine": 7,
+                          "endTokenPos": 166,
+                          "endFilePos": 404
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 170,
+                          "startFilePos": 408,
+                          "endLine": 7,
+                          "endTokenPos": 173,
+                          "endFilePos": 424
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 170,
+                            "startFilePos": 408,
+                            "endLine": 7,
+                            "endTokenPos": 170,
+                            "endFilePos": 418
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 172,
+                              "startFilePos": 420,
+                              "endLine": 7,
+                              "endTokenPos": 172,
+                              "endFilePos": 423
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 172,
+                                "startFilePos": 420,
+                                "endLine": 7,
+                                "endTokenPos": 172,
+                                "endFilePos": 423
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 176,
+                      "startFilePos": 431,
+                      "endLine": 10,
+                      "endTokenPos": 215,
+                      "endFilePos": 525
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 179,
+                        "startFilePos": 435,
+                        "endLine": 8,
+                        "endTokenPos": 186,
+                        "endFilePos": 464
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 180,
+                          "startFilePos": 436,
+                          "endLine": 8,
+                          "endTokenPos": 186,
+                          "endFilePos": 464
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 180,
+                            "startFilePos": 436,
+                            "endLine": 8,
+                            "endTokenPos": 180,
+                            "endFilePos": 451
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 182,
+                              "startFilePos": 453,
+                              "endLine": 8,
+                              "endTokenPos": 182,
+                              "endFilePos": 454
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 182,
+                                "startFilePos": 453,
+                                "endLine": 8,
+                                "endTokenPos": 182,
+                                "endFilePos": 454
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 185,
+                              "startFilePos": 457,
+                              "endLine": 8,
+                              "endTokenPos": 185,
+                              "endFilePos": 463
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 185,
+                                "startFilePos": 457,
+                                "endLine": 8,
+                                "endTokenPos": 185,
+                                "endFilePos": 463
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 191,
+                          "startFilePos": 475,
+                          "endLine": 9,
+                          "endTokenPos": 213,
+                          "endFilePos": 519
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 191,
+                            "startFilePos": 475,
+                            "endLine": 9,
+                            "endTokenPos": 212,
+                            "endFilePos": 518
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 191,
+                              "startFilePos": 475,
+                              "endLine": 9,
+                              "endTokenPos": 194,
+                              "endFilePos": 485
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 191,
+                                "startFilePos": 475,
+                                "endLine": 9,
+                                "endTokenPos": 191,
+                                "endFilePos": 481
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 193,
+                                "startFilePos": 483,
+                                "endLine": 9,
+                                "endTokenPos": 193,
+                                "endFilePos": 484
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 198,
+                              "startFilePos": 489,
+                              "endLine": 9,
+                              "endTokenPos": 212,
+                              "endFilePos": 518,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 199,
+                                  "startFilePos": 490,
+                                  "endLine": 9,
+                                  "endTokenPos": 203,
+                                  "endFilePos": 502
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 199,
+                                    "startFilePos": 490,
+                                    "endLine": 9,
+                                    "endTokenPos": 199,
+                                    "endFilePos": 494,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 203,
+                                    "startFilePos": 499,
+                                    "endLine": 9,
+                                    "endTokenPos": 203,
+                                    "endFilePos": 502
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 206,
+                                  "startFilePos": 505,
+                                  "endLine": 9,
+                                  "endTokenPos": 211,
+                                  "endFilePos": 517
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 206,
+                                    "startFilePos": 505,
+                                    "endLine": 9,
+                                    "endTokenPos": 206,
+                                    "endFilePos": 511,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 210,
+                                    "startFilePos": 516,
+                                    "endLine": 9,
+                                    "endTokenPos": 211,
+                                    "endFilePos": 517,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 217,
+                      "startFilePos": 531,
+                      "endLine": 11,
+                      "endTokenPos": 230,
+                      "endFilePos": 558
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 217,
+                        "startFilePos": 531,
+                        "endLine": 11,
+                        "endTokenPos": 229,
+                        "endFilePos": 557
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 217,
+                          "startFilePos": 531,
+                          "endLine": 11,
+                          "endTokenPos": 225,
+                          "endFilePos": 552
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 217,
+                            "startFilePos": 531,
+                            "endLine": 11,
+                            "endTokenPos": 223,
+                            "endFilePos": 550
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 217,
+                              "startFilePos": 531,
+                              "endLine": 11,
+                              "endTokenPos": 220,
+                              "endFilePos": 541
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 217,
+                                "startFilePos": 531,
+                                "endLine": 11,
+                                "endTokenPos": 217,
+                                "endFilePos": 537
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 219,
+                                "startFilePos": 539,
+                                "endLine": 11,
+                                "endTokenPos": 219,
+                                "endFilePos": 540
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 222,
+                              "startFilePos": 543,
+                              "endLine": 11,
+                              "endTokenPos": 222,
+                              "endFilePos": 549,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 229,
+                          "startFilePos": 556,
+                          "endLine": 11,
+                          "endTokenPos": 229,
+                          "endFilePos": 557
+                        },
+                        "name": "p"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 234,
+                  "startFilePos": 566,
+                  "endLine": 13,
+                  "endTokenPos": 240,
+                  "endFilePos": 578
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 234,
+                    "startFilePos": 566,
+                    "endLine": 13,
+                    "endTokenPos": 239,
+                    "endFilePos": 577
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 234,
+                      "startFilePos": 566,
+                      "endLine": 13,
+                      "endTokenPos": 234,
+                      "endFilePos": 572
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 238,
+                      "startFilePos": 576,
+                      "endLine": 13,
+                      "endTokenPos": 239,
+                      "endFilePos": 577,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 242,
+                  "startFilePos": 582,
+                  "endLine": 18,
+                  "endTokenPos": 305,
+                  "endFilePos": 721
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 245,
+                    "startFilePos": 591,
+                    "endLine": 14,
+                    "endTokenPos": 245,
+                    "endFilePos": 597
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 249,
+                    "startFilePos": 602,
+                    "endLine": 14,
+                    "endTokenPos": 249,
+                    "endFilePos": 603
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 254,
+                      "startFilePos": 612,
+                      "endLine": 17,
+                      "endTokenPos": 303,
+                      "endFilePos": 717
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 257,
+                        "startFilePos": 616,
+                        "endLine": 15,
+                        "endTokenPos": 267,
+                        "endFilePos": 638
+                      },
+                      "left": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 257,
+                          "startFilePos": 616,
+                          "endLine": 15,
+                          "endTokenPos": 263,
+                          "endFilePos": 633
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 257,
+                            "startFilePos": 616,
+                            "endLine": 15,
+                            "endTokenPos": 257,
+                            "endFilePos": 620
+                          },
+                          "name": "count"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 259,
+                              "startFilePos": 622,
+                              "endLine": 15,
+                              "endTokenPos": 262,
+                              "endFilePos": 632
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 259,
+                                "startFilePos": 622,
+                                "endLine": 15,
+                                "endTokenPos": 262,
+                                "endFilePos": 632
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 259,
+                                  "startFilePos": 622,
+                                  "endLine": 15,
+                                  "endTokenPos": 259,
+                                  "endFilePos": 623
+                                },
+                                "name": "g"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 261,
+                                  "startFilePos": 625,
+                                  "endLine": 15,
+                                  "endTokenPos": 261,
+                                  "endFilePos": 631,
+                                  "kind": 2,
+                                  "rawValue": "\"items\""
+                                },
+                                "value": "items"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "right": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 267,
+                          "startFilePos": 638,
+                          "endLine": 15,
+                          "endTokenPos": 267,
+                          "endFilePos": 638,
+                          "rawValue": "4",
+                          "kind": 10
+                        },
+                        "value": 4
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 272,
+                          "startFilePos": 649,
+                          "endLine": 16,
+                          "endTokenPos": 301,
+                          "endFilePos": 711
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 272,
+                            "startFilePos": 649,
+                            "endLine": 16,
+                            "endTokenPos": 300,
+                            "endFilePos": 710
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 272,
+                              "startFilePos": 649,
+                              "endLine": 16,
+                              "endTokenPos": 274,
+                              "endFilePos": 657
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 272,
+                                "startFilePos": 649,
+                                "endLine": 16,
+                                "endTokenPos": 272,
+                                "endFilePos": 655
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 278,
+                              "startFilePos": 661,
+                              "endLine": 16,
+                              "endTokenPos": 300,
+                              "endFilePos": 710,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 279,
+                                  "startFilePos": 662,
+                                  "endLine": 16,
+                                  "endTokenPos": 286,
+                                  "endFilePos": 680
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 279,
+                                    "startFilePos": 662,
+                                    "endLine": 16,
+                                    "endTokenPos": 279,
+                                    "endFilePos": 667,
+                                    "kind": 2,
+                                    "rawValue": "\"city\""
+                                  },
+                                  "value": "city"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 283,
+                                    "startFilePos": 672,
+                                    "endLine": 16,
+                                    "endTokenPos": 286,
+                                    "endFilePos": 680
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 16,
+                                      "startTokenPos": 283,
+                                      "startFilePos": 672,
+                                      "endLine": 16,
+                                      "endTokenPos": 283,
+                                      "endFilePos": 673
+                                    },
+                                    "name": "g"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 16,
+                                      "startTokenPos": 285,
+                                      "startFilePos": 675,
+                                      "endLine": 16,
+                                      "endTokenPos": 285,
+                                      "endFilePos": 679,
+                                      "kind": 2,
+                                      "rawValue": "\"key\""
+                                    },
+                                    "value": "key"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 289,
+                                  "startFilePos": 683,
+                                  "endLine": 16,
+                                  "endTokenPos": 299,
+                                  "endFilePos": 709
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 289,
+                                    "startFilePos": 683,
+                                    "endLine": 16,
+                                    "endTokenPos": 289,
+                                    "endFilePos": 687,
+                                    "kind": 2,
+                                    "rawValue": "\"num\""
+                                  },
+                                  "value": "num"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 293,
+                                    "startFilePos": 692,
+                                    "endLine": 16,
+                                    "endTokenPos": 299,
+                                    "endFilePos": 709
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 16,
+                                      "startTokenPos": 293,
+                                      "startFilePos": 692,
+                                      "endLine": 16,
+                                      "endTokenPos": 293,
+                                      "endFilePos": 696
+                                    },
+                                    "name": "count"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 16,
+                                        "startTokenPos": 295,
+                                        "startFilePos": 698,
+                                        "endLine": 16,
+                                        "endTokenPos": 298,
+                                        "endFilePos": 708
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 16,
+                                          "startTokenPos": 295,
+                                          "startFilePos": 698,
+                                          "endLine": 16,
+                                          "endTokenPos": 298,
+                                          "endFilePos": 708
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 16,
+                                            "startTokenPos": 295,
+                                            "startFilePos": 698,
+                                            "endLine": 16,
+                                            "endTokenPos": 295,
+                                            "endFilePos": 699
+                                          },
+                                          "name": "g"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 16,
+                                            "startTokenPos": 297,
+                                            "startFilePos": 701,
+                                            "endLine": 16,
+                                            "endTokenPos": 297,
+                                            "endFilePos": 707,
+                                            "kind": 2,
+                                            "rawValue": "\"items\""
+                                          },
+                                          "value": "items"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 19,
+                  "startTokenPos": 307,
+                  "startFilePos": 725,
+                  "endLine": 19,
+                  "endTokenPos": 310,
+                  "endFilePos": 739
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 19,
+                    "startTokenPos": 309,
+                    "startFilePos": 732,
+                    "endLine": 19,
+                    "endTokenPos": 309,
+                    "endFilePos": 738
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 21,
+        "startTokenPos": 318,
+        "startFilePos": 747,
+        "endLine": 21,
+        "endTokenPos": 339,
+        "endFilePos": 810
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 21,
+            "startTokenPos": 320,
+            "startFilePos": 752,
+            "endLine": 21,
+            "endTokenPos": 335,
+            "endFilePos": 800
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 21,
+              "startTokenPos": 320,
+              "startFilePos": 752,
+              "endLine": 21,
+              "endTokenPos": 320,
+              "endFilePos": 762
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 21,
+                "startTokenPos": 322,
+                "startFilePos": 764,
+                "endLine": 21,
+                "endTokenPos": 322,
+                "endFilePos": 769
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 21,
+                  "startTokenPos": 322,
+                  "startFilePos": 764,
+                  "endLine": 21,
+                  "endTokenPos": 322,
+                  "endFilePos": 769,
+                  "kind": 2,
+                  "rawValue": "\"    \""
+                },
+                "value": "    "
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 21,
+                "startTokenPos": 325,
+                "startFilePos": 772,
+                "endLine": 21,
+                "endTokenPos": 325,
+                "endFilePos": 775
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 21,
+                  "startTokenPos": 325,
+                  "startFilePos": 772,
+                  "endLine": 21,
+                  "endTokenPos": 325,
+                  "endFilePos": 775,
+                  "kind": 2,
+                  "rawValue": "\"  \""
+                },
+                "value": "  "
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 21,
+                "startTokenPos": 328,
+                "startFilePos": 778,
+                "endLine": 21,
+                "endTokenPos": 334,
+                "endFilePos": 799
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 21,
+                  "startTokenPos": 328,
+                  "startFilePos": 778,
+                  "endLine": 21,
+                  "endTokenPos": 334,
+                  "endFilePos": 799
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 21,
+                    "startTokenPos": 328,
+                    "startFilePos": 778,
+                    "endLine": 21,
+                    "endTokenPos": 328,
+                    "endFilePos": 788
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 21,
+                      "startTokenPos": 330,
+                      "startFilePos": 790,
+                      "endLine": 21,
+                      "endTokenPos": 330,
+                      "endFilePos": 793
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 21,
+                        "startTokenPos": 330,
+                        "startFilePos": 790,
+                        "endLine": 21,
+                        "endTokenPos": 330,
+                        "endFilePos": 793
+                      },
+                      "name": "big"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 21,
+                      "startTokenPos": 333,
+                      "startFilePos": 796,
+                      "endLine": 21,
+                      "endTokenPos": 333,
+                      "endFilePos": 798
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 21,
+                        "startTokenPos": 333,
+                        "startFilePos": 796,
+                        "endLine": 21,
+                        "endTokenPos": 333,
+                        "endFilePos": 798,
+                        "rawValue": "128",
+                        "kind": 10
+                      },
+                      "value": 128
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 21,
+            "startTokenPos": 338,
+            "startFilePos": 803,
+            "endLine": 21,
+            "endTokenPos": 338,
+            "endFilePos": 809
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 21,
+              "startTokenPos": 338,
+              "startFilePos": 803,
+              "endLine": 21,
+              "endTokenPos": 338,
+              "endFilePos": 809
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_join.php.json
+++ b/tests/json-ast/x/php/group_by_join.php.json
@@ -1,0 +1,2587 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 37,
+        "endFilePos": 81
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 36,
+          "endFilePos": 80
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 36,
+            "endFilePos": 80,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 39,
+        "startFilePos": 83,
+        "endLine": 3,
+        "endTokenPos": 91,
+        "endFilePos": 195
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 39,
+          "startFilePos": 83,
+          "endLine": 3,
+          "endTokenPos": 90,
+          "endFilePos": 194
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 39,
+            "startFilePos": 83,
+            "endLine": 3,
+            "endTokenPos": 39,
+            "endFilePos": 89
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 43,
+            "startFilePos": 93,
+            "endLine": 3,
+            "endTokenPos": 90,
+            "endFilePos": 194,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 44,
+                "startFilePos": 94,
+                "endLine": 3,
+                "endTokenPos": 57,
+                "endFilePos": 125
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 94,
+                  "endLine": 3,
+                  "endTokenPos": 57,
+                  "endFilePos": 125,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 45,
+                      "startFilePos": 95,
+                      "endLine": 3,
+                      "endTokenPos": 49,
+                      "endFilePos": 105
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 45,
+                        "startFilePos": 95,
+                        "endLine": 3,
+                        "endTokenPos": 45,
+                        "endFilePos": 98,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 49,
+                        "startFilePos": 103,
+                        "endLine": 3,
+                        "endTokenPos": 49,
+                        "endFilePos": 105,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 52,
+                      "startFilePos": 108,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 124
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 52,
+                        "startFilePos": 108,
+                        "endLine": 3,
+                        "endTokenPos": 52,
+                        "endFilePos": 119,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 56,
+                        "startFilePos": 124,
+                        "endLine": 3,
+                        "endTokenPos": 56,
+                        "endFilePos": 124,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 128,
+                "endLine": 3,
+                "endTokenPos": 73,
+                "endFilePos": 159
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 73,
+                  "endFilePos": 159,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 139
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 132,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 139,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 142,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 158
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 142,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 158,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 76,
+                "startFilePos": 162,
+                "endLine": 3,
+                "endTokenPos": 89,
+                "endFilePos": 193
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 76,
+                  "startFilePos": 162,
+                  "endLine": 3,
+                  "endTokenPos": 89,
+                  "endFilePos": 193,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 77,
+                      "startFilePos": 163,
+                      "endLine": 3,
+                      "endTokenPos": 81,
+                      "endFilePos": 173
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 77,
+                        "startFilePos": 163,
+                        "endLine": 3,
+                        "endTokenPos": 77,
+                        "endFilePos": 166,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 81,
+                        "startFilePos": 171,
+                        "endLine": 3,
+                        "endTokenPos": 81,
+                        "endFilePos": 173,
+                        "rawValue": "102",
+                        "kind": 10
+                      },
+                      "value": 102
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 176,
+                      "endLine": 3,
+                      "endTokenPos": 88,
+                      "endFilePos": 192
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 84,
+                        "startFilePos": 176,
+                        "endLine": 3,
+                        "endTokenPos": 84,
+                        "endFilePos": 187,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 88,
+                        "startFilePos": 192,
+                        "endLine": 3,
+                        "endTokenPos": 88,
+                        "endFilePos": 192,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 93,
+        "startFilePos": 197,
+        "endLine": 23,
+        "endTokenPos": 320,
+        "endFilePos": 753
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 93,
+          "startFilePos": 197,
+          "endLine": 23,
+          "endTokenPos": 319,
+          "endFilePos": 752
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 93,
+            "startFilePos": 197,
+            "endLine": 4,
+            "endTokenPos": 93,
+            "endFilePos": 202
+          },
+          "name": "stats"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 97,
+            "startFilePos": 206,
+            "endLine": 23,
+            "endTokenPos": 319,
+            "endFilePos": 752
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 98,
+              "startFilePos": 207,
+              "endLine": 23,
+              "endTokenPos": 316,
+              "endFilePos": 749
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 105,
+                  "startFilePos": 223,
+                  "endLine": 4,
+                  "endTokenPos": 105,
+                  "endFilePos": 232
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 105,
+                    "startFilePos": 223,
+                    "endLine": 4,
+                    "endTokenPos": 105,
+                    "endFilePos": 232
+                  },
+                  "name": "customers"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 108,
+                  "startFilePos": 235,
+                  "endLine": 4,
+                  "endTokenPos": 108,
+                  "endFilePos": 241
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 108,
+                    "startFilePos": 235,
+                    "endLine": 4,
+                    "endTokenPos": 108,
+                    "endFilePos": 241
+                  },
+                  "name": "orders"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 113,
+                  "startFilePos": 248,
+                  "endLine": 5,
+                  "endTokenPos": 119,
+                  "endFilePos": 260
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 113,
+                    "startFilePos": 248,
+                    "endLine": 5,
+                    "endTokenPos": 118,
+                    "endFilePos": 259
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 113,
+                      "startFilePos": 248,
+                      "endLine": 5,
+                      "endTokenPos": 113,
+                      "endFilePos": 254
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 117,
+                      "startFilePos": 258,
+                      "endLine": 5,
+                      "endTokenPos": 118,
+                      "endFilePos": 259,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 121,
+                  "startFilePos": 264,
+                  "endLine": 17,
+                  "endTokenPos": 256,
+                  "endFilePos": 609
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 124,
+                    "startFilePos": 273,
+                    "endLine": 6,
+                    "endTokenPos": 124,
+                    "endFilePos": 279
+                  },
+                  "name": "orders"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 128,
+                    "startFilePos": 284,
+                    "endLine": 6,
+                    "endTokenPos": 128,
+                    "endFilePos": 285
+                  },
+                  "name": "o"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 133,
+                      "startFilePos": 294,
+                      "endLine": 16,
+                      "endTokenPos": 254,
+                      "endFilePos": 605
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 136,
+                        "startFilePos": 303,
+                        "endLine": 7,
+                        "endTokenPos": 136,
+                        "endFilePos": 312
+                      },
+                      "name": "customers"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 140,
+                        "startFilePos": 317,
+                        "endLine": 7,
+                        "endTokenPos": 140,
+                        "endFilePos": 318
+                      },
+                      "name": "c"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 145,
+                          "startFilePos": 329,
+                          "endLine": 15,
+                          "endTokenPos": 252,
+                          "endFilePos": 599
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BinaryOp_Equal",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 148,
+                            "startFilePos": 333,
+                            "endLine": 8,
+                            "endTokenPos": 158,
+                            "endFilePos": 360
+                          },
+                          "left": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 148,
+                              "startFilePos": 333,
+                              "endLine": 8,
+                              "endTokenPos": 151,
+                              "endFilePos": 348
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 148,
+                                "startFilePos": 333,
+                                "endLine": 8,
+                                "endTokenPos": 148,
+                                "endFilePos": 334
+                              },
+                              "name": "o"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 150,
+                                "startFilePos": 336,
+                                "endLine": 8,
+                                "endTokenPos": 150,
+                                "endFilePos": 347,
+                                "kind": 2,
+                                "rawValue": "\"customerId\""
+                              },
+                              "value": "customerId"
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 155,
+                              "startFilePos": 353,
+                              "endLine": 8,
+                              "endTokenPos": 158,
+                              "endFilePos": 360
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 155,
+                                "startFilePos": 353,
+                                "endLine": 8,
+                                "endTokenPos": 155,
+                                "endFilePos": 354
+                              },
+                              "name": "c"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 157,
+                                "startFilePos": 356,
+                                "endLine": 8,
+                                "endTokenPos": 157,
+                                "endFilePos": 359,
+                                "kind": 2,
+                                "rawValue": "\"id\""
+                              },
+                              "value": "id"
+                            }
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 163,
+                              "startFilePos": 373,
+                              "endLine": 9,
+                              "endTokenPos": 171,
+                              "endFilePos": 390
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 163,
+                                "startFilePos": 373,
+                                "endLine": 9,
+                                "endTokenPos": 170,
+                                "endFilePos": 389
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 163,
+                                  "startFilePos": 373,
+                                  "endLine": 9,
+                                  "endTokenPos": 163,
+                                  "endFilePos": 376
+                                },
+                                "name": "key"
+                              },
+                              "expr": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 167,
+                                  "startFilePos": 380,
+                                  "endLine": 9,
+                                  "endTokenPos": 170,
+                                  "endFilePos": 389
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 167,
+                                    "startFilePos": 380,
+                                    "endLine": 9,
+                                    "endTokenPos": 167,
+                                    "endFilePos": 381
+                                  },
+                                  "name": "c"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 169,
+                                    "startFilePos": 383,
+                                    "endLine": 9,
+                                    "endTokenPos": 169,
+                                    "endFilePos": 388,
+                                    "kind": 2,
+                                    "rawValue": "\"name\""
+                                  },
+                                  "value": "name"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 173,
+                              "startFilePos": 400,
+                              "endLine": 10,
+                              "endTokenPos": 181,
+                              "endFilePos": 422
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 173,
+                                "startFilePos": 400,
+                                "endLine": 10,
+                                "endTokenPos": 180,
+                                "endFilePos": 421
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 173,
+                                  "startFilePos": 400,
+                                  "endLine": 10,
+                                  "endTokenPos": 173,
+                                  "endFilePos": 401
+                                },
+                                "name": "k"
+                              },
+                              "expr": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 177,
+                                  "startFilePos": 405,
+                                  "endLine": 10,
+                                  "endTokenPos": 180,
+                                  "endFilePos": 421
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 177,
+                                    "startFilePos": 405,
+                                    "endLine": 10,
+                                    "endTokenPos": 177,
+                                    "endFilePos": 415
+                                  },
+                                  "name": "json_encode"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 10,
+                                      "startTokenPos": 179,
+                                      "startFilePos": 417,
+                                      "endLine": 10,
+                                      "endTokenPos": 179,
+                                      "endFilePos": 420
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 10,
+                                        "startTokenPos": 179,
+                                        "startFilePos": 417,
+                                        "endLine": 10,
+                                        "endTokenPos": 179,
+                                        "endFilePos": 420
+                                      },
+                                      "name": "key"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "nodeType": "Stmt_If",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 183,
+                              "startFilePos": 432,
+                              "endLine": 13,
+                              "endTokenPos": 222,
+                              "endFilePos": 534
+                            },
+                            "cond": {
+                              "nodeType": "Expr_BooleanNot",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 186,
+                                "startFilePos": 436,
+                                "endLine": 11,
+                                "endTokenPos": 193,
+                                "endFilePos": 465
+                              },
+                              "expr": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 187,
+                                  "startFilePos": 437,
+                                  "endLine": 11,
+                                  "endTokenPos": 193,
+                                  "endFilePos": 465
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 187,
+                                    "startFilePos": 437,
+                                    "endLine": 11,
+                                    "endTokenPos": 187,
+                                    "endFilePos": 452
+                                  },
+                                  "name": "array_key_exists"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 189,
+                                      "startFilePos": 454,
+                                      "endLine": 11,
+                                      "endTokenPos": 189,
+                                      "endFilePos": 455
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 11,
+                                        "startTokenPos": 189,
+                                        "startFilePos": 454,
+                                        "endLine": 11,
+                                        "endTokenPos": 189,
+                                        "endFilePos": 455
+                                      },
+                                      "name": "k"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 192,
+                                      "startFilePos": 458,
+                                      "endLine": 11,
+                                      "endTokenPos": 192,
+                                      "endFilePos": 464
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 11,
+                                        "startTokenPos": 192,
+                                        "startFilePos": 458,
+                                        "endLine": 11,
+                                        "endTokenPos": 192,
+                                        "endFilePos": 464
+                                      },
+                                      "name": "groups"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            },
+                            "stmts": [
+                              {
+                                "nodeType": "Stmt_Expression",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 198,
+                                  "startFilePos": 480,
+                                  "endLine": 12,
+                                  "endTokenPos": 220,
+                                  "endFilePos": 524
+                                },
+                                "expr": {
+                                  "nodeType": "Expr_Assign",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 198,
+                                    "startFilePos": 480,
+                                    "endLine": 12,
+                                    "endTokenPos": 219,
+                                    "endFilePos": 523
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 198,
+                                      "startFilePos": 480,
+                                      "endLine": 12,
+                                      "endTokenPos": 201,
+                                      "endFilePos": 490
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 12,
+                                        "startTokenPos": 198,
+                                        "startFilePos": 480,
+                                        "endLine": 12,
+                                        "endTokenPos": 198,
+                                        "endFilePos": 486
+                                      },
+                                      "name": "groups"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 12,
+                                        "startTokenPos": 200,
+                                        "startFilePos": 488,
+                                        "endLine": 12,
+                                        "endTokenPos": 200,
+                                        "endFilePos": 489
+                                      },
+                                      "name": "k"
+                                    }
+                                  },
+                                  "expr": {
+                                    "nodeType": "Expr_Array",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 205,
+                                      "startFilePos": 494,
+                                      "endLine": 12,
+                                      "endTokenPos": 219,
+                                      "endFilePos": 523,
+                                      "kind": 2
+                                    },
+                                    "items": [
+                                      {
+                                        "nodeType": "ArrayItem",
+                                        "attributes": {
+                                          "startLine": 12,
+                                          "startTokenPos": 206,
+                                          "startFilePos": 495,
+                                          "endLine": 12,
+                                          "endTokenPos": 210,
+                                          "endFilePos": 507
+                                        },
+                                        "key": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 12,
+                                            "startTokenPos": 206,
+                                            "startFilePos": 495,
+                                            "endLine": 12,
+                                            "endTokenPos": 206,
+                                            "endFilePos": 499,
+                                            "kind": 1,
+                                            "rawValue": "'key'"
+                                          },
+                                          "value": "key"
+                                        },
+                                        "value": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 12,
+                                            "startTokenPos": 210,
+                                            "startFilePos": 504,
+                                            "endLine": 12,
+                                            "endTokenPos": 210,
+                                            "endFilePos": 507
+                                          },
+                                          "name": "key"
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      },
+                                      {
+                                        "nodeType": "ArrayItem",
+                                        "attributes": {
+                                          "startLine": 12,
+                                          "startTokenPos": 213,
+                                          "startFilePos": 510,
+                                          "endLine": 12,
+                                          "endTokenPos": 218,
+                                          "endFilePos": 522
+                                        },
+                                        "key": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 12,
+                                            "startTokenPos": 213,
+                                            "startFilePos": 510,
+                                            "endLine": 12,
+                                            "endTokenPos": 213,
+                                            "endFilePos": 516,
+                                            "kind": 1,
+                                            "rawValue": "'items'"
+                                          },
+                                          "value": "items"
+                                        },
+                                        "value": {
+                                          "nodeType": "Expr_Array",
+                                          "attributes": {
+                                            "startLine": 12,
+                                            "startTokenPos": 217,
+                                            "startFilePos": 521,
+                                            "endLine": 12,
+                                            "endTokenPos": 218,
+                                            "endFilePos": 522,
+                                            "kind": 2
+                                          },
+                                          "items": []
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "elseifs": [],
+                            "else": null
+                          },
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 224,
+                              "startFilePos": 544,
+                              "endLine": 14,
+                              "endTokenPos": 250,
+                              "endFilePos": 591
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 14,
+                                "startTokenPos": 224,
+                                "startFilePos": 544,
+                                "endLine": 14,
+                                "endTokenPos": 249,
+                                "endFilePos": 590
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 14,
+                                  "startTokenPos": 224,
+                                  "startFilePos": 544,
+                                  "endLine": 14,
+                                  "endTokenPos": 232,
+                                  "endFilePos": 565
+                                },
+                                "var": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 14,
+                                    "startTokenPos": 224,
+                                    "startFilePos": 544,
+                                    "endLine": 14,
+                                    "endTokenPos": 230,
+                                    "endFilePos": 563
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 224,
+                                      "startFilePos": 544,
+                                      "endLine": 14,
+                                      "endTokenPos": 227,
+                                      "endFilePos": 554
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 224,
+                                        "startFilePos": 544,
+                                        "endLine": 14,
+                                        "endTokenPos": 224,
+                                        "endFilePos": 550
+                                      },
+                                      "name": "groups"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 226,
+                                        "startFilePos": 552,
+                                        "endLine": 14,
+                                        "endTokenPos": 226,
+                                        "endFilePos": 553
+                                      },
+                                      "name": "k"
+                                    }
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 229,
+                                      "startFilePos": 556,
+                                      "endLine": 14,
+                                      "endTokenPos": 229,
+                                      "endFilePos": 562,
+                                      "kind": 1,
+                                      "rawValue": "'items'"
+                                    },
+                                    "value": "items"
+                                  }
+                                },
+                                "dim": null
+                              },
+                              "expr": {
+                                "nodeType": "Expr_Array",
+                                "attributes": {
+                                  "startLine": 14,
+                                  "startTokenPos": 236,
+                                  "startFilePos": 569,
+                                  "endLine": 14,
+                                  "endTokenPos": 249,
+                                  "endFilePos": 590,
+                                  "kind": 2
+                                },
+                                "items": [
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 237,
+                                      "startFilePos": 570,
+                                      "endLine": 14,
+                                      "endTokenPos": 241,
+                                      "endFilePos": 578
+                                    },
+                                    "key": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 237,
+                                        "startFilePos": 570,
+                                        "endLine": 14,
+                                        "endTokenPos": 237,
+                                        "endFilePos": 572,
+                                        "kind": 1,
+                                        "rawValue": "'o'"
+                                      },
+                                      "value": "o"
+                                    },
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 241,
+                                        "startFilePos": 577,
+                                        "endLine": 14,
+                                        "endTokenPos": 241,
+                                        "endFilePos": 578
+                                      },
+                                      "name": "o"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 244,
+                                      "startFilePos": 581,
+                                      "endLine": 14,
+                                      "endTokenPos": 248,
+                                      "endFilePos": 589
+                                    },
+                                    "key": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 244,
+                                        "startFilePos": 581,
+                                        "endLine": 14,
+                                        "endTokenPos": 244,
+                                        "endFilePos": 583,
+                                        "kind": 1,
+                                        "rawValue": "'c'"
+                                      },
+                                      "value": "c"
+                                    },
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 248,
+                                        "startFilePos": 588,
+                                        "endLine": 14,
+                                        "endTokenPos": 248,
+                                        "endFilePos": 589
+                                      },
+                                      "name": "c"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 258,
+                  "startFilePos": 613,
+                  "endLine": 18,
+                  "endTokenPos": 264,
+                  "endFilePos": 625
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 258,
+                    "startFilePos": 613,
+                    "endLine": 18,
+                    "endTokenPos": 263,
+                    "endFilePos": 624
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 258,
+                      "startFilePos": 613,
+                      "endLine": 18,
+                      "endTokenPos": 258,
+                      "endFilePos": 619
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 262,
+                      "startFilePos": 623,
+                      "endLine": 18,
+                      "endTokenPos": 263,
+                      "endFilePos": 624,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 19,
+                  "startTokenPos": 266,
+                  "startFilePos": 629,
+                  "endLine": 21,
+                  "endTokenPos": 309,
+                  "endFilePos": 729
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 19,
+                    "startTokenPos": 269,
+                    "startFilePos": 638,
+                    "endLine": 19,
+                    "endTokenPos": 269,
+                    "endFilePos": 644
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 19,
+                    "startTokenPos": 273,
+                    "startFilePos": 649,
+                    "endLine": 19,
+                    "endTokenPos": 273,
+                    "endFilePos": 650
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 20,
+                      "startTokenPos": 278,
+                      "startFilePos": 661,
+                      "endLine": 20,
+                      "endTokenPos": 307,
+                      "endFilePos": 725
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 20,
+                        "startTokenPos": 278,
+                        "startFilePos": 661,
+                        "endLine": 20,
+                        "endTokenPos": 306,
+                        "endFilePos": 724
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 20,
+                          "startTokenPos": 278,
+                          "startFilePos": 661,
+                          "endLine": 20,
+                          "endTokenPos": 280,
+                          "endFilePos": 669
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 20,
+                            "startTokenPos": 278,
+                            "startFilePos": 661,
+                            "endLine": 20,
+                            "endTokenPos": 278,
+                            "endFilePos": 667
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 20,
+                          "startTokenPos": 284,
+                          "startFilePos": 673,
+                          "endLine": 20,
+                          "endTokenPos": 306,
+                          "endFilePos": 724,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 20,
+                              "startTokenPos": 285,
+                              "startFilePos": 674,
+                              "endLine": 20,
+                              "endTokenPos": 292,
+                              "endFilePos": 692
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 285,
+                                "startFilePos": 674,
+                                "endLine": 20,
+                                "endTokenPos": 285,
+                                "endFilePos": 679,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 289,
+                                "startFilePos": 684,
+                                "endLine": 20,
+                                "endTokenPos": 292,
+                                "endFilePos": 692
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 20,
+                                  "startTokenPos": 289,
+                                  "startFilePos": 684,
+                                  "endLine": 20,
+                                  "endTokenPos": 289,
+                                  "endFilePos": 685
+                                },
+                                "name": "g"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 20,
+                                  "startTokenPos": 291,
+                                  "startFilePos": 687,
+                                  "endLine": 20,
+                                  "endTokenPos": 291,
+                                  "endFilePos": 691,
+                                  "kind": 2,
+                                  "rawValue": "\"key\""
+                                },
+                                "value": "key"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 20,
+                              "startTokenPos": 295,
+                              "startFilePos": 695,
+                              "endLine": 20,
+                              "endTokenPos": 305,
+                              "endFilePos": 723
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 295,
+                                "startFilePos": 695,
+                                "endLine": 20,
+                                "endTokenPos": 295,
+                                "endFilePos": 701,
+                                "kind": 2,
+                                "rawValue": "\"count\""
+                              },
+                              "value": "count"
+                            },
+                            "value": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 299,
+                                "startFilePos": 706,
+                                "endLine": 20,
+                                "endTokenPos": 305,
+                                "endFilePos": 723
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 20,
+                                  "startTokenPos": 299,
+                                  "startFilePos": 706,
+                                  "endLine": 20,
+                                  "endTokenPos": 299,
+                                  "endFilePos": 710
+                                },
+                                "name": "count"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 20,
+                                    "startTokenPos": 301,
+                                    "startFilePos": 712,
+                                    "endLine": 20,
+                                    "endTokenPos": 304,
+                                    "endFilePos": 722
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 20,
+                                      "startTokenPos": 301,
+                                      "startFilePos": 712,
+                                      "endLine": 20,
+                                      "endTokenPos": 304,
+                                      "endFilePos": 722
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 20,
+                                        "startTokenPos": 301,
+                                        "startFilePos": 712,
+                                        "endLine": 20,
+                                        "endTokenPos": 301,
+                                        "endFilePos": 713
+                                      },
+                                      "name": "g"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 20,
+                                        "startTokenPos": 303,
+                                        "startFilePos": 715,
+                                        "endLine": 20,
+                                        "endTokenPos": 303,
+                                        "endFilePos": 721,
+                                        "kind": 2,
+                                        "rawValue": "\"items\""
+                                      },
+                                      "value": "items"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 22,
+                  "startTokenPos": 311,
+                  "startFilePos": 733,
+                  "endLine": 22,
+                  "endTokenPos": 314,
+                  "endFilePos": 747
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 22,
+                    "startTokenPos": 313,
+                    "startFilePos": 740,
+                    "endLine": 22,
+                    "endTokenPos": 313,
+                    "endFilePos": 746
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 24,
+        "startTokenPos": 322,
+        "startFilePos": 755,
+        "endLine": 24,
+        "endTokenPos": 328,
+        "endFilePos": 798
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 24,
+            "startTokenPos": 324,
+            "startFilePos": 760,
+            "endLine": 24,
+            "endTokenPos": 324,
+            "endFilePos": 788,
+            "kind": 2,
+            "rawValue": "\"--- Orders per customer ---\""
+          },
+          "value": "--- Orders per customer ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 24,
+            "startTokenPos": 327,
+            "startFilePos": 791,
+            "endLine": 24,
+            "endTokenPos": 327,
+            "endFilePos": 797
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 24,
+              "startTokenPos": 327,
+              "startFilePos": 791,
+              "endLine": 24,
+              "endTokenPos": 327,
+              "endFilePos": 797
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 25,
+        "startTokenPos": 330,
+        "startFilePos": 800,
+        "endLine": 27,
+        "endTokenPos": 422,
+        "endFilePos": 1007
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 25,
+          "startTokenPos": 333,
+          "startFilePos": 809,
+          "endLine": 25,
+          "endTokenPos": 333,
+          "endFilePos": 814
+        },
+        "name": "stats"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 25,
+          "startTokenPos": 337,
+          "startFilePos": 819,
+          "endLine": 25,
+          "endTokenPos": 337,
+          "endFilePos": 820
+        },
+        "name": "s"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 26,
+            "startTokenPos": 342,
+            "startFilePos": 827,
+            "endLine": 26,
+            "endTokenPos": 420,
+            "endFilePos": 1005
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 26,
+                "startTokenPos": 344,
+                "startFilePos": 832,
+                "endLine": 26,
+                "endTokenPos": 416,
+                "endFilePos": 995
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 26,
+                  "startTokenPos": 344,
+                  "startFilePos": 832,
+                  "endLine": 26,
+                  "endTokenPos": 384,
+                  "endFilePos": 922
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 344,
+                    "startFilePos": 832,
+                    "endLine": 26,
+                    "endTokenPos": 380,
+                    "endFilePos": 916
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 344,
+                      "startFilePos": 832,
+                      "endLine": 26,
+                      "endTokenPos": 376,
+                      "endFilePos": 904
+                    },
+                    "left": {
+                      "nodeType": "Expr_Ternary",
+                      "attributes": {
+                        "startLine": 26,
+                        "startTokenPos": 345,
+                        "startFilePos": 833,
+                        "endLine": 26,
+                        "endTokenPos": 371,
+                        "endFilePos": 897
+                      },
+                      "cond": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 345,
+                          "startFilePos": 833,
+                          "endLine": 26,
+                          "endTokenPos": 351,
+                          "endFilePos": 852
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 345,
+                            "startFilePos": 833,
+                            "endLine": 26,
+                            "endTokenPos": 345,
+                            "endFilePos": 840
+                          },
+                          "name": "is_float"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 26,
+                              "startTokenPos": 347,
+                              "startFilePos": 842,
+                              "endLine": 26,
+                              "endTokenPos": 350,
+                              "endFilePos": 851
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 26,
+                                "startTokenPos": 347,
+                                "startFilePos": 842,
+                                "endLine": 26,
+                                "endTokenPos": 350,
+                                "endFilePos": 851
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 26,
+                                  "startTokenPos": 347,
+                                  "startFilePos": 842,
+                                  "endLine": 26,
+                                  "endTokenPos": 347,
+                                  "endFilePos": 843
+                                },
+                                "name": "s"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 26,
+                                  "startTokenPos": 349,
+                                  "startFilePos": 845,
+                                  "endLine": 26,
+                                  "endTokenPos": 349,
+                                  "endFilePos": 850,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "if": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 355,
+                          "startFilePos": 856,
+                          "endLine": 26,
+                          "endTokenPos": 364,
+                          "endFilePos": 884
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 355,
+                            "startFilePos": 856,
+                            "endLine": 26,
+                            "endTokenPos": 355,
+                            "endFilePos": 866
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 26,
+                              "startTokenPos": 357,
+                              "startFilePos": 868,
+                              "endLine": 26,
+                              "endTokenPos": 360,
+                              "endFilePos": 877
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 26,
+                                "startTokenPos": 357,
+                                "startFilePos": 868,
+                                "endLine": 26,
+                                "endTokenPos": 360,
+                                "endFilePos": 877
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 26,
+                                  "startTokenPos": 357,
+                                  "startFilePos": 868,
+                                  "endLine": 26,
+                                  "endTokenPos": 357,
+                                  "endFilePos": 869
+                                },
+                                "name": "s"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 26,
+                                  "startTokenPos": 359,
+                                  "startFilePos": 871,
+                                  "endLine": 26,
+                                  "endTokenPos": 359,
+                                  "endFilePos": 876,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 26,
+                              "startTokenPos": 363,
+                              "startFilePos": 880,
+                              "endLine": 26,
+                              "endTokenPos": 363,
+                              "endFilePos": 883
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 26,
+                                "startTokenPos": 363,
+                                "startFilePos": 880,
+                                "endLine": 26,
+                                "endTokenPos": 363,
+                                "endFilePos": 883,
+                                "rawValue": "1344",
+                                "kind": 10
+                              },
+                              "value": 1344
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "else": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 368,
+                          "startFilePos": 888,
+                          "endLine": 26,
+                          "endTokenPos": 371,
+                          "endFilePos": 897
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 368,
+                            "startFilePos": 888,
+                            "endLine": 26,
+                            "endTokenPos": 368,
+                            "endFilePos": 889
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 370,
+                            "startFilePos": 891,
+                            "endLine": 26,
+                            "endTokenPos": 370,
+                            "endFilePos": 896,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 26,
+                        "startTokenPos": 376,
+                        "startFilePos": 902,
+                        "endLine": 26,
+                        "endTokenPos": 376,
+                        "endFilePos": 904,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 380,
+                      "startFilePos": 908,
+                      "endLine": 26,
+                      "endTokenPos": 380,
+                      "endFilePos": 916,
+                      "kind": 2,
+                      "rawValue": "\"orders:\""
+                    },
+                    "value": "orders:"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 384,
+                    "startFilePos": 920,
+                    "endLine": 26,
+                    "endTokenPos": 384,
+                    "endFilePos": 922,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 26,
+                  "startTokenPos": 389,
+                  "startFilePos": 927,
+                  "endLine": 26,
+                  "endTokenPos": 415,
+                  "endFilePos": 994
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 389,
+                    "startFilePos": 927,
+                    "endLine": 26,
+                    "endTokenPos": 395,
+                    "endFilePos": 947
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 389,
+                      "startFilePos": 927,
+                      "endLine": 26,
+                      "endTokenPos": 389,
+                      "endFilePos": 934
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 26,
+                        "startTokenPos": 391,
+                        "startFilePos": 936,
+                        "endLine": 26,
+                        "endTokenPos": 394,
+                        "endFilePos": 946
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 391,
+                          "startFilePos": 936,
+                          "endLine": 26,
+                          "endTokenPos": 394,
+                          "endFilePos": 946
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 391,
+                            "startFilePos": 936,
+                            "endLine": 26,
+                            "endTokenPos": 391,
+                            "endFilePos": 937
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 393,
+                            "startFilePos": 939,
+                            "endLine": 26,
+                            "endTokenPos": 393,
+                            "endFilePos": 945,
+                            "kind": 2,
+                            "rawValue": "\"count\""
+                          },
+                          "value": "count"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 399,
+                    "startFilePos": 951,
+                    "endLine": 26,
+                    "endTokenPos": 408,
+                    "endFilePos": 980
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 399,
+                      "startFilePos": 951,
+                      "endLine": 26,
+                      "endTokenPos": 399,
+                      "endFilePos": 961
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 26,
+                        "startTokenPos": 401,
+                        "startFilePos": 963,
+                        "endLine": 26,
+                        "endTokenPos": 404,
+                        "endFilePos": 973
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 401,
+                          "startFilePos": 963,
+                          "endLine": 26,
+                          "endTokenPos": 404,
+                          "endFilePos": 973
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 401,
+                            "startFilePos": 963,
+                            "endLine": 26,
+                            "endTokenPos": 401,
+                            "endFilePos": 964
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 403,
+                            "startFilePos": 966,
+                            "endLine": 26,
+                            "endTokenPos": 403,
+                            "endFilePos": 972,
+                            "kind": 2,
+                            "rawValue": "\"count\""
+                          },
+                          "value": "count"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 26,
+                        "startTokenPos": 407,
+                        "startFilePos": 976,
+                        "endLine": 26,
+                        "endTokenPos": 407,
+                        "endFilePos": 979
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 407,
+                          "startFilePos": 976,
+                          "endLine": 26,
+                          "endTokenPos": 407,
+                          "endFilePos": 979,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 412,
+                    "startFilePos": 984,
+                    "endLine": 26,
+                    "endTokenPos": 415,
+                    "endFilePos": 994
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 412,
+                      "startFilePos": 984,
+                      "endLine": 26,
+                      "endTokenPos": 412,
+                      "endFilePos": 985
+                    },
+                    "name": "s"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 414,
+                      "startFilePos": 987,
+                      "endLine": 26,
+                      "endTokenPos": 414,
+                      "endFilePos": 993,
+                      "kind": 2,
+                      "rawValue": "\"count\""
+                    },
+                    "value": "count"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 26,
+                "startTokenPos": 419,
+                "startFilePos": 998,
+                "endLine": 26,
+                "endTokenPos": 419,
+                "endFilePos": 1004
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 26,
+                  "startTokenPos": 419,
+                  "startFilePos": 998,
+                  "endLine": 26,
+                  "endTokenPos": 419,
+                  "endFilePos": 1004
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_left_join.php.json
+++ b/tests/json-ast/x/php/group_by_left_join.php.json
@@ -1,0 +1,3835 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 53,
+        "endFilePos": 115
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 52,
+          "endFilePos": 114
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 52,
+            "endFilePos": 114,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 82,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 113
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 82,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 113,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 83,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 86,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 91,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 91,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 94,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 99,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 104,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 55,
+        "startFilePos": 117,
+        "endLine": 3,
+        "endTokenPos": 107,
+        "endFilePos": 229
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 55,
+          "startFilePos": 117,
+          "endLine": 3,
+          "endTokenPos": 106,
+          "endFilePos": 228
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 117,
+            "endLine": 3,
+            "endTokenPos": 55,
+            "endFilePos": 123
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 59,
+            "startFilePos": 127,
+            "endLine": 3,
+            "endTokenPos": 106,
+            "endFilePos": 228,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 128,
+                "endLine": 3,
+                "endTokenPos": 73,
+                "endFilePos": 159
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 73,
+                  "endFilePos": 159,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 139
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 132,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 139,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 142,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 158
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 142,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 158,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 76,
+                "startFilePos": 162,
+                "endLine": 3,
+                "endTokenPos": 89,
+                "endFilePos": 193
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 76,
+                  "startFilePos": 162,
+                  "endLine": 3,
+                  "endTokenPos": 89,
+                  "endFilePos": 193,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 77,
+                      "startFilePos": 163,
+                      "endLine": 3,
+                      "endTokenPos": 81,
+                      "endFilePos": 173
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 77,
+                        "startFilePos": 163,
+                        "endLine": 3,
+                        "endTokenPos": 77,
+                        "endFilePos": 166,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 81,
+                        "startFilePos": 171,
+                        "endLine": 3,
+                        "endTokenPos": 81,
+                        "endFilePos": 173,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 176,
+                      "endLine": 3,
+                      "endTokenPos": 88,
+                      "endFilePos": 192
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 84,
+                        "startFilePos": 176,
+                        "endLine": 3,
+                        "endTokenPos": 84,
+                        "endFilePos": 187,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 88,
+                        "startFilePos": 192,
+                        "endLine": 3,
+                        "endTokenPos": 88,
+                        "endFilePos": 192,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 92,
+                "startFilePos": 196,
+                "endLine": 3,
+                "endTokenPos": 105,
+                "endFilePos": 227
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 92,
+                  "startFilePos": 196,
+                  "endLine": 3,
+                  "endTokenPos": 105,
+                  "endFilePos": 227,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 93,
+                      "startFilePos": 197,
+                      "endLine": 3,
+                      "endTokenPos": 97,
+                      "endFilePos": 207
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 93,
+                        "startFilePos": 197,
+                        "endLine": 3,
+                        "endTokenPos": 93,
+                        "endFilePos": 200,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 97,
+                        "startFilePos": 205,
+                        "endLine": 3,
+                        "endTokenPos": 97,
+                        "endFilePos": 207,
+                        "rawValue": "102",
+                        "kind": 10
+                      },
+                      "value": 102
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 100,
+                      "startFilePos": 210,
+                      "endLine": 3,
+                      "endTokenPos": 104,
+                      "endFilePos": 226
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 100,
+                        "startFilePos": 210,
+                        "endLine": 3,
+                        "endTokenPos": 100,
+                        "endFilePos": 221,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 104,
+                        "startFilePos": 226,
+                        "endLine": 3,
+                        "endTokenPos": 104,
+                        "endFilePos": 226,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 109,
+        "startFilePos": 231,
+        "endLine": 41,
+        "endTokenPos": 530,
+        "endFilePos": 1224
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 109,
+          "startFilePos": 231,
+          "endLine": 41,
+          "endTokenPos": 529,
+          "endFilePos": 1223
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 109,
+            "startFilePos": 231,
+            "endLine": 4,
+            "endTokenPos": 109,
+            "endFilePos": 236
+          },
+          "name": "stats"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 113,
+            "startFilePos": 240,
+            "endLine": 41,
+            "endTokenPos": 529,
+            "endFilePos": 1223
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 114,
+              "startFilePos": 241,
+              "endLine": 41,
+              "endTokenPos": 526,
+              "endFilePos": 1220
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 121,
+                  "startFilePos": 257,
+                  "endLine": 4,
+                  "endTokenPos": 121,
+                  "endFilePos": 266
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 121,
+                    "startFilePos": 257,
+                    "endLine": 4,
+                    "endTokenPos": 121,
+                    "endFilePos": 266
+                  },
+                  "name": "customers"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 124,
+                  "startFilePos": 269,
+                  "endLine": 4,
+                  "endTokenPos": 124,
+                  "endFilePos": 275
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 124,
+                    "startFilePos": 269,
+                    "endLine": 4,
+                    "endTokenPos": 124,
+                    "endFilePos": 275
+                  },
+                  "name": "orders"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 129,
+                  "startFilePos": 282,
+                  "endLine": 5,
+                  "endTokenPos": 135,
+                  "endFilePos": 294
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 129,
+                    "startFilePos": 282,
+                    "endLine": 5,
+                    "endTokenPos": 134,
+                    "endFilePos": 293
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 129,
+                      "startFilePos": 282,
+                      "endLine": 5,
+                      "endTokenPos": 129,
+                      "endFilePos": 288
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 133,
+                      "startFilePos": 292,
+                      "endLine": 5,
+                      "endTokenPos": 134,
+                      "endFilePos": 293,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 137,
+                  "startFilePos": 298,
+                  "endLine": 27,
+                  "endTokenPos": 395,
+                  "endFilePos": 939
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 140,
+                    "startFilePos": 307,
+                    "endLine": 6,
+                    "endTokenPos": 140,
+                    "endFilePos": 316
+                  },
+                  "name": "customers"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 144,
+                    "startFilePos": 321,
+                    "endLine": 6,
+                    "endTokenPos": 144,
+                    "endFilePos": 322
+                  },
+                  "name": "c"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 149,
+                      "startFilePos": 331,
+                      "endLine": 7,
+                      "endTokenPos": 154,
+                      "endFilePos": 347
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 149,
+                        "startFilePos": 331,
+                        "endLine": 7,
+                        "endTokenPos": 153,
+                        "endFilePos": 346
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 149,
+                          "startFilePos": 331,
+                          "endLine": 7,
+                          "endTokenPos": 149,
+                          "endFilePos": 338
+                        },
+                        "name": "matched"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ConstFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 153,
+                          "startFilePos": 342,
+                          "endLine": 7,
+                          "endTokenPos": 153,
+                          "endFilePos": 346
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 153,
+                            "startFilePos": 342,
+                            "endLine": 7,
+                            "endTokenPos": 153,
+                            "endFilePos": 346
+                          },
+                          "name": "false"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 156,
+                      "startFilePos": 353,
+                      "endLine": 17,
+                      "endTokenPos": 286,
+                      "endFilePos": 675
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 159,
+                        "startFilePos": 362,
+                        "endLine": 8,
+                        "endTokenPos": 159,
+                        "endFilePos": 368
+                      },
+                      "name": "orders"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 163,
+                        "startFilePos": 373,
+                        "endLine": 8,
+                        "endTokenPos": 163,
+                        "endFilePos": 374
+                      },
+                      "name": "o"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 168,
+                          "startFilePos": 385,
+                          "endLine": 9,
+                          "endTokenPos": 188,
+                          "endFilePos": 430
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 171,
+                            "startFilePos": 389,
+                            "endLine": 9,
+                            "endTokenPos": 184,
+                            "endFilePos": 419
+                          },
+                          "expr": {
+                            "nodeType": "Expr_BinaryOp_Equal",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 173,
+                              "startFilePos": 391,
+                              "endLine": 9,
+                              "endTokenPos": 183,
+                              "endFilePos": 418
+                            },
+                            "left": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 173,
+                                "startFilePos": 391,
+                                "endLine": 9,
+                                "endTokenPos": 176,
+                                "endFilePos": 406
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 173,
+                                  "startFilePos": 391,
+                                  "endLine": 9,
+                                  "endTokenPos": 173,
+                                  "endFilePos": 392
+                                },
+                                "name": "o"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 175,
+                                  "startFilePos": 394,
+                                  "endLine": 9,
+                                  "endTokenPos": 175,
+                                  "endFilePos": 405,
+                                  "kind": 2,
+                                  "rawValue": "\"customerId\""
+                                },
+                                "value": "customerId"
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 180,
+                                "startFilePos": 411,
+                                "endLine": 9,
+                                "endTokenPos": 183,
+                                "endFilePos": 418
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 180,
+                                  "startFilePos": 411,
+                                  "endLine": 9,
+                                  "endTokenPos": 180,
+                                  "endFilePos": 412
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 182,
+                                  "startFilePos": 414,
+                                  "endLine": 9,
+                                  "endTokenPos": 182,
+                                  "endFilePos": 417,
+                                  "kind": 2,
+                                  "rawValue": "\"id\""
+                                },
+                                "value": "id"
+                              }
+                            }
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Continue",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 187,
+                              "startFilePos": 422,
+                              "endLine": 9,
+                              "endTokenPos": 188,
+                              "endFilePos": 430
+                            },
+                            "num": null
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 190,
+                          "startFilePos": 438,
+                          "endLine": 10,
+                          "endTokenPos": 195,
+                          "endFilePos": 453
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 190,
+                            "startFilePos": 438,
+                            "endLine": 10,
+                            "endTokenPos": 194,
+                            "endFilePos": 452
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 190,
+                              "startFilePos": 438,
+                              "endLine": 10,
+                              "endTokenPos": 190,
+                              "endFilePos": 445
+                            },
+                            "name": "matched"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 194,
+                              "startFilePos": 449,
+                              "endLine": 10,
+                              "endTokenPos": 194,
+                              "endFilePos": 452
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 194,
+                                "startFilePos": 449,
+                                "endLine": 10,
+                                "endTokenPos": 194,
+                                "endFilePos": 452
+                              },
+                              "name": "true"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 197,
+                          "startFilePos": 461,
+                          "endLine": 11,
+                          "endTokenPos": 205,
+                          "endFilePos": 478
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 197,
+                            "startFilePos": 461,
+                            "endLine": 11,
+                            "endTokenPos": 204,
+                            "endFilePos": 477
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 197,
+                              "startFilePos": 461,
+                              "endLine": 11,
+                              "endTokenPos": 197,
+                              "endFilePos": 464
+                            },
+                            "name": "key"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 201,
+                              "startFilePos": 468,
+                              "endLine": 11,
+                              "endTokenPos": 204,
+                              "endFilePos": 477
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 201,
+                                "startFilePos": 468,
+                                "endLine": 11,
+                                "endTokenPos": 201,
+                                "endFilePos": 469
+                              },
+                              "name": "c"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 203,
+                                "startFilePos": 471,
+                                "endLine": 11,
+                                "endTokenPos": 203,
+                                "endFilePos": 476,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 207,
+                          "startFilePos": 486,
+                          "endLine": 12,
+                          "endTokenPos": 215,
+                          "endFilePos": 508
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 207,
+                            "startFilePos": 486,
+                            "endLine": 12,
+                            "endTokenPos": 214,
+                            "endFilePos": 507
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 207,
+                              "startFilePos": 486,
+                              "endLine": 12,
+                              "endTokenPos": 207,
+                              "endFilePos": 487
+                            },
+                            "name": "k"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 211,
+                              "startFilePos": 491,
+                              "endLine": 12,
+                              "endTokenPos": 214,
+                              "endFilePos": 507
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 211,
+                                "startFilePos": 491,
+                                "endLine": 12,
+                                "endTokenPos": 211,
+                                "endFilePos": 501
+                              },
+                              "name": "json_encode"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 213,
+                                  "startFilePos": 503,
+                                  "endLine": 12,
+                                  "endTokenPos": 213,
+                                  "endFilePos": 506
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 213,
+                                    "startFilePos": 503,
+                                    "endLine": 12,
+                                    "endTokenPos": 213,
+                                    "endFilePos": 506
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 217,
+                          "startFilePos": 516,
+                          "endLine": 15,
+                          "endTokenPos": 256,
+                          "endFilePos": 614
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 220,
+                            "startFilePos": 520,
+                            "endLine": 13,
+                            "endTokenPos": 227,
+                            "endFilePos": 549
+                          },
+                          "expr": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 221,
+                              "startFilePos": 521,
+                              "endLine": 13,
+                              "endTokenPos": 227,
+                              "endFilePos": 549
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 221,
+                                "startFilePos": 521,
+                                "endLine": 13,
+                                "endTokenPos": 221,
+                                "endFilePos": 536
+                              },
+                              "name": "array_key_exists"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 223,
+                                  "startFilePos": 538,
+                                  "endLine": 13,
+                                  "endTokenPos": 223,
+                                  "endFilePos": 539
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 223,
+                                    "startFilePos": 538,
+                                    "endLine": 13,
+                                    "endTokenPos": 223,
+                                    "endFilePos": 539
+                                  },
+                                  "name": "k"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 226,
+                                  "startFilePos": 542,
+                                  "endLine": 13,
+                                  "endTokenPos": 226,
+                                  "endFilePos": 548
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 226,
+                                    "startFilePos": 542,
+                                    "endLine": 13,
+                                    "endTokenPos": 226,
+                                    "endFilePos": 548
+                                  },
+                                  "name": "groups"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 232,
+                              "startFilePos": 562,
+                              "endLine": 14,
+                              "endTokenPos": 254,
+                              "endFilePos": 606
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 14,
+                                "startTokenPos": 232,
+                                "startFilePos": 562,
+                                "endLine": 14,
+                                "endTokenPos": 253,
+                                "endFilePos": 605
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 14,
+                                  "startTokenPos": 232,
+                                  "startFilePos": 562,
+                                  "endLine": 14,
+                                  "endTokenPos": 235,
+                                  "endFilePos": 572
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 14,
+                                    "startTokenPos": 232,
+                                    "startFilePos": 562,
+                                    "endLine": 14,
+                                    "endTokenPos": 232,
+                                    "endFilePos": 568
+                                  },
+                                  "name": "groups"
+                                },
+                                "dim": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 14,
+                                    "startTokenPos": 234,
+                                    "startFilePos": 570,
+                                    "endLine": 14,
+                                    "endTokenPos": 234,
+                                    "endFilePos": 571
+                                  },
+                                  "name": "k"
+                                }
+                              },
+                              "expr": {
+                                "nodeType": "Expr_Array",
+                                "attributes": {
+                                  "startLine": 14,
+                                  "startTokenPos": 239,
+                                  "startFilePos": 576,
+                                  "endLine": 14,
+                                  "endTokenPos": 253,
+                                  "endFilePos": 605,
+                                  "kind": 2
+                                },
+                                "items": [
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 240,
+                                      "startFilePos": 577,
+                                      "endLine": 14,
+                                      "endTokenPos": 244,
+                                      "endFilePos": 589
+                                    },
+                                    "key": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 240,
+                                        "startFilePos": 577,
+                                        "endLine": 14,
+                                        "endTokenPos": 240,
+                                        "endFilePos": 581,
+                                        "kind": 1,
+                                        "rawValue": "'key'"
+                                      },
+                                      "value": "key"
+                                    },
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 244,
+                                        "startFilePos": 586,
+                                        "endLine": 14,
+                                        "endTokenPos": 244,
+                                        "endFilePos": 589
+                                      },
+                                      "name": "key"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 247,
+                                      "startFilePos": 592,
+                                      "endLine": 14,
+                                      "endTokenPos": 252,
+                                      "endFilePos": 604
+                                    },
+                                    "key": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 247,
+                                        "startFilePos": 592,
+                                        "endLine": 14,
+                                        "endTokenPos": 247,
+                                        "endFilePos": 598,
+                                        "kind": 1,
+                                        "rawValue": "'items'"
+                                      },
+                                      "value": "items"
+                                    },
+                                    "value": {
+                                      "nodeType": "Expr_Array",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 251,
+                                        "startFilePos": 603,
+                                        "endLine": 14,
+                                        "endTokenPos": 252,
+                                        "endFilePos": 604,
+                                        "kind": 2
+                                      },
+                                      "items": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 258,
+                          "startFilePos": 622,
+                          "endLine": 16,
+                          "endTokenPos": 284,
+                          "endFilePos": 669
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 258,
+                            "startFilePos": 622,
+                            "endLine": 16,
+                            "endTokenPos": 283,
+                            "endFilePos": 668
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 258,
+                              "startFilePos": 622,
+                              "endLine": 16,
+                              "endTokenPos": 266,
+                              "endFilePos": 643
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 16,
+                                "startTokenPos": 258,
+                                "startFilePos": 622,
+                                "endLine": 16,
+                                "endTokenPos": 264,
+                                "endFilePos": 641
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 258,
+                                  "startFilePos": 622,
+                                  "endLine": 16,
+                                  "endTokenPos": 261,
+                                  "endFilePos": 632
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 258,
+                                    "startFilePos": 622,
+                                    "endLine": 16,
+                                    "endTokenPos": 258,
+                                    "endFilePos": 628
+                                  },
+                                  "name": "groups"
+                                },
+                                "dim": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 260,
+                                    "startFilePos": 630,
+                                    "endLine": 16,
+                                    "endTokenPos": 260,
+                                    "endFilePos": 631
+                                  },
+                                  "name": "k"
+                                }
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 263,
+                                  "startFilePos": 634,
+                                  "endLine": 16,
+                                  "endTokenPos": 263,
+                                  "endFilePos": 640,
+                                  "kind": 1,
+                                  "rawValue": "'items'"
+                                },
+                                "value": "items"
+                              }
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 270,
+                              "startFilePos": 647,
+                              "endLine": 16,
+                              "endTokenPos": 283,
+                              "endFilePos": 668,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 271,
+                                  "startFilePos": 648,
+                                  "endLine": 16,
+                                  "endTokenPos": 275,
+                                  "endFilePos": 656
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 271,
+                                    "startFilePos": 648,
+                                    "endLine": 16,
+                                    "endTokenPos": 271,
+                                    "endFilePos": 650,
+                                    "kind": 1,
+                                    "rawValue": "'c'"
+                                  },
+                                  "value": "c"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 275,
+                                    "startFilePos": 655,
+                                    "endLine": 16,
+                                    "endTokenPos": 275,
+                                    "endFilePos": 656
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 16,
+                                  "startTokenPos": 278,
+                                  "startFilePos": 659,
+                                  "endLine": 16,
+                                  "endTokenPos": 282,
+                                  "endFilePos": 667
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 278,
+                                    "startFilePos": 659,
+                                    "endLine": 16,
+                                    "endTokenPos": 278,
+                                    "endFilePos": 661,
+                                    "kind": 1,
+                                    "rawValue": "'o'"
+                                  },
+                                  "value": "o"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 16,
+                                    "startTokenPos": 282,
+                                    "startFilePos": 666,
+                                    "endLine": 16,
+                                    "endTokenPos": 282,
+                                    "endFilePos": 667
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 288,
+                      "startFilePos": 681,
+                      "endLine": 26,
+                      "endTokenPos": 393,
+                      "endFilePos": 935
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 291,
+                        "startFilePos": 685,
+                        "endLine": 18,
+                        "endTokenPos": 292,
+                        "endFilePos": 693
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 292,
+                          "startFilePos": 686,
+                          "endLine": 18,
+                          "endTokenPos": 292,
+                          "endFilePos": 693
+                        },
+                        "name": "matched"
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 19,
+                          "startTokenPos": 297,
+                          "startFilePos": 704,
+                          "endLine": 19,
+                          "endTokenPos": 302,
+                          "endFilePos": 713
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 19,
+                            "startTokenPos": 297,
+                            "startFilePos": 704,
+                            "endLine": 19,
+                            "endTokenPos": 301,
+                            "endFilePos": 712
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 19,
+                              "startTokenPos": 297,
+                              "startFilePos": 704,
+                              "endLine": 19,
+                              "endTokenPos": 297,
+                              "endFilePos": 705
+                            },
+                            "name": "o"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 19,
+                              "startTokenPos": 301,
+                              "startFilePos": 709,
+                              "endLine": 19,
+                              "endTokenPos": 301,
+                              "endFilePos": 712
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 19,
+                                "startTokenPos": 301,
+                                "startFilePos": 709,
+                                "endLine": 19,
+                                "endTokenPos": 301,
+                                "endFilePos": 712
+                              },
+                              "name": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 20,
+                          "startTokenPos": 304,
+                          "startFilePos": 721,
+                          "endLine": 20,
+                          "endTokenPos": 312,
+                          "endFilePos": 738
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 20,
+                            "startTokenPos": 304,
+                            "startFilePos": 721,
+                            "endLine": 20,
+                            "endTokenPos": 311,
+                            "endFilePos": 737
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 20,
+                              "startTokenPos": 304,
+                              "startFilePos": 721,
+                              "endLine": 20,
+                              "endTokenPos": 304,
+                              "endFilePos": 724
+                            },
+                            "name": "key"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 20,
+                              "startTokenPos": 308,
+                              "startFilePos": 728,
+                              "endLine": 20,
+                              "endTokenPos": 311,
+                              "endFilePos": 737
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 308,
+                                "startFilePos": 728,
+                                "endLine": 20,
+                                "endTokenPos": 308,
+                                "endFilePos": 729
+                              },
+                              "name": "c"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 310,
+                                "startFilePos": 731,
+                                "endLine": 20,
+                                "endTokenPos": 310,
+                                "endFilePos": 736,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 21,
+                          "startTokenPos": 314,
+                          "startFilePos": 746,
+                          "endLine": 21,
+                          "endTokenPos": 322,
+                          "endFilePos": 768
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 21,
+                            "startTokenPos": 314,
+                            "startFilePos": 746,
+                            "endLine": 21,
+                            "endTokenPos": 321,
+                            "endFilePos": 767
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 314,
+                              "startFilePos": 746,
+                              "endLine": 21,
+                              "endTokenPos": 314,
+                              "endFilePos": 747
+                            },
+                            "name": "k"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 318,
+                              "startFilePos": 751,
+                              "endLine": 21,
+                              "endTokenPos": 321,
+                              "endFilePos": 767
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 318,
+                                "startFilePos": 751,
+                                "endLine": 21,
+                                "endTokenPos": 318,
+                                "endFilePos": 761
+                              },
+                              "name": "json_encode"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 21,
+                                  "startTokenPos": 320,
+                                  "startFilePos": 763,
+                                  "endLine": 21,
+                                  "endTokenPos": 320,
+                                  "endFilePos": 766
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 320,
+                                    "startFilePos": 763,
+                                    "endLine": 21,
+                                    "endTokenPos": 320,
+                                    "endFilePos": 766
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 324,
+                          "startFilePos": 776,
+                          "endLine": 24,
+                          "endTokenPos": 363,
+                          "endFilePos": 874
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 327,
+                            "startFilePos": 780,
+                            "endLine": 22,
+                            "endTokenPos": 334,
+                            "endFilePos": 809
+                          },
+                          "expr": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 328,
+                              "startFilePos": 781,
+                              "endLine": 22,
+                              "endTokenPos": 334,
+                              "endFilePos": 809
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 328,
+                                "startFilePos": 781,
+                                "endLine": 22,
+                                "endTokenPos": 328,
+                                "endFilePos": 796
+                              },
+                              "name": "array_key_exists"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 330,
+                                  "startFilePos": 798,
+                                  "endLine": 22,
+                                  "endTokenPos": 330,
+                                  "endFilePos": 799
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 330,
+                                    "startFilePos": 798,
+                                    "endLine": 22,
+                                    "endTokenPos": 330,
+                                    "endFilePos": 799
+                                  },
+                                  "name": "k"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 333,
+                                  "startFilePos": 802,
+                                  "endLine": 22,
+                                  "endTokenPos": 333,
+                                  "endFilePos": 808
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 333,
+                                    "startFilePos": 802,
+                                    "endLine": 22,
+                                    "endTokenPos": 333,
+                                    "endFilePos": 808
+                                  },
+                                  "name": "groups"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 23,
+                              "startTokenPos": 339,
+                              "startFilePos": 822,
+                              "endLine": 23,
+                              "endTokenPos": 361,
+                              "endFilePos": 866
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 339,
+                                "startFilePos": 822,
+                                "endLine": 23,
+                                "endTokenPos": 360,
+                                "endFilePos": 865
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 339,
+                                  "startFilePos": 822,
+                                  "endLine": 23,
+                                  "endTokenPos": 342,
+                                  "endFilePos": 832
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 339,
+                                    "startFilePos": 822,
+                                    "endLine": 23,
+                                    "endTokenPos": 339,
+                                    "endFilePos": 828
+                                  },
+                                  "name": "groups"
+                                },
+                                "dim": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 341,
+                                    "startFilePos": 830,
+                                    "endLine": 23,
+                                    "endTokenPos": 341,
+                                    "endFilePos": 831
+                                  },
+                                  "name": "k"
+                                }
+                              },
+                              "expr": {
+                                "nodeType": "Expr_Array",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 346,
+                                  "startFilePos": 836,
+                                  "endLine": 23,
+                                  "endTokenPos": 360,
+                                  "endFilePos": 865,
+                                  "kind": 2
+                                },
+                                "items": [
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 347,
+                                      "startFilePos": 837,
+                                      "endLine": 23,
+                                      "endTokenPos": 351,
+                                      "endFilePos": 849
+                                    },
+                                    "key": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 347,
+                                        "startFilePos": 837,
+                                        "endLine": 23,
+                                        "endTokenPos": 347,
+                                        "endFilePos": 841,
+                                        "kind": 1,
+                                        "rawValue": "'key'"
+                                      },
+                                      "value": "key"
+                                    },
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 351,
+                                        "startFilePos": 846,
+                                        "endLine": 23,
+                                        "endTokenPos": 351,
+                                        "endFilePos": 849
+                                      },
+                                      "name": "key"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 354,
+                                      "startFilePos": 852,
+                                      "endLine": 23,
+                                      "endTokenPos": 359,
+                                      "endFilePos": 864
+                                    },
+                                    "key": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 354,
+                                        "startFilePos": 852,
+                                        "endLine": 23,
+                                        "endTokenPos": 354,
+                                        "endFilePos": 858,
+                                        "kind": 1,
+                                        "rawValue": "'items'"
+                                      },
+                                      "value": "items"
+                                    },
+                                    "value": {
+                                      "nodeType": "Expr_Array",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 358,
+                                        "startFilePos": 863,
+                                        "endLine": 23,
+                                        "endTokenPos": 359,
+                                        "endFilePos": 864,
+                                        "kind": 2
+                                      },
+                                      "items": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 25,
+                          "startTokenPos": 365,
+                          "startFilePos": 882,
+                          "endLine": 25,
+                          "endTokenPos": 391,
+                          "endFilePos": 929
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 25,
+                            "startTokenPos": 365,
+                            "startFilePos": 882,
+                            "endLine": 25,
+                            "endTokenPos": 390,
+                            "endFilePos": 928
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 365,
+                              "startFilePos": 882,
+                              "endLine": 25,
+                              "endTokenPos": 373,
+                              "endFilePos": 903
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 365,
+                                "startFilePos": 882,
+                                "endLine": 25,
+                                "endTokenPos": 371,
+                                "endFilePos": 901
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 365,
+                                  "startFilePos": 882,
+                                  "endLine": 25,
+                                  "endTokenPos": 368,
+                                  "endFilePos": 892
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 365,
+                                    "startFilePos": 882,
+                                    "endLine": 25,
+                                    "endTokenPos": 365,
+                                    "endFilePos": 888
+                                  },
+                                  "name": "groups"
+                                },
+                                "dim": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 367,
+                                    "startFilePos": 890,
+                                    "endLine": 25,
+                                    "endTokenPos": 367,
+                                    "endFilePos": 891
+                                  },
+                                  "name": "k"
+                                }
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 370,
+                                  "startFilePos": 894,
+                                  "endLine": 25,
+                                  "endTokenPos": 370,
+                                  "endFilePos": 900,
+                                  "kind": 1,
+                                  "rawValue": "'items'"
+                                },
+                                "value": "items"
+                              }
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 377,
+                              "startFilePos": 907,
+                              "endLine": 25,
+                              "endTokenPos": 390,
+                              "endFilePos": 928,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 378,
+                                  "startFilePos": 908,
+                                  "endLine": 25,
+                                  "endTokenPos": 382,
+                                  "endFilePos": 916
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 378,
+                                    "startFilePos": 908,
+                                    "endLine": 25,
+                                    "endTokenPos": 378,
+                                    "endFilePos": 910,
+                                    "kind": 1,
+                                    "rawValue": "'c'"
+                                  },
+                                  "value": "c"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 382,
+                                    "startFilePos": 915,
+                                    "endLine": 25,
+                                    "endTokenPos": 382,
+                                    "endFilePos": 916
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 385,
+                                  "startFilePos": 919,
+                                  "endLine": 25,
+                                  "endTokenPos": 389,
+                                  "endFilePos": 927
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 385,
+                                    "startFilePos": 919,
+                                    "endLine": 25,
+                                    "endTokenPos": 385,
+                                    "endFilePos": 921,
+                                    "kind": 1,
+                                    "rawValue": "'o'"
+                                  },
+                                  "value": "o"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 389,
+                                    "startFilePos": 926,
+                                    "endLine": 25,
+                                    "endTokenPos": 389,
+                                    "endFilePos": 927
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 28,
+                  "startTokenPos": 397,
+                  "startFilePos": 943,
+                  "endLine": 28,
+                  "endTokenPos": 403,
+                  "endFilePos": 955
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 28,
+                    "startTokenPos": 397,
+                    "startFilePos": 943,
+                    "endLine": 28,
+                    "endTokenPos": 402,
+                    "endFilePos": 954
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 28,
+                      "startTokenPos": 397,
+                      "startFilePos": 943,
+                      "endLine": 28,
+                      "endTokenPos": 397,
+                      "endFilePos": 949
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 28,
+                      "startTokenPos": 401,
+                      "startFilePos": 953,
+                      "endLine": 28,
+                      "endTokenPos": 402,
+                      "endFilePos": 954,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 405,
+                  "startFilePos": 959,
+                  "endLine": 39,
+                  "endTokenPos": 519,
+                  "endFilePos": 1200
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 29,
+                    "startTokenPos": 408,
+                    "startFilePos": 968,
+                    "endLine": 29,
+                    "endTokenPos": 408,
+                    "endFilePos": 974
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 29,
+                    "startTokenPos": 412,
+                    "startFilePos": 979,
+                    "endLine": 29,
+                    "endTokenPos": 412,
+                    "endFilePos": 980
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 30,
+                      "startTokenPos": 417,
+                      "startFilePos": 991,
+                      "endLine": 38,
+                      "endTokenPos": 517,
+                      "endFilePos": 1196
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 30,
+                        "startTokenPos": 417,
+                        "startFilePos": 991,
+                        "endLine": 38,
+                        "endTokenPos": 516,
+                        "endFilePos": 1195
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 30,
+                          "startTokenPos": 417,
+                          "startFilePos": 991,
+                          "endLine": 30,
+                          "endTokenPos": 419,
+                          "endFilePos": 999
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 30,
+                            "startTokenPos": 417,
+                            "startFilePos": 991,
+                            "endLine": 30,
+                            "endTokenPos": 417,
+                            "endFilePos": 997
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 30,
+                          "startTokenPos": 423,
+                          "startFilePos": 1003,
+                          "endLine": 38,
+                          "endTokenPos": 516,
+                          "endFilePos": 1195,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 30,
+                              "startTokenPos": 424,
+                              "startFilePos": 1004,
+                              "endLine": 30,
+                              "endTokenPos": 431,
+                              "endFilePos": 1022
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 424,
+                                "startFilePos": 1004,
+                                "endLine": 30,
+                                "endTokenPos": 424,
+                                "endFilePos": 1009,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 428,
+                                "startFilePos": 1014,
+                                "endLine": 30,
+                                "endTokenPos": 431,
+                                "endFilePos": 1022
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 30,
+                                  "startTokenPos": 428,
+                                  "startFilePos": 1014,
+                                  "endLine": 30,
+                                  "endTokenPos": 428,
+                                  "endFilePos": 1015
+                                },
+                                "name": "g"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 30,
+                                  "startTokenPos": 430,
+                                  "startFilePos": 1017,
+                                  "endLine": 30,
+                                  "endTokenPos": 430,
+                                  "endFilePos": 1021,
+                                  "kind": 2,
+                                  "rawValue": "\"key\""
+                                },
+                                "value": "key"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 30,
+                              "startTokenPos": 434,
+                              "startFilePos": 1025,
+                              "endLine": 38,
+                              "endTokenPos": 515,
+                              "endFilePos": 1194
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 434,
+                                "startFilePos": 1025,
+                                "endLine": 30,
+                                "endTokenPos": 434,
+                                "endFilePos": 1031,
+                                "kind": 2,
+                                "rawValue": "\"count\""
+                              },
+                              "value": "count"
+                            },
+                            "value": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 438,
+                                "startFilePos": 1036,
+                                "endLine": 38,
+                                "endTokenPos": 515,
+                                "endFilePos": 1194
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 30,
+                                  "startTokenPos": 438,
+                                  "startFilePos": 1036,
+                                  "endLine": 30,
+                                  "endTokenPos": 438,
+                                  "endFilePos": 1040
+                                },
+                                "name": "count"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 30,
+                                    "startTokenPos": 440,
+                                    "startFilePos": 1042,
+                                    "endLine": 38,
+                                    "endTokenPos": 514,
+                                    "endFilePos": 1193
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_FuncCall",
+                                    "attributes": {
+                                      "startLine": 30,
+                                      "startTokenPos": 440,
+                                      "startFilePos": 1042,
+                                      "endLine": 38,
+                                      "endTokenPos": 514,
+                                      "endFilePos": 1193
+                                    },
+                                    "name": {
+                                      "nodeType": "Expr_Closure",
+                                      "attributes": {
+                                        "startLine": 30,
+                                        "startTokenPos": 441,
+                                        "startFilePos": 1043,
+                                        "endLine": 38,
+                                        "endTokenPos": 511,
+                                        "endFilePos": 1190
+                                      },
+                                      "static": false,
+                                      "byRef": false,
+                                      "params": [],
+                                      "uses": [
+                                        {
+                                          "nodeType": "ClosureUse",
+                                          "attributes": {
+                                            "startLine": 30,
+                                            "startTokenPos": 448,
+                                            "startFilePos": 1059,
+                                            "endLine": 30,
+                                            "endTokenPos": 448,
+                                            "endFilePos": 1060
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 30,
+                                              "startTokenPos": 448,
+                                              "startFilePos": 1059,
+                                              "endLine": 30,
+                                              "endTokenPos": 448,
+                                              "endFilePos": 1060
+                                            },
+                                            "name": "c"
+                                          },
+                                          "byRef": false
+                                        },
+                                        {
+                                          "nodeType": "ClosureUse",
+                                          "attributes": {
+                                            "startLine": 30,
+                                            "startTokenPos": 451,
+                                            "startFilePos": 1063,
+                                            "endLine": 30,
+                                            "endTokenPos": 451,
+                                            "endFilePos": 1064
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 30,
+                                              "startTokenPos": 451,
+                                              "startFilePos": 1063,
+                                              "endLine": 30,
+                                              "endTokenPos": 451,
+                                              "endFilePos": 1064
+                                            },
+                                            "name": "o"
+                                          },
+                                          "byRef": false
+                                        },
+                                        {
+                                          "nodeType": "ClosureUse",
+                                          "attributes": {
+                                            "startLine": 30,
+                                            "startTokenPos": 454,
+                                            "startFilePos": 1067,
+                                            "endLine": 30,
+                                            "endTokenPos": 454,
+                                            "endFilePos": 1068
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 30,
+                                              "startTokenPos": 454,
+                                              "startFilePos": 1067,
+                                              "endLine": 30,
+                                              "endTokenPos": 454,
+                                              "endFilePos": 1068
+                                            },
+                                            "name": "g"
+                                          },
+                                          "byRef": false
+                                        }
+                                      ],
+                                      "returnType": null,
+                                      "stmts": [
+                                        {
+                                          "nodeType": "Stmt_Expression",
+                                          "attributes": {
+                                            "startLine": 31,
+                                            "startTokenPos": 459,
+                                            "startFilePos": 1075,
+                                            "endLine": 31,
+                                            "endTokenPos": 465,
+                                            "endFilePos": 1087
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_Assign",
+                                            "attributes": {
+                                              "startLine": 31,
+                                              "startTokenPos": 459,
+                                              "startFilePos": 1075,
+                                              "endLine": 31,
+                                              "endTokenPos": 464,
+                                              "endFilePos": 1086
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 31,
+                                                "startTokenPos": 459,
+                                                "startFilePos": 1075,
+                                                "endLine": 31,
+                                                "endTokenPos": 459,
+                                                "endFilePos": 1081
+                                              },
+                                              "name": "result"
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Array",
+                                              "attributes": {
+                                                "startLine": 31,
+                                                "startTokenPos": 463,
+                                                "startFilePos": 1085,
+                                                "endLine": 31,
+                                                "endTokenPos": 464,
+                                                "endFilePos": 1086,
+                                                "kind": 2
+                                              },
+                                              "items": []
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "nodeType": "Stmt_Foreach",
+                                          "attributes": {
+                                            "startLine": 32,
+                                            "startTokenPos": 467,
+                                            "startFilePos": 1091,
+                                            "endLine": 36,
+                                            "endTokenPos": 504,
+                                            "endFilePos": 1170
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 32,
+                                              "startTokenPos": 470,
+                                              "startFilePos": 1100,
+                                              "endLine": 32,
+                                              "endTokenPos": 473,
+                                              "endFilePos": 1110
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 32,
+                                                "startTokenPos": 470,
+                                                "startFilePos": 1100,
+                                                "endLine": 32,
+                                                "endTokenPos": 470,
+                                                "endFilePos": 1101
+                                              },
+                                              "name": "g"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 32,
+                                                "startTokenPos": 472,
+                                                "startFilePos": 1103,
+                                                "endLine": 32,
+                                                "endTokenPos": 472,
+                                                "endFilePos": 1109,
+                                                "kind": 2,
+                                                "rawValue": "\"items\""
+                                              },
+                                              "value": "items"
+                                            }
+                                          },
+                                          "keyVar": null,
+                                          "byRef": false,
+                                          "valueVar": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 32,
+                                              "startTokenPos": 477,
+                                              "startFilePos": 1115,
+                                              "endLine": 32,
+                                              "endTokenPos": 477,
+                                              "endFilePos": 1116
+                                            },
+                                            "name": "r"
+                                          },
+                                          "stmts": [
+                                            {
+                                              "nodeType": "Stmt_If",
+                                              "attributes": {
+                                                "startLine": 33,
+                                                "startTokenPos": 482,
+                                                "startFilePos": 1125,
+                                                "endLine": 35,
+                                                "endTokenPos": 502,
+                                                "endFilePos": 1166
+                                              },
+                                              "cond": {
+                                                "nodeType": "Expr_ArrayDimFetch",
+                                                "attributes": {
+                                                  "startLine": 33,
+                                                  "startTokenPos": 485,
+                                                  "startFilePos": 1129,
+                                                  "endLine": 33,
+                                                  "endTokenPos": 488,
+                                                  "endFilePos": 1135
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 33,
+                                                    "startTokenPos": 485,
+                                                    "startFilePos": 1129,
+                                                    "endLine": 33,
+                                                    "endTokenPos": 485,
+                                                    "endFilePos": 1130
+                                                  },
+                                                  "name": "r"
+                                                },
+                                                "dim": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 33,
+                                                    "startTokenPos": 487,
+                                                    "startFilePos": 1132,
+                                                    "endLine": 33,
+                                                    "endTokenPos": 487,
+                                                    "endFilePos": 1134,
+                                                    "kind": 2,
+                                                    "rawValue": "\"o\""
+                                                  },
+                                                  "value": "o"
+                                                }
+                                              },
+                                              "stmts": [
+                                                {
+                                                  "nodeType": "Stmt_Expression",
+                                                  "attributes": {
+                                                    "startLine": 34,
+                                                    "startTokenPos": 493,
+                                                    "startFilePos": 1146,
+                                                    "endLine": 34,
+                                                    "endTokenPos": 500,
+                                                    "endFilePos": 1160
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_Assign",
+                                                    "attributes": {
+                                                      "startLine": 34,
+                                                      "startTokenPos": 493,
+                                                      "startFilePos": 1146,
+                                                      "endLine": 34,
+                                                      "endTokenPos": 499,
+                                                      "endFilePos": 1159
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_ArrayDimFetch",
+                                                      "attributes": {
+                                                        "startLine": 34,
+                                                        "startTokenPos": 493,
+                                                        "startFilePos": 1146,
+                                                        "endLine": 34,
+                                                        "endTokenPos": 495,
+                                                        "endFilePos": 1154
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_Variable",
+                                                        "attributes": {
+                                                          "startLine": 34,
+                                                          "startTokenPos": 493,
+                                                          "startFilePos": 1146,
+                                                          "endLine": 34,
+                                                          "endTokenPos": 493,
+                                                          "endFilePos": 1152
+                                                        },
+                                                        "name": "result"
+                                                      },
+                                                      "dim": null
+                                                    },
+                                                    "expr": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 34,
+                                                        "startTokenPos": 499,
+                                                        "startFilePos": 1158,
+                                                        "endLine": 34,
+                                                        "endTokenPos": 499,
+                                                        "endFilePos": 1159
+                                                      },
+                                                      "name": "r"
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "elseifs": [],
+                                              "else": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "nodeType": "Stmt_Return",
+                                          "attributes": {
+                                            "startLine": 37,
+                                            "startTokenPos": 506,
+                                            "startFilePos": 1174,
+                                            "endLine": 37,
+                                            "endTokenPos": 509,
+                                            "endFilePos": 1188
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 37,
+                                              "startTokenPos": 508,
+                                              "startFilePos": 1181,
+                                              "endLine": 37,
+                                              "endTokenPos": 508,
+                                              "endFilePos": 1187
+                                            },
+                                            "name": "result"
+                                          }
+                                        }
+                                      ],
+                                      "attrGroups": []
+                                    },
+                                    "args": []
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 40,
+                  "startTokenPos": 521,
+                  "startFilePos": 1204,
+                  "endLine": 40,
+                  "endTokenPos": 524,
+                  "endFilePos": 1218
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 40,
+                    "startTokenPos": 523,
+                    "startFilePos": 1211,
+                    "endLine": 40,
+                    "endTokenPos": 523,
+                    "endFilePos": 1217
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 42,
+        "startTokenPos": 532,
+        "startFilePos": 1226,
+        "endLine": 42,
+        "endTokenPos": 538,
+        "endFilePos": 1265
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 42,
+            "startTokenPos": 534,
+            "startFilePos": 1231,
+            "endLine": 42,
+            "endTokenPos": 534,
+            "endFilePos": 1255,
+            "kind": 2,
+            "rawValue": "\"--- Group Left Join ---\""
+          },
+          "value": "--- Group Left Join ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 42,
+            "startTokenPos": 537,
+            "startFilePos": 1258,
+            "endLine": 42,
+            "endTokenPos": 537,
+            "endFilePos": 1264
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 42,
+              "startTokenPos": 537,
+              "startFilePos": 1258,
+              "endLine": 42,
+              "endTokenPos": 537,
+              "endFilePos": 1264
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 43,
+        "startTokenPos": 540,
+        "startFilePos": 1267,
+        "endLine": 45,
+        "endTokenPos": 632,
+        "endFilePos": 1474
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 43,
+          "startTokenPos": 543,
+          "startFilePos": 1276,
+          "endLine": 43,
+          "endTokenPos": 543,
+          "endFilePos": 1281
+        },
+        "name": "stats"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 43,
+          "startTokenPos": 547,
+          "startFilePos": 1286,
+          "endLine": 43,
+          "endTokenPos": 547,
+          "endFilePos": 1287
+        },
+        "name": "s"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 44,
+            "startTokenPos": 552,
+            "startFilePos": 1294,
+            "endLine": 44,
+            "endTokenPos": 630,
+            "endFilePos": 1472
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 44,
+                "startTokenPos": 554,
+                "startFilePos": 1299,
+                "endLine": 44,
+                "endTokenPos": 626,
+                "endFilePos": 1462
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 44,
+                  "startTokenPos": 554,
+                  "startFilePos": 1299,
+                  "endLine": 44,
+                  "endTokenPos": 594,
+                  "endFilePos": 1389
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 44,
+                    "startTokenPos": 554,
+                    "startFilePos": 1299,
+                    "endLine": 44,
+                    "endTokenPos": 590,
+                    "endFilePos": 1383
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 44,
+                      "startTokenPos": 554,
+                      "startFilePos": 1299,
+                      "endLine": 44,
+                      "endTokenPos": 586,
+                      "endFilePos": 1371
+                    },
+                    "left": {
+                      "nodeType": "Expr_Ternary",
+                      "attributes": {
+                        "startLine": 44,
+                        "startTokenPos": 555,
+                        "startFilePos": 1300,
+                        "endLine": 44,
+                        "endTokenPos": 581,
+                        "endFilePos": 1364
+                      },
+                      "cond": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 44,
+                          "startTokenPos": 555,
+                          "startFilePos": 1300,
+                          "endLine": 44,
+                          "endTokenPos": 561,
+                          "endFilePos": 1319
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 555,
+                            "startFilePos": 1300,
+                            "endLine": 44,
+                            "endTokenPos": 555,
+                            "endFilePos": 1307
+                          },
+                          "name": "is_float"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 44,
+                              "startTokenPos": 557,
+                              "startFilePos": 1309,
+                              "endLine": 44,
+                              "endTokenPos": 560,
+                              "endFilePos": 1318
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 44,
+                                "startTokenPos": 557,
+                                "startFilePos": 1309,
+                                "endLine": 44,
+                                "endTokenPos": 560,
+                                "endFilePos": 1318
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 44,
+                                  "startTokenPos": 557,
+                                  "startFilePos": 1309,
+                                  "endLine": 44,
+                                  "endTokenPos": 557,
+                                  "endFilePos": 1310
+                                },
+                                "name": "s"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 44,
+                                  "startTokenPos": 559,
+                                  "startFilePos": 1312,
+                                  "endLine": 44,
+                                  "endTokenPos": 559,
+                                  "endFilePos": 1317,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "if": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 44,
+                          "startTokenPos": 565,
+                          "startFilePos": 1323,
+                          "endLine": 44,
+                          "endTokenPos": 574,
+                          "endFilePos": 1351
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 565,
+                            "startFilePos": 1323,
+                            "endLine": 44,
+                            "endTokenPos": 565,
+                            "endFilePos": 1333
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 44,
+                              "startTokenPos": 567,
+                              "startFilePos": 1335,
+                              "endLine": 44,
+                              "endTokenPos": 570,
+                              "endFilePos": 1344
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 44,
+                                "startTokenPos": 567,
+                                "startFilePos": 1335,
+                                "endLine": 44,
+                                "endTokenPos": 570,
+                                "endFilePos": 1344
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 44,
+                                  "startTokenPos": 567,
+                                  "startFilePos": 1335,
+                                  "endLine": 44,
+                                  "endTokenPos": 567,
+                                  "endFilePos": 1336
+                                },
+                                "name": "s"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 44,
+                                  "startTokenPos": 569,
+                                  "startFilePos": 1338,
+                                  "endLine": 44,
+                                  "endTokenPos": 569,
+                                  "endFilePos": 1343,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 44,
+                              "startTokenPos": 573,
+                              "startFilePos": 1347,
+                              "endLine": 44,
+                              "endTokenPos": 573,
+                              "endFilePos": 1350
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 44,
+                                "startTokenPos": 573,
+                                "startFilePos": 1347,
+                                "endLine": 44,
+                                "endTokenPos": 573,
+                                "endFilePos": 1350,
+                                "rawValue": "1344",
+                                "kind": 10
+                              },
+                              "value": 1344
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "else": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 44,
+                          "startTokenPos": 578,
+                          "startFilePos": 1355,
+                          "endLine": 44,
+                          "endTokenPos": 581,
+                          "endFilePos": 1364
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 578,
+                            "startFilePos": 1355,
+                            "endLine": 44,
+                            "endTokenPos": 578,
+                            "endFilePos": 1356
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 580,
+                            "startFilePos": 1358,
+                            "endLine": 44,
+                            "endTokenPos": 580,
+                            "endFilePos": 1363,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 44,
+                        "startTokenPos": 586,
+                        "startFilePos": 1369,
+                        "endLine": 44,
+                        "endTokenPos": 586,
+                        "endFilePos": 1371,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 44,
+                      "startTokenPos": 590,
+                      "startFilePos": 1375,
+                      "endLine": 44,
+                      "endTokenPos": 590,
+                      "endFilePos": 1383,
+                      "kind": 2,
+                      "rawValue": "\"orders:\""
+                    },
+                    "value": "orders:"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 44,
+                    "startTokenPos": 594,
+                    "startFilePos": 1387,
+                    "endLine": 44,
+                    "endTokenPos": 594,
+                    "endFilePos": 1389,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 44,
+                  "startTokenPos": 599,
+                  "startFilePos": 1394,
+                  "endLine": 44,
+                  "endTokenPos": 625,
+                  "endFilePos": 1461
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 44,
+                    "startTokenPos": 599,
+                    "startFilePos": 1394,
+                    "endLine": 44,
+                    "endTokenPos": 605,
+                    "endFilePos": 1414
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 44,
+                      "startTokenPos": 599,
+                      "startFilePos": 1394,
+                      "endLine": 44,
+                      "endTokenPos": 599,
+                      "endFilePos": 1401
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 44,
+                        "startTokenPos": 601,
+                        "startFilePos": 1403,
+                        "endLine": 44,
+                        "endTokenPos": 604,
+                        "endFilePos": 1413
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 44,
+                          "startTokenPos": 601,
+                          "startFilePos": 1403,
+                          "endLine": 44,
+                          "endTokenPos": 604,
+                          "endFilePos": 1413
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 601,
+                            "startFilePos": 1403,
+                            "endLine": 44,
+                            "endTokenPos": 601,
+                            "endFilePos": 1404
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 603,
+                            "startFilePos": 1406,
+                            "endLine": 44,
+                            "endTokenPos": 603,
+                            "endFilePos": 1412,
+                            "kind": 2,
+                            "rawValue": "\"count\""
+                          },
+                          "value": "count"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 44,
+                    "startTokenPos": 609,
+                    "startFilePos": 1418,
+                    "endLine": 44,
+                    "endTokenPos": 618,
+                    "endFilePos": 1447
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 44,
+                      "startTokenPos": 609,
+                      "startFilePos": 1418,
+                      "endLine": 44,
+                      "endTokenPos": 609,
+                      "endFilePos": 1428
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 44,
+                        "startTokenPos": 611,
+                        "startFilePos": 1430,
+                        "endLine": 44,
+                        "endTokenPos": 614,
+                        "endFilePos": 1440
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 44,
+                          "startTokenPos": 611,
+                          "startFilePos": 1430,
+                          "endLine": 44,
+                          "endTokenPos": 614,
+                          "endFilePos": 1440
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 611,
+                            "startFilePos": 1430,
+                            "endLine": 44,
+                            "endTokenPos": 611,
+                            "endFilePos": 1431
+                          },
+                          "name": "s"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 44,
+                            "startTokenPos": 613,
+                            "startFilePos": 1433,
+                            "endLine": 44,
+                            "endTokenPos": 613,
+                            "endFilePos": 1439,
+                            "kind": 2,
+                            "rawValue": "\"count\""
+                          },
+                          "value": "count"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 44,
+                        "startTokenPos": 617,
+                        "startFilePos": 1443,
+                        "endLine": 44,
+                        "endTokenPos": 617,
+                        "endFilePos": 1446
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 44,
+                          "startTokenPos": 617,
+                          "startFilePos": 1443,
+                          "endLine": 44,
+                          "endTokenPos": 617,
+                          "endFilePos": 1446,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 44,
+                    "startTokenPos": 622,
+                    "startFilePos": 1451,
+                    "endLine": 44,
+                    "endTokenPos": 625,
+                    "endFilePos": 1461
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 44,
+                      "startTokenPos": 622,
+                      "startFilePos": 1451,
+                      "endLine": 44,
+                      "endTokenPos": 622,
+                      "endFilePos": 1452
+                    },
+                    "name": "s"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 44,
+                      "startTokenPos": 624,
+                      "startFilePos": 1454,
+                      "endLine": 44,
+                      "endTokenPos": 624,
+                      "endFilePos": 1460,
+                      "kind": 2,
+                      "rawValue": "\"count\""
+                    },
+                    "value": "count"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 44,
+                "startTokenPos": 629,
+                "startFilePos": 1465,
+                "endLine": 44,
+                "endTokenPos": 629,
+                "endFilePos": 1471
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 44,
+                  "startTokenPos": 629,
+                  "startFilePos": 1465,
+                  "endLine": 44,
+                  "endTokenPos": 629,
+                  "endFilePos": 1471
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_multi_join.php.json
+++ b/tests/json-ast/x/php/group_by_multi_join.php.json
@@ -1,0 +1,3779 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 37,
+        "endFilePos": 73
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 36,
+          "endFilePos": 72
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 13
+          },
+          "name": "nations"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 17,
+            "endLine": 2,
+            "endTokenPos": 36,
+            "endFilePos": 72,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 43
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 43,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 19,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 27
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 19,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 22,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 27,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 27,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 30,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 42
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 30,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 35,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 40,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 42,
+                        "kind": 2,
+                        "rawValue": "\"A\""
+                      },
+                      "value": "A"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 46,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 71
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 46,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 71,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 47,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 55
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 47,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 50,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 55,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 55,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 58,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 70
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 58,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 63,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 68,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 70,
+                        "kind": 2,
+                        "rawValue": "\"B\""
+                      },
+                      "value": "B"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 39,
+        "startFilePos": 75,
+        "endLine": 3,
+        "endTokenPos": 75,
+        "endFilePos": 144
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 39,
+          "startFilePos": 75,
+          "endLine": 3,
+          "endTokenPos": 74,
+          "endFilePos": 143
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 39,
+            "startFilePos": 75,
+            "endLine": 3,
+            "endTokenPos": 39,
+            "endFilePos": 84
+          },
+          "name": "suppliers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 43,
+            "startFilePos": 88,
+            "endLine": 3,
+            "endTokenPos": 74,
+            "endFilePos": 143,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 44,
+                "startFilePos": 89,
+                "endLine": 3,
+                "endTokenPos": 57,
+                "endFilePos": 114
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 89,
+                  "endLine": 3,
+                  "endTokenPos": 57,
+                  "endFilePos": 114,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 45,
+                      "startFilePos": 90,
+                      "endLine": 3,
+                      "endTokenPos": 49,
+                      "endFilePos": 98
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 45,
+                        "startFilePos": 90,
+                        "endLine": 3,
+                        "endTokenPos": 45,
+                        "endFilePos": 93,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 49,
+                        "startFilePos": 98,
+                        "endLine": 3,
+                        "endTokenPos": 49,
+                        "endFilePos": 98,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 52,
+                      "startFilePos": 101,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 113
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 52,
+                        "startFilePos": 101,
+                        "endLine": 3,
+                        "endTokenPos": 52,
+                        "endFilePos": 108,
+                        "kind": 2,
+                        "rawValue": "\"nation\""
+                      },
+                      "value": "nation"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 56,
+                        "startFilePos": 113,
+                        "endLine": 3,
+                        "endTokenPos": 56,
+                        "endFilePos": 113,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 117,
+                "endLine": 3,
+                "endTokenPos": 73,
+                "endFilePos": 142
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 117,
+                  "endLine": 3,
+                  "endTokenPos": 73,
+                  "endFilePos": 142,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 118,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 126
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 118,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 121,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 126,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 126,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 141
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 136,
+                        "kind": 2,
+                        "rawValue": "\"nation\""
+                      },
+                      "value": "nation"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 141,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 141,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 77,
+        "startFilePos": 146,
+        "endLine": 4,
+        "endTokenPos": 171,
+        "endFilePos": 343
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 77,
+          "startFilePos": 146,
+          "endLine": 4,
+          "endTokenPos": 170,
+          "endFilePos": 342
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 77,
+            "startFilePos": 146,
+            "endLine": 4,
+            "endTokenPos": 77,
+            "endFilePos": 154
+          },
+          "name": "partsupp"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 81,
+            "startFilePos": 158,
+            "endLine": 4,
+            "endTokenPos": 170,
+            "endFilePos": 342,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 82,
+                "startFilePos": 159,
+                "endLine": 4,
+                "endTokenPos": 109,
+                "endFilePos": 218
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 82,
+                  "startFilePos": 159,
+                  "endLine": 4,
+                  "endTokenPos": 109,
+                  "endFilePos": 218,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 83,
+                      "startFilePos": 160,
+                      "endLine": 4,
+                      "endTokenPos": 87,
+                      "endFilePos": 172
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 83,
+                        "startFilePos": 160,
+                        "endLine": 4,
+                        "endTokenPos": 83,
+                        "endFilePos": 165,
+                        "kind": 2,
+                        "rawValue": "\"part\""
+                      },
+                      "value": "part"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 87,
+                        "startFilePos": 170,
+                        "endLine": 4,
+                        "endTokenPos": 87,
+                        "endFilePos": 172,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 90,
+                      "startFilePos": 175,
+                      "endLine": 4,
+                      "endTokenPos": 94,
+                      "endFilePos": 189
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 90,
+                        "startFilePos": 175,
+                        "endLine": 4,
+                        "endTokenPos": 90,
+                        "endFilePos": 184,
+                        "kind": 2,
+                        "rawValue": "\"supplier\""
+                      },
+                      "value": "supplier"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 94,
+                        "startFilePos": 189,
+                        "endLine": 4,
+                        "endTokenPos": 94,
+                        "endFilePos": 189,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 97,
+                      "startFilePos": 192,
+                      "endLine": 4,
+                      "endTokenPos": 101,
+                      "endFilePos": 205
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 97,
+                        "startFilePos": 192,
+                        "endLine": 4,
+                        "endTokenPos": 97,
+                        "endFilePos": 197,
+                        "kind": 2,
+                        "rawValue": "\"cost\""
+                      },
+                      "value": "cost"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 101,
+                        "startFilePos": 202,
+                        "endLine": 4,
+                        "endTokenPos": 101,
+                        "endFilePos": 205,
+                        "rawValue": "10.0"
+                      },
+                      "value": 10
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 104,
+                      "startFilePos": 208,
+                      "endLine": 4,
+                      "endTokenPos": 108,
+                      "endFilePos": 217
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 104,
+                        "startFilePos": 208,
+                        "endLine": 4,
+                        "endTokenPos": 104,
+                        "endFilePos": 212,
+                        "kind": 2,
+                        "rawValue": "\"qty\""
+                      },
+                      "value": "qty"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 108,
+                        "startFilePos": 217,
+                        "endLine": 4,
+                        "endTokenPos": 108,
+                        "endFilePos": 217,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 112,
+                "startFilePos": 221,
+                "endLine": 4,
+                "endTokenPos": 139,
+                "endFilePos": 280
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 112,
+                  "startFilePos": 221,
+                  "endLine": 4,
+                  "endTokenPos": 139,
+                  "endFilePos": 280,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 113,
+                      "startFilePos": 222,
+                      "endLine": 4,
+                      "endTokenPos": 117,
+                      "endFilePos": 234
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 113,
+                        "startFilePos": 222,
+                        "endLine": 4,
+                        "endTokenPos": 113,
+                        "endFilePos": 227,
+                        "kind": 2,
+                        "rawValue": "\"part\""
+                      },
+                      "value": "part"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 117,
+                        "startFilePos": 232,
+                        "endLine": 4,
+                        "endTokenPos": 117,
+                        "endFilePos": 234,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 120,
+                      "startFilePos": 237,
+                      "endLine": 4,
+                      "endTokenPos": 124,
+                      "endFilePos": 251
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 120,
+                        "startFilePos": 237,
+                        "endLine": 4,
+                        "endTokenPos": 120,
+                        "endFilePos": 246,
+                        "kind": 2,
+                        "rawValue": "\"supplier\""
+                      },
+                      "value": "supplier"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 124,
+                        "startFilePos": 251,
+                        "endLine": 4,
+                        "endTokenPos": 124,
+                        "endFilePos": 251,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 127,
+                      "startFilePos": 254,
+                      "endLine": 4,
+                      "endTokenPos": 131,
+                      "endFilePos": 267
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 127,
+                        "startFilePos": 254,
+                        "endLine": 4,
+                        "endTokenPos": 127,
+                        "endFilePos": 259,
+                        "kind": 2,
+                        "rawValue": "\"cost\""
+                      },
+                      "value": "cost"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 131,
+                        "startFilePos": 264,
+                        "endLine": 4,
+                        "endTokenPos": 131,
+                        "endFilePos": 267,
+                        "rawValue": "20.0"
+                      },
+                      "value": 20
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 134,
+                      "startFilePos": 270,
+                      "endLine": 4,
+                      "endTokenPos": 138,
+                      "endFilePos": 279
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 134,
+                        "startFilePos": 270,
+                        "endLine": 4,
+                        "endTokenPos": 134,
+                        "endFilePos": 274,
+                        "kind": 2,
+                        "rawValue": "\"qty\""
+                      },
+                      "value": "qty"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 138,
+                        "startFilePos": 279,
+                        "endLine": 4,
+                        "endTokenPos": 138,
+                        "endFilePos": 279,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 142,
+                "startFilePos": 283,
+                "endLine": 4,
+                "endTokenPos": 169,
+                "endFilePos": 341
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 142,
+                  "startFilePos": 283,
+                  "endLine": 4,
+                  "endTokenPos": 169,
+                  "endFilePos": 341,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 143,
+                      "startFilePos": 284,
+                      "endLine": 4,
+                      "endTokenPos": 147,
+                      "endFilePos": 296
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 143,
+                        "startFilePos": 284,
+                        "endLine": 4,
+                        "endTokenPos": 143,
+                        "endFilePos": 289,
+                        "kind": 2,
+                        "rawValue": "\"part\""
+                      },
+                      "value": "part"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 147,
+                        "startFilePos": 294,
+                        "endLine": 4,
+                        "endTokenPos": 147,
+                        "endFilePos": 296,
+                        "rawValue": "200",
+                        "kind": 10
+                      },
+                      "value": 200
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 150,
+                      "startFilePos": 299,
+                      "endLine": 4,
+                      "endTokenPos": 154,
+                      "endFilePos": 313
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 150,
+                        "startFilePos": 299,
+                        "endLine": 4,
+                        "endTokenPos": 150,
+                        "endFilePos": 308,
+                        "kind": 2,
+                        "rawValue": "\"supplier\""
+                      },
+                      "value": "supplier"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 154,
+                        "startFilePos": 313,
+                        "endLine": 4,
+                        "endTokenPos": 154,
+                        "endFilePos": 313,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 157,
+                      "startFilePos": 316,
+                      "endLine": 4,
+                      "endTokenPos": 161,
+                      "endFilePos": 328
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 157,
+                        "startFilePos": 316,
+                        "endLine": 4,
+                        "endTokenPos": 157,
+                        "endFilePos": 321,
+                        "kind": 2,
+                        "rawValue": "\"cost\""
+                      },
+                      "value": "cost"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 161,
+                        "startFilePos": 326,
+                        "endLine": 4,
+                        "endTokenPos": 161,
+                        "endFilePos": 328,
+                        "rawValue": "5.0"
+                      },
+                      "value": 5
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 164,
+                      "startFilePos": 331,
+                      "endLine": 4,
+                      "endTokenPos": 168,
+                      "endFilePos": 340
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 164,
+                        "startFilePos": 331,
+                        "endLine": 4,
+                        "endTokenPos": 164,
+                        "endFilePos": 335,
+                        "kind": 2,
+                        "rawValue": "\"qty\""
+                      },
+                      "value": "qty"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 168,
+                        "startFilePos": 340,
+                        "endLine": 4,
+                        "endTokenPos": 168,
+                        "endFilePos": 340,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 173,
+        "startFilePos": 345,
+        "endLine": 5,
+        "endTokenPos": 179,
+        "endFilePos": 359
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 173,
+          "startFilePos": 345,
+          "endLine": 5,
+          "endTokenPos": 178,
+          "endFilePos": 358
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 173,
+            "startFilePos": 345,
+            "endLine": 5,
+            "endTokenPos": 173,
+            "endFilePos": 353
+          },
+          "name": "filtered"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 177,
+            "startFilePos": 357,
+            "endLine": 5,
+            "endTokenPos": 178,
+            "endFilePos": 358,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 181,
+        "startFilePos": 361,
+        "endLine": 14,
+        "endTokenPos": 301,
+        "endFilePos": 644
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 184,
+          "startFilePos": 370,
+          "endLine": 6,
+          "endTokenPos": 184,
+          "endFilePos": 378
+        },
+        "name": "partsupp"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 188,
+          "startFilePos": 383,
+          "endLine": 6,
+          "endTokenPos": 188,
+          "endFilePos": 385
+        },
+        "name": "ps"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 193,
+            "startFilePos": 392,
+            "endLine": 13,
+            "endTokenPos": 299,
+            "endFilePos": 642
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 196,
+              "startFilePos": 401,
+              "endLine": 7,
+              "endTokenPos": 196,
+              "endFilePos": 410
+            },
+            "name": "suppliers"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 200,
+              "startFilePos": 415,
+              "endLine": 7,
+              "endTokenPos": 200,
+              "endFilePos": 416
+            },
+            "name": "s"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Foreach",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 205,
+                "startFilePos": 425,
+                "endLine": 12,
+                "endTokenPos": 297,
+                "endFilePos": 638
+              },
+              "expr": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 208,
+                  "startFilePos": 434,
+                  "endLine": 8,
+                  "endTokenPos": 208,
+                  "endFilePos": 441
+                },
+                "name": "nations"
+              },
+              "keyVar": null,
+              "byRef": false,
+              "valueVar": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 212,
+                  "startFilePos": 446,
+                  "endLine": 8,
+                  "endTokenPos": 212,
+                  "endFilePos": 447
+                },
+                "name": "n"
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_If",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 217,
+                    "startFilePos": 458,
+                    "endLine": 11,
+                    "endTokenPos": 295,
+                    "endFilePos": 632
+                  },
+                  "cond": {
+                    "nodeType": "Expr_BinaryOp_BooleanAnd",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 220,
+                      "startFilePos": 462,
+                      "endLine": 9,
+                      "endTokenPos": 255,
+                      "endFilePos": 537
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_BooleanAnd",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 220,
+                        "startFilePos": 462,
+                        "endLine": 9,
+                        "endTokenPos": 244,
+                        "endFilePos": 516
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Equal",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 220,
+                          "startFilePos": 462,
+                          "endLine": 9,
+                          "endTokenPos": 230,
+                          "endFilePos": 488
+                        },
+                        "left": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 220,
+                            "startFilePos": 462,
+                            "endLine": 9,
+                            "endTokenPos": 223,
+                            "endFilePos": 469
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 220,
+                              "startFilePos": 462,
+                              "endLine": 9,
+                              "endTokenPos": 220,
+                              "endFilePos": 463
+                            },
+                            "name": "s"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 222,
+                              "startFilePos": 465,
+                              "endLine": 9,
+                              "endTokenPos": 222,
+                              "endFilePos": 468,
+                              "kind": 2,
+                              "rawValue": "\"id\""
+                            },
+                            "value": "id"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 227,
+                            "startFilePos": 474,
+                            "endLine": 9,
+                            "endTokenPos": 230,
+                            "endFilePos": 488
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 227,
+                              "startFilePos": 474,
+                              "endLine": 9,
+                              "endTokenPos": 227,
+                              "endFilePos": 476
+                            },
+                            "name": "ps"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 229,
+                              "startFilePos": 478,
+                              "endLine": 9,
+                              "endTokenPos": 229,
+                              "endFilePos": 487,
+                              "kind": 2,
+                              "rawValue": "\"supplier\""
+                            },
+                            "value": "supplier"
+                          }
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_BinaryOp_Equal",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 234,
+                          "startFilePos": 493,
+                          "endLine": 9,
+                          "endTokenPos": 244,
+                          "endFilePos": 516
+                        },
+                        "left": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 234,
+                            "startFilePos": 493,
+                            "endLine": 9,
+                            "endTokenPos": 237,
+                            "endFilePos": 500
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 234,
+                              "startFilePos": 493,
+                              "endLine": 9,
+                              "endTokenPos": 234,
+                              "endFilePos": 494
+                            },
+                            "name": "n"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 236,
+                              "startFilePos": 496,
+                              "endLine": 9,
+                              "endTokenPos": 236,
+                              "endFilePos": 499,
+                              "kind": 2,
+                              "rawValue": "\"id\""
+                            },
+                            "value": "id"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 241,
+                            "startFilePos": 505,
+                            "endLine": 9,
+                            "endTokenPos": 244,
+                            "endFilePos": 516
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 241,
+                              "startFilePos": 505,
+                              "endLine": 9,
+                              "endTokenPos": 241,
+                              "endFilePos": 506
+                            },
+                            "name": "s"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 243,
+                              "startFilePos": 508,
+                              "endLine": 9,
+                              "endTokenPos": 243,
+                              "endFilePos": 515,
+                              "kind": 2,
+                              "rawValue": "\"nation\""
+                            },
+                            "value": "nation"
+                          }
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Expr_BinaryOp_Equal",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 248,
+                        "startFilePos": 521,
+                        "endLine": 9,
+                        "endTokenPos": 255,
+                        "endFilePos": 537
+                      },
+                      "left": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 248,
+                          "startFilePos": 521,
+                          "endLine": 9,
+                          "endTokenPos": 251,
+                          "endFilePos": 530
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 248,
+                            "startFilePos": 521,
+                            "endLine": 9,
+                            "endTokenPos": 248,
+                            "endFilePos": 522
+                          },
+                          "name": "n"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 250,
+                            "startFilePos": 524,
+                            "endLine": 9,
+                            "endTokenPos": 250,
+                            "endFilePos": 529,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 255,
+                          "startFilePos": 535,
+                          "endLine": 9,
+                          "endTokenPos": 255,
+                          "endFilePos": 537,
+                          "kind": 2,
+                          "rawValue": "\"A\""
+                        },
+                        "value": "A"
+                      }
+                    }
+                  },
+                  "stmts": [
+                    {
+                      "nodeType": "Stmt_Expression",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 260,
+                        "startFilePos": 550,
+                        "endLine": 10,
+                        "endTokenPos": 293,
+                        "endFilePos": 624
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Assign",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 260,
+                          "startFilePos": 550,
+                          "endLine": 10,
+                          "endTokenPos": 292,
+                          "endFilePos": 623
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 260,
+                            "startFilePos": 550,
+                            "endLine": 10,
+                            "endTokenPos": 262,
+                            "endFilePos": 560
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 260,
+                              "startFilePos": 550,
+                              "endLine": 10,
+                              "endTokenPos": 260,
+                              "endFilePos": 558
+                            },
+                            "name": "filtered"
+                          },
+                          "dim": null
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 266,
+                            "startFilePos": 564,
+                            "endLine": 10,
+                            "endTokenPos": 292,
+                            "endFilePos": 623,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 267,
+                                "startFilePos": 565,
+                                "endLine": 10,
+                                "endTokenPos": 274,
+                                "endFilePos": 585
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 267,
+                                  "startFilePos": 565,
+                                  "endLine": 10,
+                                  "endTokenPos": 267,
+                                  "endFilePos": 570,
+                                  "kind": 2,
+                                  "rawValue": "\"part\""
+                                },
+                                "value": "part"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 271,
+                                  "startFilePos": 575,
+                                  "endLine": 10,
+                                  "endTokenPos": 274,
+                                  "endFilePos": 585
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 271,
+                                    "startFilePos": 575,
+                                    "endLine": 10,
+                                    "endTokenPos": 271,
+                                    "endFilePos": 577
+                                  },
+                                  "name": "ps"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 273,
+                                    "startFilePos": 579,
+                                    "endLine": 10,
+                                    "endTokenPos": 273,
+                                    "endFilePos": 584,
+                                    "kind": 2,
+                                    "rawValue": "\"part\""
+                                  },
+                                  "value": "part"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 277,
+                                "startFilePos": 588,
+                                "endLine": 10,
+                                "endTokenPos": 291,
+                                "endFilePos": 622
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 277,
+                                  "startFilePos": 588,
+                                  "endLine": 10,
+                                  "endTokenPos": 277,
+                                  "endFilePos": 594,
+                                  "kind": 2,
+                                  "rawValue": "\"value\""
+                                },
+                                "value": "value"
+                              },
+                              "value": {
+                                "nodeType": "Expr_BinaryOp_Mul",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 281,
+                                  "startFilePos": 599,
+                                  "endLine": 10,
+                                  "endTokenPos": 291,
+                                  "endFilePos": 622
+                                },
+                                "left": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 281,
+                                    "startFilePos": 599,
+                                    "endLine": 10,
+                                    "endTokenPos": 284,
+                                    "endFilePos": 609
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 10,
+                                      "startTokenPos": 281,
+                                      "startFilePos": 599,
+                                      "endLine": 10,
+                                      "endTokenPos": 281,
+                                      "endFilePos": 601
+                                    },
+                                    "name": "ps"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 10,
+                                      "startTokenPos": 283,
+                                      "startFilePos": 603,
+                                      "endLine": 10,
+                                      "endTokenPos": 283,
+                                      "endFilePos": 608,
+                                      "kind": 2,
+                                      "rawValue": "\"cost\""
+                                    },
+                                    "value": "cost"
+                                  }
+                                },
+                                "right": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 288,
+                                    "startFilePos": 613,
+                                    "endLine": 10,
+                                    "endTokenPos": 291,
+                                    "endFilePos": 622
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 10,
+                                      "startTokenPos": 288,
+                                      "startFilePos": 613,
+                                      "endLine": 10,
+                                      "endTokenPos": 288,
+                                      "endFilePos": 615
+                                    },
+                                    "name": "ps"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 10,
+                                      "startTokenPos": 290,
+                                      "startFilePos": 617,
+                                      "endLine": 10,
+                                      "endTokenPos": 290,
+                                      "endFilePos": 621,
+                                      "kind": 2,
+                                      "rawValue": "\"qty\""
+                                    },
+                                    "value": "qty"
+                                  }
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "elseifs": [],
+                  "else": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 16,
+        "startTokenPos": 303,
+        "startFilePos": 647,
+        "endLine": 37,
+        "endTokenPos": 547,
+        "endFilePos": 1220
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 16,
+          "startTokenPos": 303,
+          "startFilePos": 647,
+          "endLine": 37,
+          "endTokenPos": 546,
+          "endFilePos": 1219
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 303,
+            "startFilePos": 647,
+            "endLine": 16,
+            "endTokenPos": 303,
+            "endFilePos": 654
+          },
+          "name": "grouped"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 307,
+            "startFilePos": 658,
+            "endLine": 37,
+            "endTokenPos": 546,
+            "endFilePos": 1219
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 308,
+              "startFilePos": 659,
+              "endLine": 37,
+              "endTokenPos": 543,
+              "endFilePos": 1216
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 315,
+                  "startFilePos": 675,
+                  "endLine": 16,
+                  "endTokenPos": 315,
+                  "endFilePos": 682
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 315,
+                    "startFilePos": 675,
+                    "endLine": 16,
+                    "endTokenPos": 315,
+                    "endFilePos": 682
+                  },
+                  "name": "nations"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 318,
+                  "startFilePos": 685,
+                  "endLine": 16,
+                  "endTokenPos": 318,
+                  "endFilePos": 694
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 318,
+                    "startFilePos": 685,
+                    "endLine": 16,
+                    "endTokenPos": 318,
+                    "endFilePos": 694
+                  },
+                  "name": "suppliers"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 321,
+                  "startFilePos": 697,
+                  "endLine": 16,
+                  "endTokenPos": 321,
+                  "endFilePos": 705
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 321,
+                    "startFilePos": 697,
+                    "endLine": 16,
+                    "endTokenPos": 321,
+                    "endFilePos": 705
+                  },
+                  "name": "partsupp"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 324,
+                  "startFilePos": 708,
+                  "endLine": 16,
+                  "endTokenPos": 324,
+                  "endFilePos": 716
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 324,
+                    "startFilePos": 708,
+                    "endLine": 16,
+                    "endTokenPos": 324,
+                    "endFilePos": 716
+                  },
+                  "name": "filtered"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 17,
+                  "startTokenPos": 329,
+                  "startFilePos": 723,
+                  "endLine": 17,
+                  "endTokenPos": 335,
+                  "endFilePos": 735
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 329,
+                    "startFilePos": 723,
+                    "endLine": 17,
+                    "endTokenPos": 334,
+                    "endFilePos": 734
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 17,
+                      "startTokenPos": 329,
+                      "startFilePos": 723,
+                      "endLine": 17,
+                      "endTokenPos": 329,
+                      "endFilePos": 729
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 17,
+                      "startTokenPos": 333,
+                      "startFilePos": 733,
+                      "endLine": 17,
+                      "endTokenPos": 334,
+                      "endFilePos": 734,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 337,
+                  "startFilePos": 739,
+                  "endLine": 25,
+                  "endTokenPos": 425,
+                  "endFilePos": 953
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 340,
+                    "startFilePos": 748,
+                    "endLine": 18,
+                    "endTokenPos": 340,
+                    "endFilePos": 756
+                  },
+                  "name": "filtered"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 344,
+                    "startFilePos": 761,
+                    "endLine": 18,
+                    "endTokenPos": 344,
+                    "endFilePos": 762
+                  },
+                  "name": "x"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 19,
+                      "startTokenPos": 349,
+                      "startFilePos": 771,
+                      "endLine": 19,
+                      "endTokenPos": 357,
+                      "endFilePos": 788
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 19,
+                        "startTokenPos": 349,
+                        "startFilePos": 771,
+                        "endLine": 19,
+                        "endTokenPos": 356,
+                        "endFilePos": 787
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 19,
+                          "startTokenPos": 349,
+                          "startFilePos": 771,
+                          "endLine": 19,
+                          "endTokenPos": 349,
+                          "endFilePos": 774
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 19,
+                          "startTokenPos": 353,
+                          "startFilePos": 778,
+                          "endLine": 19,
+                          "endTokenPos": 356,
+                          "endFilePos": 787
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 19,
+                            "startTokenPos": 353,
+                            "startFilePos": 778,
+                            "endLine": 19,
+                            "endTokenPos": 353,
+                            "endFilePos": 779
+                          },
+                          "name": "x"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 19,
+                            "startTokenPos": 355,
+                            "startFilePos": 781,
+                            "endLine": 19,
+                            "endTokenPos": 355,
+                            "endFilePos": 786,
+                            "kind": 2,
+                            "rawValue": "\"part\""
+                          },
+                          "value": "part"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 20,
+                      "startTokenPos": 359,
+                      "startFilePos": 794,
+                      "endLine": 20,
+                      "endTokenPos": 367,
+                      "endFilePos": 816
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 20,
+                        "startTokenPos": 359,
+                        "startFilePos": 794,
+                        "endLine": 20,
+                        "endTokenPos": 366,
+                        "endFilePos": 815
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 20,
+                          "startTokenPos": 359,
+                          "startFilePos": 794,
+                          "endLine": 20,
+                          "endTokenPos": 359,
+                          "endFilePos": 795
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 20,
+                          "startTokenPos": 363,
+                          "startFilePos": 799,
+                          "endLine": 20,
+                          "endTokenPos": 366,
+                          "endFilePos": 815
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 20,
+                            "startTokenPos": 363,
+                            "startFilePos": 799,
+                            "endLine": 20,
+                            "endTokenPos": 363,
+                            "endFilePos": 809
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 20,
+                              "startTokenPos": 365,
+                              "startFilePos": 811,
+                              "endLine": 20,
+                              "endTokenPos": 365,
+                              "endFilePos": 814
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 20,
+                                "startTokenPos": 365,
+                                "startFilePos": 811,
+                                "endLine": 20,
+                                "endTokenPos": 365,
+                                "endFilePos": 814
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 21,
+                      "startTokenPos": 369,
+                      "startFilePos": 822,
+                      "endLine": 23,
+                      "endTokenPos": 408,
+                      "endFilePos": 916
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 21,
+                        "startTokenPos": 372,
+                        "startFilePos": 826,
+                        "endLine": 21,
+                        "endTokenPos": 379,
+                        "endFilePos": 855
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 21,
+                          "startTokenPos": 373,
+                          "startFilePos": 827,
+                          "endLine": 21,
+                          "endTokenPos": 379,
+                          "endFilePos": 855
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 21,
+                            "startTokenPos": 373,
+                            "startFilePos": 827,
+                            "endLine": 21,
+                            "endTokenPos": 373,
+                            "endFilePos": 842
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 375,
+                              "startFilePos": 844,
+                              "endLine": 21,
+                              "endTokenPos": 375,
+                              "endFilePos": 845
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 375,
+                                "startFilePos": 844,
+                                "endLine": 21,
+                                "endTokenPos": 375,
+                                "endFilePos": 845
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 378,
+                              "startFilePos": 848,
+                              "endLine": 21,
+                              "endTokenPos": 378,
+                              "endFilePos": 854
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 378,
+                                "startFilePos": 848,
+                                "endLine": 21,
+                                "endTokenPos": 378,
+                                "endFilePos": 854
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 384,
+                          "startFilePos": 866,
+                          "endLine": 22,
+                          "endTokenPos": 406,
+                          "endFilePos": 910
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 384,
+                            "startFilePos": 866,
+                            "endLine": 22,
+                            "endTokenPos": 405,
+                            "endFilePos": 909
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 384,
+                              "startFilePos": 866,
+                              "endLine": 22,
+                              "endTokenPos": 387,
+                              "endFilePos": 876
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 384,
+                                "startFilePos": 866,
+                                "endLine": 22,
+                                "endTokenPos": 384,
+                                "endFilePos": 872
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 386,
+                                "startFilePos": 874,
+                                "endLine": 22,
+                                "endTokenPos": 386,
+                                "endFilePos": 875
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 391,
+                              "startFilePos": 880,
+                              "endLine": 22,
+                              "endTokenPos": 405,
+                              "endFilePos": 909,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 392,
+                                  "startFilePos": 881,
+                                  "endLine": 22,
+                                  "endTokenPos": 396,
+                                  "endFilePos": 893
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 392,
+                                    "startFilePos": 881,
+                                    "endLine": 22,
+                                    "endTokenPos": 392,
+                                    "endFilePos": 885,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 396,
+                                    "startFilePos": 890,
+                                    "endLine": 22,
+                                    "endTokenPos": 396,
+                                    "endFilePos": 893
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 399,
+                                  "startFilePos": 896,
+                                  "endLine": 22,
+                                  "endTokenPos": 404,
+                                  "endFilePos": 908
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 399,
+                                    "startFilePos": 896,
+                                    "endLine": 22,
+                                    "endTokenPos": 399,
+                                    "endFilePos": 902,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 403,
+                                    "startFilePos": 907,
+                                    "endLine": 22,
+                                    "endTokenPos": 404,
+                                    "endFilePos": 908,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 24,
+                      "startTokenPos": 410,
+                      "startFilePos": 922,
+                      "endLine": 24,
+                      "endTokenPos": 423,
+                      "endFilePos": 949
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 24,
+                        "startTokenPos": 410,
+                        "startFilePos": 922,
+                        "endLine": 24,
+                        "endTokenPos": 422,
+                        "endFilePos": 948
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 24,
+                          "startTokenPos": 410,
+                          "startFilePos": 922,
+                          "endLine": 24,
+                          "endTokenPos": 418,
+                          "endFilePos": 943
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 24,
+                            "startTokenPos": 410,
+                            "startFilePos": 922,
+                            "endLine": 24,
+                            "endTokenPos": 416,
+                            "endFilePos": 941
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 24,
+                              "startTokenPos": 410,
+                              "startFilePos": 922,
+                              "endLine": 24,
+                              "endTokenPos": 413,
+                              "endFilePos": 932
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 24,
+                                "startTokenPos": 410,
+                                "startFilePos": 922,
+                                "endLine": 24,
+                                "endTokenPos": 410,
+                                "endFilePos": 928
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 24,
+                                "startTokenPos": 412,
+                                "startFilePos": 930,
+                                "endLine": 24,
+                                "endTokenPos": 412,
+                                "endFilePos": 931
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 24,
+                              "startTokenPos": 415,
+                              "startFilePos": 934,
+                              "endLine": 24,
+                              "endTokenPos": 415,
+                              "endFilePos": 940,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 24,
+                          "startTokenPos": 422,
+                          "startFilePos": 947,
+                          "endLine": 24,
+                          "endTokenPos": 422,
+                          "endFilePos": 948
+                        },
+                        "name": "x"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 26,
+                  "startTokenPos": 427,
+                  "startFilePos": 957,
+                  "endLine": 26,
+                  "endTokenPos": 433,
+                  "endFilePos": 969
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 427,
+                    "startFilePos": 957,
+                    "endLine": 26,
+                    "endTokenPos": 432,
+                    "endFilePos": 968
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 427,
+                      "startFilePos": 957,
+                      "endLine": 26,
+                      "endTokenPos": 427,
+                      "endFilePos": 963
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 431,
+                      "startFilePos": 967,
+                      "endLine": 26,
+                      "endTokenPos": 432,
+                      "endFilePos": 968,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 435,
+                  "startFilePos": 973,
+                  "endLine": 35,
+                  "endTokenPos": 536,
+                  "endFilePos": 1196
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 438,
+                    "startFilePos": 982,
+                    "endLine": 27,
+                    "endTokenPos": 438,
+                    "endFilePos": 988
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 442,
+                    "startFilePos": 993,
+                    "endLine": 27,
+                    "endTokenPos": 442,
+                    "endFilePos": 994
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 28,
+                      "startTokenPos": 447,
+                      "startFilePos": 1005,
+                      "endLine": 34,
+                      "endTokenPos": 534,
+                      "endFilePos": 1192
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 28,
+                        "startTokenPos": 447,
+                        "startFilePos": 1005,
+                        "endLine": 34,
+                        "endTokenPos": 533,
+                        "endFilePos": 1191
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 28,
+                          "startTokenPos": 447,
+                          "startFilePos": 1005,
+                          "endLine": 28,
+                          "endTokenPos": 449,
+                          "endFilePos": 1013
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 28,
+                            "startTokenPos": 447,
+                            "startFilePos": 1005,
+                            "endLine": 28,
+                            "endTokenPos": 447,
+                            "endFilePos": 1011
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 28,
+                          "startTokenPos": 453,
+                          "startFilePos": 1017,
+                          "endLine": 34,
+                          "endTokenPos": 533,
+                          "endFilePos": 1191,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 28,
+                              "startTokenPos": 454,
+                              "startFilePos": 1018,
+                              "endLine": 28,
+                              "endTokenPos": 461,
+                              "endFilePos": 1036
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 28,
+                                "startTokenPos": 454,
+                                "startFilePos": 1018,
+                                "endLine": 28,
+                                "endTokenPos": 454,
+                                "endFilePos": 1023,
+                                "kind": 2,
+                                "rawValue": "\"part\""
+                              },
+                              "value": "part"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 28,
+                                "startTokenPos": 458,
+                                "startFilePos": 1028,
+                                "endLine": 28,
+                                "endTokenPos": 461,
+                                "endFilePos": 1036
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 28,
+                                  "startTokenPos": 458,
+                                  "startFilePos": 1028,
+                                  "endLine": 28,
+                                  "endTokenPos": 458,
+                                  "endFilePos": 1029
+                                },
+                                "name": "g"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 28,
+                                  "startTokenPos": 460,
+                                  "startFilePos": 1031,
+                                  "endLine": 28,
+                                  "endTokenPos": 460,
+                                  "endFilePos": 1035,
+                                  "kind": 2,
+                                  "rawValue": "\"key\""
+                                },
+                                "value": "key"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 28,
+                              "startTokenPos": 464,
+                              "startFilePos": 1039,
+                              "endLine": 34,
+                              "endTokenPos": 532,
+                              "endFilePos": 1190
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 28,
+                                "startTokenPos": 464,
+                                "startFilePos": 1039,
+                                "endLine": 28,
+                                "endTokenPos": 464,
+                                "endFilePos": 1045,
+                                "kind": 2,
+                                "rawValue": "\"total\""
+                              },
+                              "value": "total"
+                            },
+                            "value": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 28,
+                                "startTokenPos": 468,
+                                "startFilePos": 1050,
+                                "endLine": 34,
+                                "endTokenPos": 532,
+                                "endFilePos": 1190
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 28,
+                                  "startTokenPos": 468,
+                                  "startFilePos": 1050,
+                                  "endLine": 28,
+                                  "endTokenPos": 468,
+                                  "endFilePos": 1058
+                                },
+                                "name": "array_sum"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 28,
+                                    "startTokenPos": 470,
+                                    "startFilePos": 1060,
+                                    "endLine": 34,
+                                    "endTokenPos": 531,
+                                    "endFilePos": 1189
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_FuncCall",
+                                    "attributes": {
+                                      "startLine": 28,
+                                      "startTokenPos": 470,
+                                      "startFilePos": 1060,
+                                      "endLine": 34,
+                                      "endTokenPos": 531,
+                                      "endFilePos": 1189
+                                    },
+                                    "name": {
+                                      "nodeType": "Expr_Closure",
+                                      "attributes": {
+                                        "startLine": 28,
+                                        "startTokenPos": 471,
+                                        "startFilePos": 1061,
+                                        "endLine": 34,
+                                        "endTokenPos": 528,
+                                        "endFilePos": 1186
+                                      },
+                                      "static": false,
+                                      "byRef": false,
+                                      "params": [],
+                                      "uses": [
+                                        {
+                                          "nodeType": "ClosureUse",
+                                          "attributes": {
+                                            "startLine": 28,
+                                            "startTokenPos": 478,
+                                            "startFilePos": 1077,
+                                            "endLine": 28,
+                                            "endTokenPos": 478,
+                                            "endFilePos": 1078
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 478,
+                                              "startFilePos": 1077,
+                                              "endLine": 28,
+                                              "endTokenPos": 478,
+                                              "endFilePos": 1078
+                                            },
+                                            "name": "x"
+                                          },
+                                          "byRef": false
+                                        },
+                                        {
+                                          "nodeType": "ClosureUse",
+                                          "attributes": {
+                                            "startLine": 28,
+                                            "startTokenPos": 481,
+                                            "startFilePos": 1081,
+                                            "endLine": 28,
+                                            "endTokenPos": 481,
+                                            "endFilePos": 1082
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 481,
+                                              "startFilePos": 1081,
+                                              "endLine": 28,
+                                              "endTokenPos": 481,
+                                              "endFilePos": 1082
+                                            },
+                                            "name": "g"
+                                          },
+                                          "byRef": false
+                                        }
+                                      ],
+                                      "returnType": null,
+                                      "stmts": [
+                                        {
+                                          "nodeType": "Stmt_Expression",
+                                          "attributes": {
+                                            "startLine": 29,
+                                            "startTokenPos": 486,
+                                            "startFilePos": 1089,
+                                            "endLine": 29,
+                                            "endTokenPos": 492,
+                                            "endFilePos": 1101
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_Assign",
+                                            "attributes": {
+                                              "startLine": 29,
+                                              "startTokenPos": 486,
+                                              "startFilePos": 1089,
+                                              "endLine": 29,
+                                              "endTokenPos": 491,
+                                              "endFilePos": 1100
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 29,
+                                                "startTokenPos": 486,
+                                                "startFilePos": 1089,
+                                                "endLine": 29,
+                                                "endTokenPos": 486,
+                                                "endFilePos": 1095
+                                              },
+                                              "name": "result"
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Array",
+                                              "attributes": {
+                                                "startLine": 29,
+                                                "startTokenPos": 490,
+                                                "startFilePos": 1099,
+                                                "endLine": 29,
+                                                "endTokenPos": 491,
+                                                "endFilePos": 1100,
+                                                "kind": 2
+                                              },
+                                              "items": []
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "nodeType": "Stmt_Foreach",
+                                          "attributes": {
+                                            "startLine": 30,
+                                            "startTokenPos": 494,
+                                            "startFilePos": 1105,
+                                            "endLine": 32,
+                                            "endTokenPos": 521,
+                                            "endFilePos": 1166
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 30,
+                                              "startTokenPos": 497,
+                                              "startFilePos": 1114,
+                                              "endLine": 30,
+                                              "endTokenPos": 500,
+                                              "endFilePos": 1124
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 30,
+                                                "startTokenPos": 497,
+                                                "startFilePos": 1114,
+                                                "endLine": 30,
+                                                "endTokenPos": 497,
+                                                "endFilePos": 1115
+                                              },
+                                              "name": "g"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 30,
+                                                "startTokenPos": 499,
+                                                "startFilePos": 1117,
+                                                "endLine": 30,
+                                                "endTokenPos": 499,
+                                                "endFilePos": 1123,
+                                                "kind": 2,
+                                                "rawValue": "\"items\""
+                                              },
+                                              "value": "items"
+                                            }
+                                          },
+                                          "keyVar": null,
+                                          "byRef": false,
+                                          "valueVar": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 30,
+                                              "startTokenPos": 504,
+                                              "startFilePos": 1129,
+                                              "endLine": 30,
+                                              "endTokenPos": 504,
+                                              "endFilePos": 1130
+                                            },
+                                            "name": "r"
+                                          },
+                                          "stmts": [
+                                            {
+                                              "nodeType": "Stmt_Expression",
+                                              "attributes": {
+                                                "startLine": 31,
+                                                "startTokenPos": 509,
+                                                "startFilePos": 1139,
+                                                "endLine": 31,
+                                                "endTokenPos": 519,
+                                                "endFilePos": 1162
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Assign",
+                                                "attributes": {
+                                                  "startLine": 31,
+                                                  "startTokenPos": 509,
+                                                  "startFilePos": 1139,
+                                                  "endLine": 31,
+                                                  "endTokenPos": 518,
+                                                  "endFilePos": 1161
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 31,
+                                                    "startTokenPos": 509,
+                                                    "startFilePos": 1139,
+                                                    "endLine": 31,
+                                                    "endTokenPos": 511,
+                                                    "endFilePos": 1147
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 31,
+                                                      "startTokenPos": 509,
+                                                      "startFilePos": 1139,
+                                                      "endLine": 31,
+                                                      "endTokenPos": 509,
+                                                      "endFilePos": 1145
+                                                    },
+                                                    "name": "result"
+                                                  },
+                                                  "dim": null
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 31,
+                                                    "startTokenPos": 515,
+                                                    "startFilePos": 1151,
+                                                    "endLine": 31,
+                                                    "endTokenPos": 518,
+                                                    "endFilePos": 1161
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 31,
+                                                      "startTokenPos": 515,
+                                                      "startFilePos": 1151,
+                                                      "endLine": 31,
+                                                      "endTokenPos": 515,
+                                                      "endFilePos": 1152
+                                                    },
+                                                    "name": "r"
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 31,
+                                                      "startTokenPos": 517,
+                                                      "startFilePos": 1154,
+                                                      "endLine": 31,
+                                                      "endTokenPos": 517,
+                                                      "endFilePos": 1160,
+                                                      "kind": 2,
+                                                      "rawValue": "\"value\""
+                                                    },
+                                                    "value": "value"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "nodeType": "Stmt_Return",
+                                          "attributes": {
+                                            "startLine": 33,
+                                            "startTokenPos": 523,
+                                            "startFilePos": 1170,
+                                            "endLine": 33,
+                                            "endTokenPos": 526,
+                                            "endFilePos": 1184
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 33,
+                                              "startTokenPos": 525,
+                                              "startFilePos": 1177,
+                                              "endLine": 33,
+                                              "endTokenPos": 525,
+                                              "endFilePos": 1183
+                                            },
+                                            "name": "result"
+                                          }
+                                        }
+                                      ],
+                                      "attrGroups": []
+                                    },
+                                    "args": []
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 36,
+                  "startTokenPos": 538,
+                  "startFilePos": 1200,
+                  "endLine": 36,
+                  "endTokenPos": 541,
+                  "endFilePos": 1214
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 36,
+                    "startTokenPos": 540,
+                    "startFilePos": 1207,
+                    "endLine": 36,
+                    "endTokenPos": 540,
+                    "endFilePos": 1213
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 38,
+        "startTokenPos": 549,
+        "startFilePos": 1222,
+        "endLine": 38,
+        "endTokenPos": 606,
+        "endFilePos": 1395
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 38,
+            "startTokenPos": 551,
+            "startFilePos": 1227,
+            "endLine": 38,
+            "endTokenPos": 602,
+            "endFilePos": 1385
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 38,
+              "startTokenPos": 551,
+              "startFilePos": 1227,
+              "endLine": 38,
+              "endTokenPos": 551,
+              "endFilePos": 1237
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 38,
+                "startTokenPos": 553,
+                "startFilePos": 1239,
+                "endLine": 38,
+                "endTokenPos": 553,
+                "endFilePos": 1245
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 38,
+                  "startTokenPos": 553,
+                  "startFilePos": 1239,
+                  "endLine": 38,
+                  "endTokenPos": 553,
+                  "endFilePos": 1245,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 38,
+                "startTokenPos": 556,
+                "startFilePos": 1248,
+                "endLine": 38,
+                "endTokenPos": 556,
+                "endFilePos": 1254
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 38,
+                  "startTokenPos": 556,
+                  "startFilePos": 1248,
+                  "endLine": 38,
+                  "endTokenPos": 556,
+                  "endFilePos": 1254,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 38,
+                "startTokenPos": 559,
+                "startFilePos": 1257,
+                "endLine": 38,
+                "endTokenPos": 601,
+                "endFilePos": 1384
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 38,
+                  "startTokenPos": 559,
+                  "startFilePos": 1257,
+                  "endLine": 38,
+                  "endTokenPos": 601,
+                  "endFilePos": 1384
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 38,
+                    "startTokenPos": 559,
+                    "startFilePos": 1257,
+                    "endLine": 38,
+                    "endTokenPos": 559,
+                    "endFilePos": 1267
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 38,
+                      "startTokenPos": 561,
+                      "startFilePos": 1269,
+                      "endLine": 38,
+                      "endTokenPos": 561,
+                      "endFilePos": 1274
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 38,
+                        "startTokenPos": 561,
+                        "startFilePos": 1269,
+                        "endLine": 38,
+                        "endTokenPos": 561,
+                        "endFilePos": 1274,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 38,
+                      "startTokenPos": 564,
+                      "startFilePos": 1277,
+                      "endLine": 38,
+                      "endTokenPos": 564,
+                      "endFilePos": 1282
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 38,
+                        "startTokenPos": 564,
+                        "startFilePos": 1277,
+                        "endLine": 38,
+                        "endTokenPos": 564,
+                        "endFilePos": 1282,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 38,
+                      "startTokenPos": 567,
+                      "startFilePos": 1285,
+                      "endLine": 38,
+                      "endTokenPos": 600,
+                      "endFilePos": 1383
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 38,
+                        "startTokenPos": 567,
+                        "startFilePos": 1285,
+                        "endLine": 38,
+                        "endTokenPos": 600,
+                        "endFilePos": 1383
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 38,
+                          "startTokenPos": 567,
+                          "startFilePos": 1285,
+                          "endLine": 38,
+                          "endTokenPos": 567,
+                          "endFilePos": 1295
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 38,
+                            "startTokenPos": 569,
+                            "startFilePos": 1297,
+                            "endLine": 38,
+                            "endTokenPos": 569,
+                            "endFilePos": 1300
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 569,
+                              "startFilePos": 1297,
+                              "endLine": 38,
+                              "endTokenPos": 569,
+                              "endFilePos": 1300,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 38,
+                            "startTokenPos": 572,
+                            "startFilePos": 1303,
+                            "endLine": 38,
+                            "endTokenPos": 572,
+                            "endFilePos": 1305
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 572,
+                              "startFilePos": 1303,
+                              "endLine": 38,
+                              "endTokenPos": 572,
+                              "endFilePos": 1305,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 38,
+                            "startTokenPos": 575,
+                            "startFilePos": 1308,
+                            "endLine": 38,
+                            "endTokenPos": 599,
+                            "endFilePos": 1382
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 575,
+                              "startFilePos": 1308,
+                              "endLine": 38,
+                              "endTokenPos": 599,
+                              "endFilePos": 1382
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 575,
+                                "startFilePos": 1308,
+                                "endLine": 38,
+                                "endTokenPos": 575,
+                                "endFilePos": 1318
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 577,
+                                  "startFilePos": 1320,
+                                  "endLine": 38,
+                                  "endTokenPos": 577,
+                                  "endFilePos": 1322
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 577,
+                                    "startFilePos": 1320,
+                                    "endLine": 38,
+                                    "endTokenPos": 577,
+                                    "endFilePos": 1322,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 580,
+                                  "startFilePos": 1325,
+                                  "endLine": 38,
+                                  "endTokenPos": 580,
+                                  "endFilePos": 1328
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 580,
+                                    "startFilePos": 1325,
+                                    "endLine": 38,
+                                    "endTokenPos": 580,
+                                    "endFilePos": 1328,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 583,
+                                  "startFilePos": 1331,
+                                  "endLine": 38,
+                                  "endTokenPos": 598,
+                                  "endFilePos": 1381
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 583,
+                                    "startFilePos": 1331,
+                                    "endLine": 38,
+                                    "endTokenPos": 598,
+                                    "endFilePos": 1381
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 583,
+                                      "startFilePos": 1331,
+                                      "endLine": 38,
+                                      "endTokenPos": 583,
+                                      "endFilePos": 1341
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 585,
+                                        "startFilePos": 1343,
+                                        "endLine": 38,
+                                        "endTokenPos": 585,
+                                        "endFilePos": 1345
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 38,
+                                          "startTokenPos": 585,
+                                          "startFilePos": 1343,
+                                          "endLine": 38,
+                                          "endTokenPos": 585,
+                                          "endFilePos": 1345,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 588,
+                                        "startFilePos": 1348,
+                                        "endLine": 38,
+                                        "endTokenPos": 588,
+                                        "endFilePos": 1351
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 38,
+                                          "startTokenPos": 588,
+                                          "startFilePos": 1348,
+                                          "endLine": 38,
+                                          "endTokenPos": 588,
+                                          "endFilePos": 1351,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 591,
+                                        "startFilePos": 1354,
+                                        "endLine": 38,
+                                        "endTokenPos": 597,
+                                        "endFilePos": 1380
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 38,
+                                          "startTokenPos": 591,
+                                          "startFilePos": 1354,
+                                          "endLine": 38,
+                                          "endTokenPos": 597,
+                                          "endFilePos": 1380
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 38,
+                                            "startTokenPos": 591,
+                                            "startFilePos": 1354,
+                                            "endLine": 38,
+                                            "endTokenPos": 591,
+                                            "endFilePos": 1364
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 593,
+                                              "startFilePos": 1366,
+                                              "endLine": 38,
+                                              "endTokenPos": 593,
+                                              "endFilePos": 1373
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 38,
+                                                "startTokenPos": 593,
+                                                "startFilePos": 1366,
+                                                "endLine": 38,
+                                                "endTokenPos": 593,
+                                                "endFilePos": 1373
+                                              },
+                                              "name": "grouped"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 596,
+                                              "startFilePos": 1376,
+                                              "endLine": 38,
+                                              "endTokenPos": 596,
+                                              "endFilePos": 1379
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 38,
+                                                "startTokenPos": 596,
+                                                "startFilePos": 1376,
+                                                "endLine": 38,
+                                                "endTokenPos": 596,
+                                                "endFilePos": 1379,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 38,
+            "startTokenPos": 605,
+            "startFilePos": 1388,
+            "endLine": 38,
+            "endTokenPos": 605,
+            "endFilePos": 1394
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 38,
+              "startTokenPos": 605,
+              "startFilePos": 1388,
+              "endLine": 38,
+              "endTokenPos": 605,
+              "endFilePos": 1394
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_multi_join_sort.php.json
+++ b/tests/json-ast/x/php/group_by_multi_join_sort.php.json
@@ -1,0 +1,6375 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 21,
+        "endFilePos": 60
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 20,
+          "endFilePos": 59
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "nation"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 20,
+            "endFilePos": 59,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 58
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 58,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 35
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 30,
+                        "kind": 2,
+                        "rawValue": "\"n_nationkey\""
+                      },
+                      "value": "n_nationkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 35,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 35,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 38,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 57
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 38,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 45,
+                        "kind": 2,
+                        "rawValue": "\"n_name\""
+                      },
+                      "value": "n_name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 50,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 57,
+                        "kind": 2,
+                        "rawValue": "\"BRAZIL\""
+                      },
+                      "value": "BRAZIL"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 23,
+        "startFilePos": 62,
+        "endLine": 3,
+        "endTokenPos": 78,
+        "endFilePos": 230
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 23,
+          "startFilePos": 62,
+          "endLine": 3,
+          "endTokenPos": 77,
+          "endFilePos": 229
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 23,
+            "startFilePos": 62,
+            "endLine": 3,
+            "endTokenPos": 23,
+            "endFilePos": 70
+          },
+          "name": "customer"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 27,
+            "startFilePos": 74,
+            "endLine": 3,
+            "endTokenPos": 77,
+            "endFilePos": 229,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 28,
+                "startFilePos": 75,
+                "endLine": 3,
+                "endTokenPos": 76,
+                "endFilePos": 228
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 28,
+                  "startFilePos": 75,
+                  "endLine": 3,
+                  "endTokenPos": 76,
+                  "endFilePos": 228,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 29,
+                      "startFilePos": 76,
+                      "endLine": 3,
+                      "endTokenPos": 33,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 29,
+                        "startFilePos": 76,
+                        "endLine": 3,
+                        "endTokenPos": 29,
+                        "endFilePos": 86,
+                        "kind": 2,
+                        "rawValue": "\"c_custkey\""
+                      },
+                      "value": "c_custkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 33,
+                        "startFilePos": 91,
+                        "endLine": 3,
+                        "endTokenPos": 33,
+                        "endFilePos": 91,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 94,
+                      "endLine": 3,
+                      "endTokenPos": 40,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 36,
+                        "startFilePos": 94,
+                        "endLine": 3,
+                        "endTokenPos": 36,
+                        "endFilePos": 101,
+                        "kind": 2,
+                        "rawValue": "\"c_name\""
+                      },
+                      "value": "c_name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 40,
+                        "startFilePos": 106,
+                        "endLine": 3,
+                        "endTokenPos": 40,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 43,
+                      "startFilePos": 115,
+                      "endLine": 3,
+                      "endTokenPos": 47,
+                      "endFilePos": 134
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 43,
+                        "startFilePos": 115,
+                        "endLine": 3,
+                        "endTokenPos": 43,
+                        "endFilePos": 125,
+                        "kind": 2,
+                        "rawValue": "\"c_acctbal\""
+                      },
+                      "value": "c_acctbal"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 47,
+                        "startFilePos": 130,
+                        "endLine": 3,
+                        "endTokenPos": 47,
+                        "endFilePos": 134,
+                        "rawValue": "100.0"
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 50,
+                      "startFilePos": 137,
+                      "endLine": 3,
+                      "endTokenPos": 54,
+                      "endFilePos": 154
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 50,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 50,
+                        "endFilePos": 149,
+                        "kind": 2,
+                        "rawValue": "\"c_nationkey\""
+                      },
+                      "value": "c_nationkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 54,
+                        "startFilePos": 154,
+                        "endLine": 3,
+                        "endTokenPos": 54,
+                        "endFilePos": 154,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 57,
+                      "startFilePos": 157,
+                      "endLine": 3,
+                      "endTokenPos": 61,
+                      "endFilePos": 179
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 57,
+                        "startFilePos": 157,
+                        "endLine": 3,
+                        "endTokenPos": 57,
+                        "endFilePos": 167,
+                        "kind": 2,
+                        "rawValue": "\"c_address\""
+                      },
+                      "value": "c_address"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 172,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 179,
+                        "kind": 2,
+                        "rawValue": "\"123 St\""
+                      },
+                      "value": "123 St"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 64,
+                      "startFilePos": 182,
+                      "endLine": 3,
+                      "endTokenPos": 68,
+                      "endFilePos": 203
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 64,
+                        "startFilePos": 182,
+                        "endLine": 3,
+                        "endTokenPos": 64,
+                        "endFilePos": 190,
+                        "kind": 2,
+                        "rawValue": "\"c_phone\""
+                      },
+                      "value": "c_phone"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 195,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 203,
+                        "kind": 2,
+                        "rawValue": "\"123-456\""
+                      },
+                      "value": "123-456"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 71,
+                      "startFilePos": 206,
+                      "endLine": 3,
+                      "endTokenPos": 75,
+                      "endFilePos": 227
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 71,
+                        "startFilePos": 206,
+                        "endLine": 3,
+                        "endTokenPos": 71,
+                        "endFilePos": 216,
+                        "kind": 2,
+                        "rawValue": "\"c_comment\""
+                      },
+                      "value": "c_comment"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 75,
+                        "startFilePos": 221,
+                        "endLine": 3,
+                        "endTokenPos": 75,
+                        "endFilePos": 227,
+                        "kind": 2,
+                        "rawValue": "\"Loyal\""
+                      },
+                      "value": "Loyal"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 80,
+        "startFilePos": 232,
+        "endLine": 4,
+        "endTokenPos": 130,
+        "endFilePos": 388
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 80,
+          "startFilePos": 232,
+          "endLine": 4,
+          "endTokenPos": 129,
+          "endFilePos": 387
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 80,
+            "startFilePos": 232,
+            "endLine": 4,
+            "endTokenPos": 80,
+            "endFilePos": 238
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 84,
+            "startFilePos": 242,
+            "endLine": 4,
+            "endTokenPos": 129,
+            "endFilePos": 387,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 85,
+                "startFilePos": 243,
+                "endLine": 4,
+                "endTokenPos": 105,
+                "endFilePos": 313
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 85,
+                  "startFilePos": 243,
+                  "endLine": 4,
+                  "endTokenPos": 105,
+                  "endFilePos": 313,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 86,
+                      "startFilePos": 244,
+                      "endLine": 4,
+                      "endTokenPos": 90,
+                      "endFilePos": 263
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 86,
+                        "startFilePos": 244,
+                        "endLine": 4,
+                        "endTokenPos": 86,
+                        "endFilePos": 255,
+                        "kind": 2,
+                        "rawValue": "\"o_orderkey\""
+                      },
+                      "value": "o_orderkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 90,
+                        "startFilePos": 260,
+                        "endLine": 4,
+                        "endTokenPos": 90,
+                        "endFilePos": 263,
+                        "rawValue": "1000",
+                        "kind": 10
+                      },
+                      "value": 1000
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 93,
+                      "startFilePos": 266,
+                      "endLine": 4,
+                      "endTokenPos": 97,
+                      "endFilePos": 281
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 93,
+                        "startFilePos": 266,
+                        "endLine": 4,
+                        "endTokenPos": 93,
+                        "endFilePos": 276,
+                        "kind": 2,
+                        "rawValue": "\"o_custkey\""
+                      },
+                      "value": "o_custkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 97,
+                        "startFilePos": 281,
+                        "endLine": 4,
+                        "endTokenPos": 97,
+                        "endFilePos": 281,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 100,
+                      "startFilePos": 284,
+                      "endLine": 4,
+                      "endTokenPos": 104,
+                      "endFilePos": 312
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 100,
+                        "startFilePos": 284,
+                        "endLine": 4,
+                        "endTokenPos": 100,
+                        "endFilePos": 296,
+                        "kind": 2,
+                        "rawValue": "\"o_orderdate\""
+                      },
+                      "value": "o_orderdate"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 104,
+                        "startFilePos": 301,
+                        "endLine": 4,
+                        "endTokenPos": 104,
+                        "endFilePos": 312,
+                        "kind": 2,
+                        "rawValue": "\"1993-10-15\""
+                      },
+                      "value": "1993-10-15"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 108,
+                "startFilePos": 316,
+                "endLine": 4,
+                "endTokenPos": 128,
+                "endFilePos": 386
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 108,
+                  "startFilePos": 316,
+                  "endLine": 4,
+                  "endTokenPos": 128,
+                  "endFilePos": 386,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 109,
+                      "startFilePos": 317,
+                      "endLine": 4,
+                      "endTokenPos": 113,
+                      "endFilePos": 336
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 109,
+                        "startFilePos": 317,
+                        "endLine": 4,
+                        "endTokenPos": 109,
+                        "endFilePos": 328,
+                        "kind": 2,
+                        "rawValue": "\"o_orderkey\""
+                      },
+                      "value": "o_orderkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 113,
+                        "startFilePos": 333,
+                        "endLine": 4,
+                        "endTokenPos": 113,
+                        "endFilePos": 336,
+                        "rawValue": "2000",
+                        "kind": 10
+                      },
+                      "value": 2000
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 116,
+                      "startFilePos": 339,
+                      "endLine": 4,
+                      "endTokenPos": 120,
+                      "endFilePos": 354
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 116,
+                        "startFilePos": 339,
+                        "endLine": 4,
+                        "endTokenPos": 116,
+                        "endFilePos": 349,
+                        "kind": 2,
+                        "rawValue": "\"o_custkey\""
+                      },
+                      "value": "o_custkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 120,
+                        "startFilePos": 354,
+                        "endLine": 4,
+                        "endTokenPos": 120,
+                        "endFilePos": 354,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 123,
+                      "startFilePos": 357,
+                      "endLine": 4,
+                      "endTokenPos": 127,
+                      "endFilePos": 385
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 123,
+                        "startFilePos": 357,
+                        "endLine": 4,
+                        "endTokenPos": 123,
+                        "endFilePos": 369,
+                        "kind": 2,
+                        "rawValue": "\"o_orderdate\""
+                      },
+                      "value": "o_orderdate"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 127,
+                        "startFilePos": 374,
+                        "endLine": 4,
+                        "endTokenPos": 127,
+                        "endFilePos": 385,
+                        "kind": 2,
+                        "rawValue": "\"1994-01-02\""
+                      },
+                      "value": "1994-01-02"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 132,
+        "startFilePos": 390,
+        "endLine": 5,
+        "endTokenPos": 196,
+        "endFilePos": 595
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 132,
+          "startFilePos": 390,
+          "endLine": 5,
+          "endTokenPos": 195,
+          "endFilePos": 594
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 132,
+            "startFilePos": 390,
+            "endLine": 5,
+            "endTokenPos": 132,
+            "endFilePos": 398
+          },
+          "name": "lineitem"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 136,
+            "startFilePos": 402,
+            "endLine": 5,
+            "endTokenPos": 195,
+            "endFilePos": 594,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 137,
+                "startFilePos": 403,
+                "endLine": 5,
+                "endTokenPos": 164,
+                "endFilePos": 497
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 137,
+                  "startFilePos": 403,
+                  "endLine": 5,
+                  "endTokenPos": 164,
+                  "endFilePos": 497,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 138,
+                      "startFilePos": 404,
+                      "endLine": 5,
+                      "endTokenPos": 142,
+                      "endFilePos": 423
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 138,
+                        "startFilePos": 404,
+                        "endLine": 5,
+                        "endTokenPos": 138,
+                        "endFilePos": 415,
+                        "kind": 2,
+                        "rawValue": "\"l_orderkey\""
+                      },
+                      "value": "l_orderkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 142,
+                        "startFilePos": 420,
+                        "endLine": 5,
+                        "endTokenPos": 142,
+                        "endFilePos": 423,
+                        "rawValue": "1000",
+                        "kind": 10
+                      },
+                      "value": 1000
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 145,
+                      "startFilePos": 426,
+                      "endLine": 5,
+                      "endTokenPos": 149,
+                      "endFilePos": 446
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 145,
+                        "startFilePos": 426,
+                        "endLine": 5,
+                        "endTokenPos": 145,
+                        "endFilePos": 439,
+                        "kind": 2,
+                        "rawValue": "\"l_returnflag\""
+                      },
+                      "value": "l_returnflag"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 149,
+                        "startFilePos": 444,
+                        "endLine": 5,
+                        "endTokenPos": 149,
+                        "endFilePos": 446,
+                        "kind": 2,
+                        "rawValue": "\"R\""
+                      },
+                      "value": "R"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 152,
+                      "startFilePos": 449,
+                      "endLine": 5,
+                      "endTokenPos": 156,
+                      "endFilePos": 475
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 152,
+                        "startFilePos": 449,
+                        "endLine": 5,
+                        "endTokenPos": 152,
+                        "endFilePos": 465,
+                        "kind": 2,
+                        "rawValue": "\"l_extendedprice\""
+                      },
+                      "value": "l_extendedprice"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 156,
+                        "startFilePos": 470,
+                        "endLine": 5,
+                        "endTokenPos": 156,
+                        "endFilePos": 475,
+                        "rawValue": "1000.0"
+                      },
+                      "value": 1000
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 159,
+                      "startFilePos": 478,
+                      "endLine": 5,
+                      "endTokenPos": 163,
+                      "endFilePos": 496
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 159,
+                        "startFilePos": 478,
+                        "endLine": 5,
+                        "endTokenPos": 159,
+                        "endFilePos": 489,
+                        "kind": 2,
+                        "rawValue": "\"l_discount\""
+                      },
+                      "value": "l_discount"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 163,
+                        "startFilePos": 494,
+                        "endLine": 5,
+                        "endTokenPos": 163,
+                        "endFilePos": 496,
+                        "rawValue": "0.1"
+                      },
+                      "value": 0.1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 167,
+                "startFilePos": 500,
+                "endLine": 5,
+                "endTokenPos": 194,
+                "endFilePos": 593
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 167,
+                  "startFilePos": 500,
+                  "endLine": 5,
+                  "endTokenPos": 194,
+                  "endFilePos": 593,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 168,
+                      "startFilePos": 501,
+                      "endLine": 5,
+                      "endTokenPos": 172,
+                      "endFilePos": 520
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 168,
+                        "startFilePos": 501,
+                        "endLine": 5,
+                        "endTokenPos": 168,
+                        "endFilePos": 512,
+                        "kind": 2,
+                        "rawValue": "\"l_orderkey\""
+                      },
+                      "value": "l_orderkey"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 172,
+                        "startFilePos": 517,
+                        "endLine": 5,
+                        "endTokenPos": 172,
+                        "endFilePos": 520,
+                        "rawValue": "2000",
+                        "kind": 10
+                      },
+                      "value": 2000
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 175,
+                      "startFilePos": 523,
+                      "endLine": 5,
+                      "endTokenPos": 179,
+                      "endFilePos": 543
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 175,
+                        "startFilePos": 523,
+                        "endLine": 5,
+                        "endTokenPos": 175,
+                        "endFilePos": 536,
+                        "kind": 2,
+                        "rawValue": "\"l_returnflag\""
+                      },
+                      "value": "l_returnflag"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 179,
+                        "startFilePos": 541,
+                        "endLine": 5,
+                        "endTokenPos": 179,
+                        "endFilePos": 543,
+                        "kind": 2,
+                        "rawValue": "\"N\""
+                      },
+                      "value": "N"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 182,
+                      "startFilePos": 546,
+                      "endLine": 5,
+                      "endTokenPos": 186,
+                      "endFilePos": 571
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 182,
+                        "startFilePos": 546,
+                        "endLine": 5,
+                        "endTokenPos": 182,
+                        "endFilePos": 562,
+                        "kind": 2,
+                        "rawValue": "\"l_extendedprice\""
+                      },
+                      "value": "l_extendedprice"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 186,
+                        "startFilePos": 567,
+                        "endLine": 5,
+                        "endTokenPos": 186,
+                        "endFilePos": 571,
+                        "rawValue": "500.0"
+                      },
+                      "value": 500
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 189,
+                      "startFilePos": 574,
+                      "endLine": 5,
+                      "endTokenPos": 193,
+                      "endFilePos": 592
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 189,
+                        "startFilePos": 574,
+                        "endLine": 5,
+                        "endTokenPos": 189,
+                        "endFilePos": 585,
+                        "kind": 2,
+                        "rawValue": "\"l_discount\""
+                      },
+                      "value": "l_discount"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Float",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 193,
+                        "startFilePos": 590,
+                        "endLine": 5,
+                        "endTokenPos": 193,
+                        "endFilePos": 592,
+                        "rawValue": "0.0"
+                      },
+                      "value": 0
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 198,
+        "startFilePos": 597,
+        "endLine": 6,
+        "endTokenPos": 203,
+        "endFilePos": 623
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 198,
+          "startFilePos": 597,
+          "endLine": 6,
+          "endTokenPos": 202,
+          "endFilePos": 622
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 198,
+            "startFilePos": 597,
+            "endLine": 6,
+            "endTokenPos": 198,
+            "endFilePos": 607
+          },
+          "name": "start_date"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 202,
+            "startFilePos": 611,
+            "endLine": 6,
+            "endTokenPos": 202,
+            "endFilePos": 622,
+            "kind": 2,
+            "rawValue": "\"1993-10-01\""
+          },
+          "value": "1993-10-01"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 205,
+        "startFilePos": 625,
+        "endLine": 7,
+        "endTokenPos": 210,
+        "endFilePos": 649
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 7,
+          "startTokenPos": 205,
+          "startFilePos": 625,
+          "endLine": 7,
+          "endTokenPos": 209,
+          "endFilePos": 648
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 205,
+            "startFilePos": 625,
+            "endLine": 7,
+            "endTokenPos": 205,
+            "endFilePos": 633
+          },
+          "name": "end_date"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 209,
+            "startFilePos": 637,
+            "endLine": 7,
+            "endTokenPos": 209,
+            "endFilePos": 648,
+            "kind": 2,
+            "rawValue": "\"1994-01-01\""
+          },
+          "value": "1994-01-01"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 212,
+        "startFilePos": 651,
+        "endLine": 45,
+        "endTokenPos": 942,
+        "endFilePos": 2508
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 8,
+          "startTokenPos": 212,
+          "startFilePos": 651,
+          "endLine": 45,
+          "endTokenPos": 941,
+          "endFilePos": 2507
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 212,
+            "startFilePos": 651,
+            "endLine": 8,
+            "endTokenPos": 212,
+            "endFilePos": 657
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 216,
+            "startFilePos": 661,
+            "endLine": 45,
+            "endTokenPos": 941,
+            "endFilePos": 2507
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 217,
+              "startFilePos": 662,
+              "endLine": 45,
+              "endTokenPos": 938,
+              "endFilePos": 2504
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 224,
+                  "startFilePos": 678,
+                  "endLine": 8,
+                  "endTokenPos": 224,
+                  "endFilePos": 684
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 224,
+                    "startFilePos": 678,
+                    "endLine": 8,
+                    "endTokenPos": 224,
+                    "endFilePos": 684
+                  },
+                  "name": "nation"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 227,
+                  "startFilePos": 687,
+                  "endLine": 8,
+                  "endTokenPos": 227,
+                  "endFilePos": 695
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 227,
+                    "startFilePos": 687,
+                    "endLine": 8,
+                    "endTokenPos": 227,
+                    "endFilePos": 695
+                  },
+                  "name": "customer"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 230,
+                  "startFilePos": 698,
+                  "endLine": 8,
+                  "endTokenPos": 230,
+                  "endFilePos": 704
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 230,
+                    "startFilePos": 698,
+                    "endLine": 8,
+                    "endTokenPos": 230,
+                    "endFilePos": 704
+                  },
+                  "name": "orders"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 233,
+                  "startFilePos": 707,
+                  "endLine": 8,
+                  "endTokenPos": 233,
+                  "endFilePos": 715
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 233,
+                    "startFilePos": 707,
+                    "endLine": 8,
+                    "endTokenPos": 233,
+                    "endFilePos": 715
+                  },
+                  "name": "lineitem"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 236,
+                  "startFilePos": 718,
+                  "endLine": 8,
+                  "endTokenPos": 236,
+                  "endFilePos": 728
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 236,
+                    "startFilePos": 718,
+                    "endLine": 8,
+                    "endTokenPos": 236,
+                    "endFilePos": 728
+                  },
+                  "name": "start_date"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 239,
+                  "startFilePos": 731,
+                  "endLine": 8,
+                  "endTokenPos": 239,
+                  "endFilePos": 739
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 239,
+                    "startFilePos": 731,
+                    "endLine": 8,
+                    "endTokenPos": 239,
+                    "endFilePos": 739
+                  },
+                  "name": "end_date"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 244,
+                  "startFilePos": 746,
+                  "endLine": 9,
+                  "endTokenPos": 250,
+                  "endFilePos": 758
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 244,
+                    "startFilePos": 746,
+                    "endLine": 9,
+                    "endTokenPos": 249,
+                    "endFilePos": 757
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 244,
+                      "startFilePos": 746,
+                      "endLine": 9,
+                      "endTokenPos": 244,
+                      "endFilePos": 752
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 248,
+                      "startFilePos": 756,
+                      "endLine": 9,
+                      "endTokenPos": 249,
+                      "endFilePos": 757,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 252,
+                  "startFilePos": 762,
+                  "endLine": 25,
+                  "endTokenPos": 556,
+                  "endFilePos": 1630
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 255,
+                    "startFilePos": 771,
+                    "endLine": 10,
+                    "endTokenPos": 255,
+                    "endFilePos": 779
+                  },
+                  "name": "customer"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 259,
+                    "startFilePos": 784,
+                    "endLine": 10,
+                    "endTokenPos": 259,
+                    "endFilePos": 785
+                  },
+                  "name": "c"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 264,
+                      "startFilePos": 794,
+                      "endLine": 24,
+                      "endTokenPos": 554,
+                      "endFilePos": 1626
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 267,
+                        "startFilePos": 803,
+                        "endLine": 11,
+                        "endTokenPos": 267,
+                        "endFilePos": 809
+                      },
+                      "name": "orders"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 271,
+                        "startFilePos": 814,
+                        "endLine": 11,
+                        "endTokenPos": 271,
+                        "endFilePos": 815
+                      },
+                      "name": "o"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Foreach",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 276,
+                          "startFilePos": 826,
+                          "endLine": 23,
+                          "endTokenPos": 552,
+                          "endFilePos": 1620
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 279,
+                            "startFilePos": 835,
+                            "endLine": 12,
+                            "endTokenPos": 279,
+                            "endFilePos": 843
+                          },
+                          "name": "lineitem"
+                        },
+                        "keyVar": null,
+                        "byRef": false,
+                        "valueVar": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 283,
+                            "startFilePos": 848,
+                            "endLine": 12,
+                            "endTokenPos": 283,
+                            "endFilePos": 849
+                          },
+                          "name": "l"
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Foreach",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 288,
+                              "startFilePos": 862,
+                              "endLine": 22,
+                              "endTokenPos": 550,
+                              "endFilePos": 1612
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 291,
+                                "startFilePos": 871,
+                                "endLine": 13,
+                                "endTokenPos": 291,
+                                "endFilePos": 877
+                              },
+                              "name": "nation"
+                            },
+                            "keyVar": null,
+                            "byRef": false,
+                            "valueVar": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 295,
+                                "startFilePos": 882,
+                                "endLine": 13,
+                                "endTokenPos": 295,
+                                "endFilePos": 883
+                              },
+                              "name": "n"
+                            },
+                            "stmts": [
+                              {
+                                "nodeType": "Stmt_If",
+                                "attributes": {
+                                  "startLine": 14,
+                                  "startTokenPos": 300,
+                                  "startFilePos": 898,
+                                  "endLine": 21,
+                                  "endTokenPos": 548,
+                                  "endFilePos": 1602
+                                },
+                                "cond": {
+                                  "nodeType": "Expr_BinaryOp_BooleanAnd",
+                                  "attributes": {
+                                    "startLine": 14,
+                                    "startTokenPos": 303,
+                                    "startFilePos": 902,
+                                    "endLine": 14,
+                                    "endTokenPos": 374,
+                                    "endFilePos": 1115
+                                  },
+                                  "left": {
+                                    "nodeType": "Expr_BinaryOp_BooleanAnd",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 303,
+                                      "startFilePos": 902,
+                                      "endLine": 14,
+                                      "endTokenPos": 363,
+                                      "endFilePos": 1086
+                                    },
+                                    "left": {
+                                      "nodeType": "Expr_BinaryOp_BooleanAnd",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 303,
+                                        "startFilePos": 902,
+                                        "endLine": 14,
+                                        "endTokenPos": 352,
+                                        "endFilePos": 1053
+                                      },
+                                      "left": {
+                                        "nodeType": "Expr_BinaryOp_BooleanAnd",
+                                        "attributes": {
+                                          "startLine": 14,
+                                          "startTokenPos": 303,
+                                          "startFilePos": 902,
+                                          "endLine": 14,
+                                          "endTokenPos": 341,
+                                          "endFilePos": 1017
+                                        },
+                                        "left": {
+                                          "nodeType": "Expr_BinaryOp_BooleanAnd",
+                                          "attributes": {
+                                            "startLine": 14,
+                                            "startTokenPos": 303,
+                                            "startFilePos": 902,
+                                            "endLine": 14,
+                                            "endTokenPos": 327,
+                                            "endFilePos": 975
+                                          },
+                                          "left": {
+                                            "nodeType": "Expr_BinaryOp_Equal",
+                                            "attributes": {
+                                              "startLine": 14,
+                                              "startTokenPos": 303,
+                                              "startFilePos": 902,
+                                              "endLine": 14,
+                                              "endTokenPos": 313,
+                                              "endFilePos": 935
+                                            },
+                                            "left": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 303,
+                                                "startFilePos": 902,
+                                                "endLine": 14,
+                                                "endTokenPos": 306,
+                                                "endFilePos": 916
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 303,
+                                                  "startFilePos": 902,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 303,
+                                                  "endFilePos": 903
+                                                },
+                                                "name": "o"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 305,
+                                                  "startFilePos": 905,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 305,
+                                                  "endFilePos": 915,
+                                                  "kind": 2,
+                                                  "rawValue": "\"o_custkey\""
+                                                },
+                                                "value": "o_custkey"
+                                              }
+                                            },
+                                            "right": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 310,
+                                                "startFilePos": 921,
+                                                "endLine": 14,
+                                                "endTokenPos": 313,
+                                                "endFilePos": 935
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 310,
+                                                  "startFilePos": 921,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 310,
+                                                  "endFilePos": 922
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 312,
+                                                  "startFilePos": 924,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 312,
+                                                  "endFilePos": 934,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_custkey\""
+                                                },
+                                                "value": "c_custkey"
+                                              }
+                                            }
+                                          },
+                                          "right": {
+                                            "nodeType": "Expr_BinaryOp_Equal",
+                                            "attributes": {
+                                              "startLine": 14,
+                                              "startTokenPos": 317,
+                                              "startFilePos": 940,
+                                              "endLine": 14,
+                                              "endTokenPos": 327,
+                                              "endFilePos": 975
+                                            },
+                                            "left": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 317,
+                                                "startFilePos": 940,
+                                                "endLine": 14,
+                                                "endTokenPos": 320,
+                                                "endFilePos": 955
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 317,
+                                                  "startFilePos": 940,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 317,
+                                                  "endFilePos": 941
+                                                },
+                                                "name": "l"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 319,
+                                                  "startFilePos": 943,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 319,
+                                                  "endFilePos": 954,
+                                                  "kind": 2,
+                                                  "rawValue": "\"l_orderkey\""
+                                                },
+                                                "value": "l_orderkey"
+                                              }
+                                            },
+                                            "right": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 324,
+                                                "startFilePos": 960,
+                                                "endLine": 14,
+                                                "endTokenPos": 327,
+                                                "endFilePos": 975
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 324,
+                                                  "startFilePos": 960,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 324,
+                                                  "endFilePos": 961
+                                                },
+                                                "name": "o"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 14,
+                                                  "startTokenPos": 326,
+                                                  "startFilePos": 963,
+                                                  "endLine": 14,
+                                                  "endTokenPos": 326,
+                                                  "endFilePos": 974,
+                                                  "kind": 2,
+                                                  "rawValue": "\"o_orderkey\""
+                                                },
+                                                "value": "o_orderkey"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "right": {
+                                          "nodeType": "Expr_BinaryOp_Equal",
+                                          "attributes": {
+                                            "startLine": 14,
+                                            "startTokenPos": 331,
+                                            "startFilePos": 980,
+                                            "endLine": 14,
+                                            "endTokenPos": 341,
+                                            "endFilePos": 1017
+                                          },
+                                          "left": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 14,
+                                              "startTokenPos": 331,
+                                              "startFilePos": 980,
+                                              "endLine": 14,
+                                              "endTokenPos": 334,
+                                              "endFilePos": 996
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 331,
+                                                "startFilePos": 980,
+                                                "endLine": 14,
+                                                "endTokenPos": 331,
+                                                "endFilePos": 981
+                                              },
+                                              "name": "n"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 333,
+                                                "startFilePos": 983,
+                                                "endLine": 14,
+                                                "endTokenPos": 333,
+                                                "endFilePos": 995,
+                                                "kind": 2,
+                                                "rawValue": "\"n_nationkey\""
+                                              },
+                                              "value": "n_nationkey"
+                                            }
+                                          },
+                                          "right": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 14,
+                                              "startTokenPos": 338,
+                                              "startFilePos": 1001,
+                                              "endLine": 14,
+                                              "endTokenPos": 341,
+                                              "endFilePos": 1017
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 338,
+                                                "startFilePos": 1001,
+                                                "endLine": 14,
+                                                "endTokenPos": 338,
+                                                "endFilePos": 1002
+                                              },
+                                              "name": "c"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 14,
+                                                "startTokenPos": 340,
+                                                "startFilePos": 1004,
+                                                "endLine": 14,
+                                                "endTokenPos": 340,
+                                                "endFilePos": 1016,
+                                                "kind": 2,
+                                                "rawValue": "\"c_nationkey\""
+                                              },
+                                              "value": "c_nationkey"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "right": {
+                                        "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+                                        "attributes": {
+                                          "startLine": 14,
+                                          "startTokenPos": 345,
+                                          "startFilePos": 1022,
+                                          "endLine": 14,
+                                          "endTokenPos": 352,
+                                          "endFilePos": 1053
+                                        },
+                                        "left": {
+                                          "nodeType": "Expr_ArrayDimFetch",
+                                          "attributes": {
+                                            "startLine": 14,
+                                            "startTokenPos": 345,
+                                            "startFilePos": 1022,
+                                            "endLine": 14,
+                                            "endTokenPos": 348,
+                                            "endFilePos": 1038
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 14,
+                                              "startTokenPos": 345,
+                                              "startFilePos": 1022,
+                                              "endLine": 14,
+                                              "endTokenPos": 345,
+                                              "endFilePos": 1023
+                                            },
+                                            "name": "o"
+                                          },
+                                          "dim": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 14,
+                                              "startTokenPos": 347,
+                                              "startFilePos": 1025,
+                                              "endLine": 14,
+                                              "endTokenPos": 347,
+                                              "endFilePos": 1037,
+                                              "kind": 2,
+                                              "rawValue": "\"o_orderdate\""
+                                            },
+                                            "value": "o_orderdate"
+                                          }
+                                        },
+                                        "right": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 14,
+                                            "startTokenPos": 352,
+                                            "startFilePos": 1043,
+                                            "endLine": 14,
+                                            "endTokenPos": 352,
+                                            "endFilePos": 1053
+                                          },
+                                          "name": "start_date"
+                                        }
+                                      }
+                                    },
+                                    "right": {
+                                      "nodeType": "Expr_BinaryOp_Smaller",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 356,
+                                        "startFilePos": 1058,
+                                        "endLine": 14,
+                                        "endTokenPos": 363,
+                                        "endFilePos": 1086
+                                      },
+                                      "left": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 14,
+                                          "startTokenPos": 356,
+                                          "startFilePos": 1058,
+                                          "endLine": 14,
+                                          "endTokenPos": 359,
+                                          "endFilePos": 1074
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 14,
+                                            "startTokenPos": 356,
+                                            "startFilePos": 1058,
+                                            "endLine": 14,
+                                            "endTokenPos": 356,
+                                            "endFilePos": 1059
+                                          },
+                                          "name": "o"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 14,
+                                            "startTokenPos": 358,
+                                            "startFilePos": 1061,
+                                            "endLine": 14,
+                                            "endTokenPos": 358,
+                                            "endFilePos": 1073,
+                                            "kind": 2,
+                                            "rawValue": "\"o_orderdate\""
+                                          },
+                                          "value": "o_orderdate"
+                                        }
+                                      },
+                                      "right": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 14,
+                                          "startTokenPos": 363,
+                                          "startFilePos": 1078,
+                                          "endLine": 14,
+                                          "endTokenPos": 363,
+                                          "endFilePos": 1086
+                                        },
+                                        "name": "end_date"
+                                      }
+                                    }
+                                  },
+                                  "right": {
+                                    "nodeType": "Expr_BinaryOp_Equal",
+                                    "attributes": {
+                                      "startLine": 14,
+                                      "startTokenPos": 367,
+                                      "startFilePos": 1091,
+                                      "endLine": 14,
+                                      "endTokenPos": 374,
+                                      "endFilePos": 1115
+                                    },
+                                    "left": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 367,
+                                        "startFilePos": 1091,
+                                        "endLine": 14,
+                                        "endTokenPos": 370,
+                                        "endFilePos": 1108
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 14,
+                                          "startTokenPos": 367,
+                                          "startFilePos": 1091,
+                                          "endLine": 14,
+                                          "endTokenPos": 367,
+                                          "endFilePos": 1092
+                                        },
+                                        "name": "l"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 14,
+                                          "startTokenPos": 369,
+                                          "startFilePos": 1094,
+                                          "endLine": 14,
+                                          "endTokenPos": 369,
+                                          "endFilePos": 1107,
+                                          "kind": 2,
+                                          "rawValue": "\"l_returnflag\""
+                                        },
+                                        "value": "l_returnflag"
+                                      }
+                                    },
+                                    "right": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 14,
+                                        "startTokenPos": 374,
+                                        "startFilePos": 1113,
+                                        "endLine": 14,
+                                        "endTokenPos": 374,
+                                        "endFilePos": 1115,
+                                        "kind": 2,
+                                        "rawValue": "\"R\""
+                                      },
+                                      "value": "R"
+                                    }
+                                  }
+                                },
+                                "stmts": [
+                                  {
+                                    "nodeType": "Stmt_Expression",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 379,
+                                      "startFilePos": 1132,
+                                      "endLine": 15,
+                                      "endTokenPos": 453,
+                                      "endFilePos": 1347
+                                    },
+                                    "expr": {
+                                      "nodeType": "Expr_Assign",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 379,
+                                        "startFilePos": 1132,
+                                        "endLine": 15,
+                                        "endTokenPos": 452,
+                                        "endFilePos": 1346
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 379,
+                                          "startFilePos": 1132,
+                                          "endLine": 15,
+                                          "endTokenPos": 379,
+                                          "endFilePos": 1135
+                                        },
+                                        "name": "key"
+                                      },
+                                      "expr": {
+                                        "nodeType": "Expr_Array",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 383,
+                                          "startFilePos": 1139,
+                                          "endLine": 15,
+                                          "endTokenPos": 452,
+                                          "endFilePos": 1346,
+                                          "kind": 2
+                                        },
+                                        "items": [
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 384,
+                                              "startFilePos": 1140,
+                                              "endLine": 15,
+                                              "endTokenPos": 391,
+                                              "endFilePos": 1169
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 384,
+                                                "startFilePos": 1140,
+                                                "endLine": 15,
+                                                "endTokenPos": 384,
+                                                "endFilePos": 1150,
+                                                "kind": 2,
+                                                "rawValue": "\"c_custkey\""
+                                              },
+                                              "value": "c_custkey"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 388,
+                                                "startFilePos": 1155,
+                                                "endLine": 15,
+                                                "endTokenPos": 391,
+                                                "endFilePos": 1169
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 388,
+                                                  "startFilePos": 1155,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 388,
+                                                  "endFilePos": 1156
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 390,
+                                                  "startFilePos": 1158,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 390,
+                                                  "endFilePos": 1168,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_custkey\""
+                                                },
+                                                "value": "c_custkey"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 394,
+                                              "startFilePos": 1172,
+                                              "endLine": 15,
+                                              "endTokenPos": 401,
+                                              "endFilePos": 1195
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 394,
+                                                "startFilePos": 1172,
+                                                "endLine": 15,
+                                                "endTokenPos": 394,
+                                                "endFilePos": 1179,
+                                                "kind": 2,
+                                                "rawValue": "\"c_name\""
+                                              },
+                                              "value": "c_name"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 398,
+                                                "startFilePos": 1184,
+                                                "endLine": 15,
+                                                "endTokenPos": 401,
+                                                "endFilePos": 1195
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 398,
+                                                  "startFilePos": 1184,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 398,
+                                                  "endFilePos": 1185
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 400,
+                                                  "startFilePos": 1187,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 400,
+                                                  "endFilePos": 1194,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_name\""
+                                                },
+                                                "value": "c_name"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 404,
+                                              "startFilePos": 1198,
+                                              "endLine": 15,
+                                              "endTokenPos": 411,
+                                              "endFilePos": 1227
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 404,
+                                                "startFilePos": 1198,
+                                                "endLine": 15,
+                                                "endTokenPos": 404,
+                                                "endFilePos": 1208,
+                                                "kind": 2,
+                                                "rawValue": "\"c_acctbal\""
+                                              },
+                                              "value": "c_acctbal"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 408,
+                                                "startFilePos": 1213,
+                                                "endLine": 15,
+                                                "endTokenPos": 411,
+                                                "endFilePos": 1227
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 408,
+                                                  "startFilePos": 1213,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 408,
+                                                  "endFilePos": 1214
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 410,
+                                                  "startFilePos": 1216,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 410,
+                                                  "endFilePos": 1226,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_acctbal\""
+                                                },
+                                                "value": "c_acctbal"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 414,
+                                              "startFilePos": 1230,
+                                              "endLine": 15,
+                                              "endTokenPos": 421,
+                                              "endFilePos": 1259
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 414,
+                                                "startFilePos": 1230,
+                                                "endLine": 15,
+                                                "endTokenPos": 414,
+                                                "endFilePos": 1240,
+                                                "kind": 2,
+                                                "rawValue": "\"c_address\""
+                                              },
+                                              "value": "c_address"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 418,
+                                                "startFilePos": 1245,
+                                                "endLine": 15,
+                                                "endTokenPos": 421,
+                                                "endFilePos": 1259
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 418,
+                                                  "startFilePos": 1245,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 418,
+                                                  "endFilePos": 1246
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 420,
+                                                  "startFilePos": 1248,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 420,
+                                                  "endFilePos": 1258,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_address\""
+                                                },
+                                                "value": "c_address"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 424,
+                                              "startFilePos": 1262,
+                                              "endLine": 15,
+                                              "endTokenPos": 431,
+                                              "endFilePos": 1287
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 424,
+                                                "startFilePos": 1262,
+                                                "endLine": 15,
+                                                "endTokenPos": 424,
+                                                "endFilePos": 1270,
+                                                "kind": 2,
+                                                "rawValue": "\"c_phone\""
+                                              },
+                                              "value": "c_phone"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 428,
+                                                "startFilePos": 1275,
+                                                "endLine": 15,
+                                                "endTokenPos": 431,
+                                                "endFilePos": 1287
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 428,
+                                                  "startFilePos": 1275,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 428,
+                                                  "endFilePos": 1276
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 430,
+                                                  "startFilePos": 1278,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 430,
+                                                  "endFilePos": 1286,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_phone\""
+                                                },
+                                                "value": "c_phone"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 434,
+                                              "startFilePos": 1290,
+                                              "endLine": 15,
+                                              "endTokenPos": 441,
+                                              "endFilePos": 1319
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 434,
+                                                "startFilePos": 1290,
+                                                "endLine": 15,
+                                                "endTokenPos": 434,
+                                                "endFilePos": 1300,
+                                                "kind": 2,
+                                                "rawValue": "\"c_comment\""
+                                              },
+                                              "value": "c_comment"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 438,
+                                                "startFilePos": 1305,
+                                                "endLine": 15,
+                                                "endTokenPos": 441,
+                                                "endFilePos": 1319
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 438,
+                                                  "startFilePos": 1305,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 438,
+                                                  "endFilePos": 1306
+                                                },
+                                                "name": "c"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 440,
+                                                  "startFilePos": 1308,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 440,
+                                                  "endFilePos": 1318,
+                                                  "kind": 2,
+                                                  "rawValue": "\"c_comment\""
+                                                },
+                                                "value": "c_comment"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 444,
+                                              "startFilePos": 1322,
+                                              "endLine": 15,
+                                              "endTokenPos": 451,
+                                              "endFilePos": 1345
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 444,
+                                                "startFilePos": 1322,
+                                                "endLine": 15,
+                                                "endTokenPos": 444,
+                                                "endFilePos": 1329,
+                                                "kind": 2,
+                                                "rawValue": "\"n_name\""
+                                              },
+                                              "value": "n_name"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 448,
+                                                "startFilePos": 1334,
+                                                "endLine": 15,
+                                                "endTokenPos": 451,
+                                                "endFilePos": 1345
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 448,
+                                                  "startFilePos": 1334,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 448,
+                                                  "endFilePos": 1335
+                                                },
+                                                "name": "n"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 15,
+                                                  "startTokenPos": 450,
+                                                  "startFilePos": 1337,
+                                                  "endLine": 15,
+                                                  "endTokenPos": 450,
+                                                  "endFilePos": 1344,
+                                                  "kind": 2,
+                                                  "rawValue": "\"n_name\""
+                                                },
+                                                "value": "n_name"
+                                              }
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "nodeType": "Stmt_Expression",
+                                    "attributes": {
+                                      "startLine": 16,
+                                      "startTokenPos": 455,
+                                      "startFilePos": 1361,
+                                      "endLine": 16,
+                                      "endTokenPos": 463,
+                                      "endFilePos": 1383
+                                    },
+                                    "expr": {
+                                      "nodeType": "Expr_Assign",
+                                      "attributes": {
+                                        "startLine": 16,
+                                        "startTokenPos": 455,
+                                        "startFilePos": 1361,
+                                        "endLine": 16,
+                                        "endTokenPos": 462,
+                                        "endFilePos": 1382
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 16,
+                                          "startTokenPos": 455,
+                                          "startFilePos": 1361,
+                                          "endLine": 16,
+                                          "endTokenPos": 455,
+                                          "endFilePos": 1362
+                                        },
+                                        "name": "k"
+                                      },
+                                      "expr": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 16,
+                                          "startTokenPos": 459,
+                                          "startFilePos": 1366,
+                                          "endLine": 16,
+                                          "endTokenPos": 462,
+                                          "endFilePos": 1382
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 16,
+                                            "startTokenPos": 459,
+                                            "startFilePos": 1366,
+                                            "endLine": 16,
+                                            "endTokenPos": 459,
+                                            "endFilePos": 1376
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 16,
+                                              "startTokenPos": 461,
+                                              "startFilePos": 1378,
+                                              "endLine": 16,
+                                              "endTokenPos": 461,
+                                              "endFilePos": 1381
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 16,
+                                                "startTokenPos": 461,
+                                                "startFilePos": 1378,
+                                                "endLine": 16,
+                                                "endTokenPos": 461,
+                                                "endFilePos": 1381
+                                              },
+                                              "name": "key"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "nodeType": "Stmt_If",
+                                    "attributes": {
+                                      "startLine": 17,
+                                      "startTokenPos": 465,
+                                      "startFilePos": 1397,
+                                      "endLine": 19,
+                                      "endTokenPos": 504,
+                                      "endFilePos": 1507
+                                    },
+                                    "cond": {
+                                      "nodeType": "Expr_BooleanNot",
+                                      "attributes": {
+                                        "startLine": 17,
+                                        "startTokenPos": 468,
+                                        "startFilePos": 1401,
+                                        "endLine": 17,
+                                        "endTokenPos": 475,
+                                        "endFilePos": 1430
+                                      },
+                                      "expr": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 17,
+                                          "startTokenPos": 469,
+                                          "startFilePos": 1402,
+                                          "endLine": 17,
+                                          "endTokenPos": 475,
+                                          "endFilePos": 1430
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 17,
+                                            "startTokenPos": 469,
+                                            "startFilePos": 1402,
+                                            "endLine": 17,
+                                            "endTokenPos": 469,
+                                            "endFilePos": 1417
+                                          },
+                                          "name": "array_key_exists"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 17,
+                                              "startTokenPos": 471,
+                                              "startFilePos": 1419,
+                                              "endLine": 17,
+                                              "endTokenPos": 471,
+                                              "endFilePos": 1420
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 471,
+                                                "startFilePos": 1419,
+                                                "endLine": 17,
+                                                "endTokenPos": 471,
+                                                "endFilePos": 1420
+                                              },
+                                              "name": "k"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 17,
+                                              "startTokenPos": 474,
+                                              "startFilePos": 1423,
+                                              "endLine": 17,
+                                              "endTokenPos": 474,
+                                              "endFilePos": 1429
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 474,
+                                                "startFilePos": 1423,
+                                                "endLine": 17,
+                                                "endTokenPos": 474,
+                                                "endFilePos": 1429
+                                              },
+                                              "name": "groups"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "stmts": [
+                                      {
+                                        "nodeType": "Stmt_Expression",
+                                        "attributes": {
+                                          "startLine": 18,
+                                          "startTokenPos": 480,
+                                          "startFilePos": 1449,
+                                          "endLine": 18,
+                                          "endTokenPos": 502,
+                                          "endFilePos": 1493
+                                        },
+                                        "expr": {
+                                          "nodeType": "Expr_Assign",
+                                          "attributes": {
+                                            "startLine": 18,
+                                            "startTokenPos": 480,
+                                            "startFilePos": 1449,
+                                            "endLine": 18,
+                                            "endTokenPos": 501,
+                                            "endFilePos": 1492
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 18,
+                                              "startTokenPos": 480,
+                                              "startFilePos": 1449,
+                                              "endLine": 18,
+                                              "endTokenPos": 483,
+                                              "endFilePos": 1459
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 18,
+                                                "startTokenPos": 480,
+                                                "startFilePos": 1449,
+                                                "endLine": 18,
+                                                "endTokenPos": 480,
+                                                "endFilePos": 1455
+                                              },
+                                              "name": "groups"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 18,
+                                                "startTokenPos": 482,
+                                                "startFilePos": 1457,
+                                                "endLine": 18,
+                                                "endTokenPos": 482,
+                                                "endFilePos": 1458
+                                              },
+                                              "name": "k"
+                                            }
+                                          },
+                                          "expr": {
+                                            "nodeType": "Expr_Array",
+                                            "attributes": {
+                                              "startLine": 18,
+                                              "startTokenPos": 487,
+                                              "startFilePos": 1463,
+                                              "endLine": 18,
+                                              "endTokenPos": 501,
+                                              "endFilePos": 1492,
+                                              "kind": 2
+                                            },
+                                            "items": [
+                                              {
+                                                "nodeType": "ArrayItem",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 488,
+                                                  "startFilePos": 1464,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 492,
+                                                  "endFilePos": 1476
+                                                },
+                                                "key": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 488,
+                                                    "startFilePos": 1464,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 488,
+                                                    "endFilePos": 1468,
+                                                    "kind": 1,
+                                                    "rawValue": "'key'"
+                                                  },
+                                                  "value": "key"
+                                                },
+                                                "value": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 492,
+                                                    "startFilePos": 1473,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 492,
+                                                    "endFilePos": 1476
+                                                  },
+                                                  "name": "key"
+                                                },
+                                                "byRef": false,
+                                                "unpack": false
+                                              },
+                                              {
+                                                "nodeType": "ArrayItem",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 495,
+                                                  "startFilePos": 1479,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 500,
+                                                  "endFilePos": 1491
+                                                },
+                                                "key": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 495,
+                                                    "startFilePos": 1479,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 495,
+                                                    "endFilePos": 1485,
+                                                    "kind": 1,
+                                                    "rawValue": "'items'"
+                                                  },
+                                                  "value": "items"
+                                                },
+                                                "value": {
+                                                  "nodeType": "Expr_Array",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 499,
+                                                    "startFilePos": 1490,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 500,
+                                                    "endFilePos": 1491,
+                                                    "kind": 2
+                                                  },
+                                                  "items": []
+                                                },
+                                                "byRef": false,
+                                                "unpack": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "elseifs": [],
+                                    "else": null
+                                  },
+                                  {
+                                    "nodeType": "Stmt_Expression",
+                                    "attributes": {
+                                      "startLine": 20,
+                                      "startTokenPos": 506,
+                                      "startFilePos": 1521,
+                                      "endLine": 20,
+                                      "endTokenPos": 546,
+                                      "endFilePos": 1590
+                                    },
+                                    "expr": {
+                                      "nodeType": "Expr_Assign",
+                                      "attributes": {
+                                        "startLine": 20,
+                                        "startTokenPos": 506,
+                                        "startFilePos": 1521,
+                                        "endLine": 20,
+                                        "endTokenPos": 545,
+                                        "endFilePos": 1589
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 20,
+                                          "startTokenPos": 506,
+                                          "startFilePos": 1521,
+                                          "endLine": 20,
+                                          "endTokenPos": 514,
+                                          "endFilePos": 1542
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_ArrayDimFetch",
+                                          "attributes": {
+                                            "startLine": 20,
+                                            "startTokenPos": 506,
+                                            "startFilePos": 1521,
+                                            "endLine": 20,
+                                            "endTokenPos": 512,
+                                            "endFilePos": 1540
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 506,
+                                              "startFilePos": 1521,
+                                              "endLine": 20,
+                                              "endTokenPos": 509,
+                                              "endFilePos": 1531
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 506,
+                                                "startFilePos": 1521,
+                                                "endLine": 20,
+                                                "endTokenPos": 506,
+                                                "endFilePos": 1527
+                                              },
+                                              "name": "groups"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 508,
+                                                "startFilePos": 1529,
+                                                "endLine": 20,
+                                                "endTokenPos": 508,
+                                                "endFilePos": 1530
+                                              },
+                                              "name": "k"
+                                            }
+                                          },
+                                          "dim": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 511,
+                                              "startFilePos": 1533,
+                                              "endLine": 20,
+                                              "endTokenPos": 511,
+                                              "endFilePos": 1539,
+                                              "kind": 1,
+                                              "rawValue": "'items'"
+                                            },
+                                            "value": "items"
+                                          }
+                                        },
+                                        "dim": null
+                                      },
+                                      "expr": {
+                                        "nodeType": "Expr_Array",
+                                        "attributes": {
+                                          "startLine": 20,
+                                          "startTokenPos": 518,
+                                          "startFilePos": 1546,
+                                          "endLine": 20,
+                                          "endTokenPos": 545,
+                                          "endFilePos": 1589,
+                                          "kind": 2
+                                        },
+                                        "items": [
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 519,
+                                              "startFilePos": 1547,
+                                              "endLine": 20,
+                                              "endTokenPos": 523,
+                                              "endFilePos": 1555
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 519,
+                                                "startFilePos": 1547,
+                                                "endLine": 20,
+                                                "endTokenPos": 519,
+                                                "endFilePos": 1549,
+                                                "kind": 1,
+                                                "rawValue": "'c'"
+                                              },
+                                              "value": "c"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 523,
+                                                "startFilePos": 1554,
+                                                "endLine": 20,
+                                                "endTokenPos": 523,
+                                                "endFilePos": 1555
+                                              },
+                                              "name": "c"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 526,
+                                              "startFilePos": 1558,
+                                              "endLine": 20,
+                                              "endTokenPos": 530,
+                                              "endFilePos": 1566
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 526,
+                                                "startFilePos": 1558,
+                                                "endLine": 20,
+                                                "endTokenPos": 526,
+                                                "endFilePos": 1560,
+                                                "kind": 1,
+                                                "rawValue": "'o'"
+                                              },
+                                              "value": "o"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 530,
+                                                "startFilePos": 1565,
+                                                "endLine": 20,
+                                                "endTokenPos": 530,
+                                                "endFilePos": 1566
+                                              },
+                                              "name": "o"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 533,
+                                              "startFilePos": 1569,
+                                              "endLine": 20,
+                                              "endTokenPos": 537,
+                                              "endFilePos": 1577
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 533,
+                                                "startFilePos": 1569,
+                                                "endLine": 20,
+                                                "endTokenPos": 533,
+                                                "endFilePos": 1571,
+                                                "kind": 1,
+                                                "rawValue": "'l'"
+                                              },
+                                              "value": "l"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 537,
+                                                "startFilePos": 1576,
+                                                "endLine": 20,
+                                                "endTokenPos": 537,
+                                                "endFilePos": 1577
+                                              },
+                                              "name": "l"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "ArrayItem",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 540,
+                                              "startFilePos": 1580,
+                                              "endLine": 20,
+                                              "endTokenPos": 544,
+                                              "endFilePos": 1588
+                                            },
+                                            "key": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 540,
+                                                "startFilePos": 1580,
+                                                "endLine": 20,
+                                                "endTokenPos": 540,
+                                                "endFilePos": 1582,
+                                                "kind": 1,
+                                                "rawValue": "'n'"
+                                              },
+                                              "value": "n"
+                                            },
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 544,
+                                                "startFilePos": 1587,
+                                                "endLine": 20,
+                                                "endTokenPos": 544,
+                                                "endFilePos": 1588
+                                              },
+                                              "name": "n"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "elseifs": [],
+                                "else": null
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 26,
+                  "startTokenPos": 558,
+                  "startFilePos": 1634,
+                  "endLine": 26,
+                  "endTokenPos": 564,
+                  "endFilePos": 1646
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 558,
+                    "startFilePos": 1634,
+                    "endLine": 26,
+                    "endTokenPos": 563,
+                    "endFilePos": 1645
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 558,
+                      "startFilePos": 1634,
+                      "endLine": 26,
+                      "endTokenPos": 558,
+                      "endFilePos": 1640
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 562,
+                      "startFilePos": 1644,
+                      "endLine": 26,
+                      "endTokenPos": 563,
+                      "endFilePos": 1645,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 566,
+                  "startFilePos": 1650,
+                  "endLine": 41,
+                  "endTokenPos": 874,
+                  "endFilePos": 2371
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 569,
+                    "startFilePos": 1659,
+                    "endLine": 27,
+                    "endTokenPos": 569,
+                    "endFilePos": 1665
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 573,
+                    "startFilePos": 1670,
+                    "endLine": 27,
+                    "endTokenPos": 573,
+                    "endFilePos": 1671
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 28,
+                      "startTokenPos": 578,
+                      "startFilePos": 1682,
+                      "endLine": 40,
+                      "endTokenPos": 872,
+                      "endFilePos": 2367
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 28,
+                        "startTokenPos": 578,
+                        "startFilePos": 1682,
+                        "endLine": 40,
+                        "endTokenPos": 871,
+                        "endFilePos": 2366
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 28,
+                          "startTokenPos": 578,
+                          "startFilePos": 1682,
+                          "endLine": 28,
+                          "endTokenPos": 580,
+                          "endFilePos": 1690
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 28,
+                            "startTokenPos": 578,
+                            "startFilePos": 1682,
+                            "endLine": 28,
+                            "endTokenPos": 578,
+                            "endFilePos": 1688
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 28,
+                          "startTokenPos": 584,
+                          "startFilePos": 1694,
+                          "endLine": 40,
+                          "endTokenPos": 871,
+                          "endFilePos": 2366,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 28,
+                              "startTokenPos": 585,
+                              "startFilePos": 1695,
+                              "endLine": 34,
+                              "endTokenPos": 678,
+                              "endFilePos": 1893
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_UnaryMinus",
+                              "attributes": {
+                                "startLine": 28,
+                                "startTokenPos": 585,
+                                "startFilePos": 1695,
+                                "endLine": 34,
+                                "endTokenPos": 678,
+                                "endFilePos": 1893
+                              },
+                              "expr": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 28,
+                                  "startTokenPos": 586,
+                                  "startFilePos": 1696,
+                                  "endLine": 34,
+                                  "endTokenPos": 678,
+                                  "endFilePos": 1893
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 28,
+                                    "startTokenPos": 586,
+                                    "startFilePos": 1696,
+                                    "endLine": 28,
+                                    "endTokenPos": 586,
+                                    "endFilePos": 1704
+                                  },
+                                  "name": "array_sum"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 28,
+                                      "startTokenPos": 588,
+                                      "startFilePos": 1706,
+                                      "endLine": 34,
+                                      "endTokenPos": 677,
+                                      "endFilePos": 1892
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 28,
+                                        "startTokenPos": 588,
+                                        "startFilePos": 1706,
+                                        "endLine": 34,
+                                        "endTokenPos": 677,
+                                        "endFilePos": 1892
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 28,
+                                          "startTokenPos": 589,
+                                          "startFilePos": 1707,
+                                          "endLine": 34,
+                                          "endTokenPos": 674,
+                                          "endFilePos": 1889
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 596,
+                                              "startFilePos": 1723,
+                                              "endLine": 28,
+                                              "endTokenPos": 596,
+                                              "endFilePos": 1724
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 28,
+                                                "startTokenPos": 596,
+                                                "startFilePos": 1723,
+                                                "endLine": 28,
+                                                "endTokenPos": 596,
+                                                "endFilePos": 1724
+                                              },
+                                              "name": "c"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 599,
+                                              "startFilePos": 1727,
+                                              "endLine": 28,
+                                              "endTokenPos": 599,
+                                              "endFilePos": 1728
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 28,
+                                                "startTokenPos": 599,
+                                                "startFilePos": 1727,
+                                                "endLine": 28,
+                                                "endTokenPos": 599,
+                                                "endFilePos": 1728
+                                              },
+                                              "name": "o"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 602,
+                                              "startFilePos": 1731,
+                                              "endLine": 28,
+                                              "endTokenPos": 602,
+                                              "endFilePos": 1732
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 28,
+                                                "startTokenPos": 602,
+                                                "startFilePos": 1731,
+                                                "endLine": 28,
+                                                "endTokenPos": 602,
+                                                "endFilePos": 1732
+                                              },
+                                              "name": "l"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 605,
+                                              "startFilePos": 1735,
+                                              "endLine": 28,
+                                              "endTokenPos": 605,
+                                              "endFilePos": 1736
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 28,
+                                                "startTokenPos": 605,
+                                                "startFilePos": 1735,
+                                                "endLine": 28,
+                                                "endTokenPos": 605,
+                                                "endFilePos": 1736
+                                              },
+                                              "name": "n"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 28,
+                                              "startTokenPos": 608,
+                                              "startFilePos": 1739,
+                                              "endLine": 28,
+                                              "endTokenPos": 608,
+                                              "endFilePos": 1740
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 28,
+                                                "startTokenPos": 608,
+                                                "startFilePos": 1739,
+                                                "endLine": 28,
+                                                "endTokenPos": 608,
+                                                "endFilePos": 1740
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 29,
+                                              "startTokenPos": 613,
+                                              "startFilePos": 1747,
+                                              "endLine": 29,
+                                              "endTokenPos": 619,
+                                              "endFilePos": 1759
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 29,
+                                                "startTokenPos": 613,
+                                                "startFilePos": 1747,
+                                                "endLine": 29,
+                                                "endTokenPos": 618,
+                                                "endFilePos": 1758
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 29,
+                                                  "startTokenPos": 613,
+                                                  "startFilePos": 1747,
+                                                  "endLine": 29,
+                                                  "endTokenPos": 613,
+                                                  "endFilePos": 1753
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 29,
+                                                  "startTokenPos": 617,
+                                                  "startFilePos": 1757,
+                                                  "endLine": 29,
+                                                  "endTokenPos": 618,
+                                                  "endFilePos": 1758,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 30,
+                                              "startTokenPos": 621,
+                                              "startFilePos": 1763,
+                                              "endLine": 32,
+                                              "endTokenPos": 667,
+                                              "endFilePos": 1869
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 30,
+                                                "startTokenPos": 624,
+                                                "startFilePos": 1772,
+                                                "endLine": 30,
+                                                "endTokenPos": 627,
+                                                "endFilePos": 1782
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 30,
+                                                  "startTokenPos": 624,
+                                                  "startFilePos": 1772,
+                                                  "endLine": 30,
+                                                  "endTokenPos": 624,
+                                                  "endFilePos": 1773
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 30,
+                                                  "startTokenPos": 626,
+                                                  "startFilePos": 1775,
+                                                  "endLine": 30,
+                                                  "endTokenPos": 626,
+                                                  "endFilePos": 1781,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 30,
+                                                "startTokenPos": 631,
+                                                "startFilePos": 1787,
+                                                "endLine": 30,
+                                                "endTokenPos": 631,
+                                                "endFilePos": 1788
+                                              },
+                                              "name": "x"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 31,
+                                                  "startTokenPos": 636,
+                                                  "startFilePos": 1797,
+                                                  "endLine": 31,
+                                                  "endTokenPos": 665,
+                                                  "endFilePos": 1865
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 31,
+                                                    "startTokenPos": 636,
+                                                    "startFilePos": 1797,
+                                                    "endLine": 31,
+                                                    "endTokenPos": 664,
+                                                    "endFilePos": 1864
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 31,
+                                                      "startTokenPos": 636,
+                                                      "startFilePos": 1797,
+                                                      "endLine": 31,
+                                                      "endTokenPos": 638,
+                                                      "endFilePos": 1805
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 31,
+                                                        "startTokenPos": 636,
+                                                        "startFilePos": 1797,
+                                                        "endLine": 31,
+                                                        "endTokenPos": 636,
+                                                        "endFilePos": 1803
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_BinaryOp_Mul",
+                                                    "attributes": {
+                                                      "startLine": 31,
+                                                      "startTokenPos": 642,
+                                                      "startFilePos": 1809,
+                                                      "endLine": 31,
+                                                      "endTokenPos": 664,
+                                                      "endFilePos": 1864
+                                                    },
+                                                    "left": {
+                                                      "nodeType": "Expr_ArrayDimFetch",
+                                                      "attributes": {
+                                                        "startLine": 31,
+                                                        "startTokenPos": 642,
+                                                        "startFilePos": 1809,
+                                                        "endLine": 31,
+                                                        "endTokenPos": 648,
+                                                        "endFilePos": 1834
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 31,
+                                                          "startTokenPos": 642,
+                                                          "startFilePos": 1809,
+                                                          "endLine": 31,
+                                                          "endTokenPos": 645,
+                                                          "endFilePos": 1815
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_Variable",
+                                                          "attributes": {
+                                                            "startLine": 31,
+                                                            "startTokenPos": 642,
+                                                            "startFilePos": 1809,
+                                                            "endLine": 31,
+                                                            "endTokenPos": 642,
+                                                            "endFilePos": 1810
+                                                          },
+                                                          "name": "x"
+                                                        },
+                                                        "dim": {
+                                                          "nodeType": "Scalar_String",
+                                                          "attributes": {
+                                                            "startLine": 31,
+                                                            "startTokenPos": 644,
+                                                            "startFilePos": 1812,
+                                                            "endLine": 31,
+                                                            "endTokenPos": 644,
+                                                            "endFilePos": 1814,
+                                                            "kind": 2,
+                                                            "rawValue": "\"l\""
+                                                          },
+                                                          "value": "l"
+                                                        }
+                                                      },
+                                                      "dim": {
+                                                        "nodeType": "Scalar_String",
+                                                        "attributes": {
+                                                          "startLine": 31,
+                                                          "startTokenPos": 647,
+                                                          "startFilePos": 1817,
+                                                          "endLine": 31,
+                                                          "endTokenPos": 647,
+                                                          "endFilePos": 1833,
+                                                          "kind": 2,
+                                                          "rawValue": "\"l_extendedprice\""
+                                                        },
+                                                        "value": "l_extendedprice"
+                                                      }
+                                                    },
+                                                    "right": {
+                                                      "nodeType": "Expr_BinaryOp_Minus",
+                                                      "attributes": {
+                                                        "startLine": 31,
+                                                        "startTokenPos": 653,
+                                                        "startFilePos": 1839,
+                                                        "endLine": 31,
+                                                        "endTokenPos": 663,
+                                                        "endFilePos": 1863
+                                                      },
+                                                      "left": {
+                                                        "nodeType": "Scalar_Int",
+                                                        "attributes": {
+                                                          "startLine": 31,
+                                                          "startTokenPos": 653,
+                                                          "startFilePos": 1839,
+                                                          "endLine": 31,
+                                                          "endTokenPos": 653,
+                                                          "endFilePos": 1839,
+                                                          "rawValue": "1",
+                                                          "kind": 10
+                                                        },
+                                                        "value": 1
+                                                      },
+                                                      "right": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 31,
+                                                          "startTokenPos": 657,
+                                                          "startFilePos": 1843,
+                                                          "endLine": 31,
+                                                          "endTokenPos": 663,
+                                                          "endFilePos": 1863
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_ArrayDimFetch",
+                                                          "attributes": {
+                                                            "startLine": 31,
+                                                            "startTokenPos": 657,
+                                                            "startFilePos": 1843,
+                                                            "endLine": 31,
+                                                            "endTokenPos": 660,
+                                                            "endFilePos": 1849
+                                                          },
+                                                          "var": {
+                                                            "nodeType": "Expr_Variable",
+                                                            "attributes": {
+                                                              "startLine": 31,
+                                                              "startTokenPos": 657,
+                                                              "startFilePos": 1843,
+                                                              "endLine": 31,
+                                                              "endTokenPos": 657,
+                                                              "endFilePos": 1844
+                                                            },
+                                                            "name": "x"
+                                                          },
+                                                          "dim": {
+                                                            "nodeType": "Scalar_String",
+                                                            "attributes": {
+                                                              "startLine": 31,
+                                                              "startTokenPos": 659,
+                                                              "startFilePos": 1846,
+                                                              "endLine": 31,
+                                                              "endTokenPos": 659,
+                                                              "endFilePos": 1848,
+                                                              "kind": 2,
+                                                              "rawValue": "\"l\""
+                                                            },
+                                                            "value": "l"
+                                                          }
+                                                        },
+                                                        "dim": {
+                                                          "nodeType": "Scalar_String",
+                                                          "attributes": {
+                                                            "startLine": 31,
+                                                            "startTokenPos": 662,
+                                                            "startFilePos": 1851,
+                                                            "endLine": 31,
+                                                            "endTokenPos": 662,
+                                                            "endFilePos": 1862,
+                                                            "kind": 2,
+                                                            "rawValue": "\"l_discount\""
+                                                          },
+                                                          "value": "l_discount"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 33,
+                                              "startTokenPos": 669,
+                                              "startFilePos": 1873,
+                                              "endLine": 33,
+                                              "endTokenPos": 672,
+                                              "endFilePos": 1887
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 33,
+                                                "startTokenPos": 671,
+                                                "startFilePos": 1880,
+                                                "endLine": 33,
+                                                "endTokenPos": 671,
+                                                "endFilePos": 1886
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 34,
+                              "startTokenPos": 681,
+                              "startFilePos": 1896,
+                              "endLine": 40,
+                              "endTokenPos": 870,
+                              "endFilePos": 2365
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 34,
+                                "startTokenPos": 681,
+                                "startFilePos": 1896,
+                                "endLine": 40,
+                                "endTokenPos": 870,
+                                "endFilePos": 2365,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 34,
+                                    "startTokenPos": 682,
+                                    "startFilePos": 1897,
+                                    "endLine": 34,
+                                    "endTokenPos": 692,
+                                    "endFilePos": 1933
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 34,
+                                      "startTokenPos": 682,
+                                      "startFilePos": 1897,
+                                      "endLine": 34,
+                                      "endTokenPos": 682,
+                                      "endFilePos": 1907,
+                                      "kind": 2,
+                                      "rawValue": "\"c_custkey\""
+                                    },
+                                    "value": "c_custkey"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 34,
+                                      "startTokenPos": 686,
+                                      "startFilePos": 1912,
+                                      "endLine": 34,
+                                      "endTokenPos": 692,
+                                      "endFilePos": 1933
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 34,
+                                        "startTokenPos": 686,
+                                        "startFilePos": 1912,
+                                        "endLine": 34,
+                                        "endTokenPos": 689,
+                                        "endFilePos": 1920
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 34,
+                                          "startTokenPos": 686,
+                                          "startFilePos": 1912,
+                                          "endLine": 34,
+                                          "endTokenPos": 686,
+                                          "endFilePos": 1913
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 34,
+                                          "startTokenPos": 688,
+                                          "startFilePos": 1915,
+                                          "endLine": 34,
+                                          "endTokenPos": 688,
+                                          "endFilePos": 1919,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 34,
+                                        "startTokenPos": 691,
+                                        "startFilePos": 1922,
+                                        "endLine": 34,
+                                        "endTokenPos": 691,
+                                        "endFilePos": 1932,
+                                        "kind": 2,
+                                        "rawValue": "\"c_custkey\""
+                                      },
+                                      "value": "c_custkey"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 34,
+                                    "startTokenPos": 695,
+                                    "startFilePos": 1936,
+                                    "endLine": 34,
+                                    "endTokenPos": 705,
+                                    "endFilePos": 1966
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 34,
+                                      "startTokenPos": 695,
+                                      "startFilePos": 1936,
+                                      "endLine": 34,
+                                      "endTokenPos": 695,
+                                      "endFilePos": 1943,
+                                      "kind": 2,
+                                      "rawValue": "\"c_name\""
+                                    },
+                                    "value": "c_name"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 34,
+                                      "startTokenPos": 699,
+                                      "startFilePos": 1948,
+                                      "endLine": 34,
+                                      "endTokenPos": 705,
+                                      "endFilePos": 1966
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 34,
+                                        "startTokenPos": 699,
+                                        "startFilePos": 1948,
+                                        "endLine": 34,
+                                        "endTokenPos": 702,
+                                        "endFilePos": 1956
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 34,
+                                          "startTokenPos": 699,
+                                          "startFilePos": 1948,
+                                          "endLine": 34,
+                                          "endTokenPos": 699,
+                                          "endFilePos": 1949
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 34,
+                                          "startTokenPos": 701,
+                                          "startFilePos": 1951,
+                                          "endLine": 34,
+                                          "endTokenPos": 701,
+                                          "endFilePos": 1955,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 34,
+                                        "startTokenPos": 704,
+                                        "startFilePos": 1958,
+                                        "endLine": 34,
+                                        "endTokenPos": 704,
+                                        "endFilePos": 1965,
+                                        "kind": 2,
+                                        "rawValue": "\"c_name\""
+                                      },
+                                      "value": "c_name"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 34,
+                                    "startTokenPos": 708,
+                                    "startFilePos": 1969,
+                                    "endLine": 40,
+                                    "endTokenPos": 804,
+                                    "endFilePos": 2179
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 34,
+                                      "startTokenPos": 708,
+                                      "startFilePos": 1969,
+                                      "endLine": 34,
+                                      "endTokenPos": 708,
+                                      "endFilePos": 1977,
+                                      "kind": 2,
+                                      "rawValue": "\"revenue\""
+                                    },
+                                    "value": "revenue"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_FuncCall",
+                                    "attributes": {
+                                      "startLine": 34,
+                                      "startTokenPos": 712,
+                                      "startFilePos": 1982,
+                                      "endLine": 40,
+                                      "endTokenPos": 804,
+                                      "endFilePos": 2179
+                                    },
+                                    "name": {
+                                      "nodeType": "Name",
+                                      "attributes": {
+                                        "startLine": 34,
+                                        "startTokenPos": 712,
+                                        "startFilePos": 1982,
+                                        "endLine": 34,
+                                        "endTokenPos": 712,
+                                        "endFilePos": 1990
+                                      },
+                                      "name": "array_sum"
+                                    },
+                                    "args": [
+                                      {
+                                        "nodeType": "Arg",
+                                        "attributes": {
+                                          "startLine": 34,
+                                          "startTokenPos": 714,
+                                          "startFilePos": 1992,
+                                          "endLine": 40,
+                                          "endTokenPos": 803,
+                                          "endFilePos": 2178
+                                        },
+                                        "name": null,
+                                        "value": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 34,
+                                            "startTokenPos": 714,
+                                            "startFilePos": 1992,
+                                            "endLine": 40,
+                                            "endTokenPos": 803,
+                                            "endFilePos": 2178
+                                          },
+                                          "name": {
+                                            "nodeType": "Expr_Closure",
+                                            "attributes": {
+                                              "startLine": 34,
+                                              "startTokenPos": 715,
+                                              "startFilePos": 1993,
+                                              "endLine": 40,
+                                              "endTokenPos": 800,
+                                              "endFilePos": 2175
+                                            },
+                                            "static": false,
+                                            "byRef": false,
+                                            "params": [],
+                                            "uses": [
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 34,
+                                                  "startTokenPos": 722,
+                                                  "startFilePos": 2009,
+                                                  "endLine": 34,
+                                                  "endTokenPos": 722,
+                                                  "endFilePos": 2010
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 34,
+                                                    "startTokenPos": 722,
+                                                    "startFilePos": 2009,
+                                                    "endLine": 34,
+                                                    "endTokenPos": 722,
+                                                    "endFilePos": 2010
+                                                  },
+                                                  "name": "c"
+                                                },
+                                                "byRef": false
+                                              },
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 34,
+                                                  "startTokenPos": 725,
+                                                  "startFilePos": 2013,
+                                                  "endLine": 34,
+                                                  "endTokenPos": 725,
+                                                  "endFilePos": 2014
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 34,
+                                                    "startTokenPos": 725,
+                                                    "startFilePos": 2013,
+                                                    "endLine": 34,
+                                                    "endTokenPos": 725,
+                                                    "endFilePos": 2014
+                                                  },
+                                                  "name": "o"
+                                                },
+                                                "byRef": false
+                                              },
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 34,
+                                                  "startTokenPos": 728,
+                                                  "startFilePos": 2017,
+                                                  "endLine": 34,
+                                                  "endTokenPos": 728,
+                                                  "endFilePos": 2018
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 34,
+                                                    "startTokenPos": 728,
+                                                    "startFilePos": 2017,
+                                                    "endLine": 34,
+                                                    "endTokenPos": 728,
+                                                    "endFilePos": 2018
+                                                  },
+                                                  "name": "l"
+                                                },
+                                                "byRef": false
+                                              },
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 34,
+                                                  "startTokenPos": 731,
+                                                  "startFilePos": 2021,
+                                                  "endLine": 34,
+                                                  "endTokenPos": 731,
+                                                  "endFilePos": 2022
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 34,
+                                                    "startTokenPos": 731,
+                                                    "startFilePos": 2021,
+                                                    "endLine": 34,
+                                                    "endTokenPos": 731,
+                                                    "endFilePos": 2022
+                                                  },
+                                                  "name": "n"
+                                                },
+                                                "byRef": false
+                                              },
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 34,
+                                                  "startTokenPos": 734,
+                                                  "startFilePos": 2025,
+                                                  "endLine": 34,
+                                                  "endTokenPos": 734,
+                                                  "endFilePos": 2026
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 34,
+                                                    "startTokenPos": 734,
+                                                    "startFilePos": 2025,
+                                                    "endLine": 34,
+                                                    "endTokenPos": 734,
+                                                    "endFilePos": 2026
+                                                  },
+                                                  "name": "g"
+                                                },
+                                                "byRef": false
+                                              }
+                                            ],
+                                            "returnType": null,
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 35,
+                                                  "startTokenPos": 739,
+                                                  "startFilePos": 2033,
+                                                  "endLine": 35,
+                                                  "endTokenPos": 745,
+                                                  "endFilePos": 2045
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 35,
+                                                    "startTokenPos": 739,
+                                                    "startFilePos": 2033,
+                                                    "endLine": 35,
+                                                    "endTokenPos": 744,
+                                                    "endFilePos": 2044
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 35,
+                                                      "startTokenPos": 739,
+                                                      "startFilePos": 2033,
+                                                      "endLine": 35,
+                                                      "endTokenPos": 739,
+                                                      "endFilePos": 2039
+                                                    },
+                                                    "name": "result"
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_Array",
+                                                    "attributes": {
+                                                      "startLine": 35,
+                                                      "startTokenPos": 743,
+                                                      "startFilePos": 2043,
+                                                      "endLine": 35,
+                                                      "endTokenPos": 744,
+                                                      "endFilePos": 2044,
+                                                      "kind": 2
+                                                    },
+                                                    "items": []
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "nodeType": "Stmt_Foreach",
+                                                "attributes": {
+                                                  "startLine": 36,
+                                                  "startTokenPos": 747,
+                                                  "startFilePos": 2049,
+                                                  "endLine": 38,
+                                                  "endTokenPos": 793,
+                                                  "endFilePos": 2155
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 36,
+                                                    "startTokenPos": 750,
+                                                    "startFilePos": 2058,
+                                                    "endLine": 36,
+                                                    "endTokenPos": 753,
+                                                    "endFilePos": 2068
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 36,
+                                                      "startTokenPos": 750,
+                                                      "startFilePos": 2058,
+                                                      "endLine": 36,
+                                                      "endTokenPos": 750,
+                                                      "endFilePos": 2059
+                                                    },
+                                                    "name": "g"
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 36,
+                                                      "startTokenPos": 752,
+                                                      "startFilePos": 2061,
+                                                      "endLine": 36,
+                                                      "endTokenPos": 752,
+                                                      "endFilePos": 2067,
+                                                      "kind": 2,
+                                                      "rawValue": "\"items\""
+                                                    },
+                                                    "value": "items"
+                                                  }
+                                                },
+                                                "keyVar": null,
+                                                "byRef": false,
+                                                "valueVar": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 36,
+                                                    "startTokenPos": 757,
+                                                    "startFilePos": 2073,
+                                                    "endLine": 36,
+                                                    "endTokenPos": 757,
+                                                    "endFilePos": 2074
+                                                  },
+                                                  "name": "x"
+                                                },
+                                                "stmts": [
+                                                  {
+                                                    "nodeType": "Stmt_Expression",
+                                                    "attributes": {
+                                                      "startLine": 37,
+                                                      "startTokenPos": 762,
+                                                      "startFilePos": 2083,
+                                                      "endLine": 37,
+                                                      "endTokenPos": 791,
+                                                      "endFilePos": 2151
+                                                    },
+                                                    "expr": {
+                                                      "nodeType": "Expr_Assign",
+                                                      "attributes": {
+                                                        "startLine": 37,
+                                                        "startTokenPos": 762,
+                                                        "startFilePos": 2083,
+                                                        "endLine": 37,
+                                                        "endTokenPos": 790,
+                                                        "endFilePos": 2150
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 37,
+                                                          "startTokenPos": 762,
+                                                          "startFilePos": 2083,
+                                                          "endLine": 37,
+                                                          "endTokenPos": 764,
+                                                          "endFilePos": 2091
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_Variable",
+                                                          "attributes": {
+                                                            "startLine": 37,
+                                                            "startTokenPos": 762,
+                                                            "startFilePos": 2083,
+                                                            "endLine": 37,
+                                                            "endTokenPos": 762,
+                                                            "endFilePos": 2089
+                                                          },
+                                                          "name": "result"
+                                                        },
+                                                        "dim": null
+                                                      },
+                                                      "expr": {
+                                                        "nodeType": "Expr_BinaryOp_Mul",
+                                                        "attributes": {
+                                                          "startLine": 37,
+                                                          "startTokenPos": 768,
+                                                          "startFilePos": 2095,
+                                                          "endLine": 37,
+                                                          "endTokenPos": 790,
+                                                          "endFilePos": 2150
+                                                        },
+                                                        "left": {
+                                                          "nodeType": "Expr_ArrayDimFetch",
+                                                          "attributes": {
+                                                            "startLine": 37,
+                                                            "startTokenPos": 768,
+                                                            "startFilePos": 2095,
+                                                            "endLine": 37,
+                                                            "endTokenPos": 774,
+                                                            "endFilePos": 2120
+                                                          },
+                                                          "var": {
+                                                            "nodeType": "Expr_ArrayDimFetch",
+                                                            "attributes": {
+                                                              "startLine": 37,
+                                                              "startTokenPos": 768,
+                                                              "startFilePos": 2095,
+                                                              "endLine": 37,
+                                                              "endTokenPos": 771,
+                                                              "endFilePos": 2101
+                                                            },
+                                                            "var": {
+                                                              "nodeType": "Expr_Variable",
+                                                              "attributes": {
+                                                                "startLine": 37,
+                                                                "startTokenPos": 768,
+                                                                "startFilePos": 2095,
+                                                                "endLine": 37,
+                                                                "endTokenPos": 768,
+                                                                "endFilePos": 2096
+                                                              },
+                                                              "name": "x"
+                                                            },
+                                                            "dim": {
+                                                              "nodeType": "Scalar_String",
+                                                              "attributes": {
+                                                                "startLine": 37,
+                                                                "startTokenPos": 770,
+                                                                "startFilePos": 2098,
+                                                                "endLine": 37,
+                                                                "endTokenPos": 770,
+                                                                "endFilePos": 2100,
+                                                                "kind": 2,
+                                                                "rawValue": "\"l\""
+                                                              },
+                                                              "value": "l"
+                                                            }
+                                                          },
+                                                          "dim": {
+                                                            "nodeType": "Scalar_String",
+                                                            "attributes": {
+                                                              "startLine": 37,
+                                                              "startTokenPos": 773,
+                                                              "startFilePos": 2103,
+                                                              "endLine": 37,
+                                                              "endTokenPos": 773,
+                                                              "endFilePos": 2119,
+                                                              "kind": 2,
+                                                              "rawValue": "\"l_extendedprice\""
+                                                            },
+                                                            "value": "l_extendedprice"
+                                                          }
+                                                        },
+                                                        "right": {
+                                                          "nodeType": "Expr_BinaryOp_Minus",
+                                                          "attributes": {
+                                                            "startLine": 37,
+                                                            "startTokenPos": 779,
+                                                            "startFilePos": 2125,
+                                                            "endLine": 37,
+                                                            "endTokenPos": 789,
+                                                            "endFilePos": 2149
+                                                          },
+                                                          "left": {
+                                                            "nodeType": "Scalar_Int",
+                                                            "attributes": {
+                                                              "startLine": 37,
+                                                              "startTokenPos": 779,
+                                                              "startFilePos": 2125,
+                                                              "endLine": 37,
+                                                              "endTokenPos": 779,
+                                                              "endFilePos": 2125,
+                                                              "rawValue": "1",
+                                                              "kind": 10
+                                                            },
+                                                            "value": 1
+                                                          },
+                                                          "right": {
+                                                            "nodeType": "Expr_ArrayDimFetch",
+                                                            "attributes": {
+                                                              "startLine": 37,
+                                                              "startTokenPos": 783,
+                                                              "startFilePos": 2129,
+                                                              "endLine": 37,
+                                                              "endTokenPos": 789,
+                                                              "endFilePos": 2149
+                                                            },
+                                                            "var": {
+                                                              "nodeType": "Expr_ArrayDimFetch",
+                                                              "attributes": {
+                                                                "startLine": 37,
+                                                                "startTokenPos": 783,
+                                                                "startFilePos": 2129,
+                                                                "endLine": 37,
+                                                                "endTokenPos": 786,
+                                                                "endFilePos": 2135
+                                                              },
+                                                              "var": {
+                                                                "nodeType": "Expr_Variable",
+                                                                "attributes": {
+                                                                  "startLine": 37,
+                                                                  "startTokenPos": 783,
+                                                                  "startFilePos": 2129,
+                                                                  "endLine": 37,
+                                                                  "endTokenPos": 783,
+                                                                  "endFilePos": 2130
+                                                                },
+                                                                "name": "x"
+                                                              },
+                                                              "dim": {
+                                                                "nodeType": "Scalar_String",
+                                                                "attributes": {
+                                                                  "startLine": 37,
+                                                                  "startTokenPos": 785,
+                                                                  "startFilePos": 2132,
+                                                                  "endLine": 37,
+                                                                  "endTokenPos": 785,
+                                                                  "endFilePos": 2134,
+                                                                  "kind": 2,
+                                                                  "rawValue": "\"l\""
+                                                                },
+                                                                "value": "l"
+                                                              }
+                                                            },
+                                                            "dim": {
+                                                              "nodeType": "Scalar_String",
+                                                              "attributes": {
+                                                                "startLine": 37,
+                                                                "startTokenPos": 788,
+                                                                "startFilePos": 2137,
+                                                                "endLine": 37,
+                                                                "endTokenPos": 788,
+                                                                "endFilePos": 2148,
+                                                                "kind": 2,
+                                                                "rawValue": "\"l_discount\""
+                                                              },
+                                                              "value": "l_discount"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "nodeType": "Stmt_Return",
+                                                "attributes": {
+                                                  "startLine": 39,
+                                                  "startTokenPos": 795,
+                                                  "startFilePos": 2159,
+                                                  "endLine": 39,
+                                                  "endTokenPos": 798,
+                                                  "endFilePos": 2173
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 39,
+                                                    "startTokenPos": 797,
+                                                    "startFilePos": 2166,
+                                                    "endLine": 39,
+                                                    "endTokenPos": 797,
+                                                    "endFilePos": 2172
+                                                  },
+                                                  "name": "result"
+                                                }
+                                              }
+                                            ],
+                                            "attrGroups": []
+                                          },
+                                          "args": []
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      }
+                                    ]
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 40,
+                                    "startTokenPos": 807,
+                                    "startFilePos": 2182,
+                                    "endLine": 40,
+                                    "endTokenPos": 817,
+                                    "endFilePos": 2218
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 807,
+                                      "startFilePos": 2182,
+                                      "endLine": 40,
+                                      "endTokenPos": 807,
+                                      "endFilePos": 2192,
+                                      "kind": 2,
+                                      "rawValue": "\"c_acctbal\""
+                                    },
+                                    "value": "c_acctbal"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 811,
+                                      "startFilePos": 2197,
+                                      "endLine": 40,
+                                      "endTokenPos": 817,
+                                      "endFilePos": 2218
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 811,
+                                        "startFilePos": 2197,
+                                        "endLine": 40,
+                                        "endTokenPos": 814,
+                                        "endFilePos": 2205
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 811,
+                                          "startFilePos": 2197,
+                                          "endLine": 40,
+                                          "endTokenPos": 811,
+                                          "endFilePos": 2198
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 813,
+                                          "startFilePos": 2200,
+                                          "endLine": 40,
+                                          "endTokenPos": 813,
+                                          "endFilePos": 2204,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 816,
+                                        "startFilePos": 2207,
+                                        "endLine": 40,
+                                        "endTokenPos": 816,
+                                        "endFilePos": 2217,
+                                        "kind": 2,
+                                        "rawValue": "\"c_acctbal\""
+                                      },
+                                      "value": "c_acctbal"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 40,
+                                    "startTokenPos": 820,
+                                    "startFilePos": 2221,
+                                    "endLine": 40,
+                                    "endTokenPos": 830,
+                                    "endFilePos": 2251
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 820,
+                                      "startFilePos": 2221,
+                                      "endLine": 40,
+                                      "endTokenPos": 820,
+                                      "endFilePos": 2228,
+                                      "kind": 2,
+                                      "rawValue": "\"n_name\""
+                                    },
+                                    "value": "n_name"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 824,
+                                      "startFilePos": 2233,
+                                      "endLine": 40,
+                                      "endTokenPos": 830,
+                                      "endFilePos": 2251
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 824,
+                                        "startFilePos": 2233,
+                                        "endLine": 40,
+                                        "endTokenPos": 827,
+                                        "endFilePos": 2241
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 824,
+                                          "startFilePos": 2233,
+                                          "endLine": 40,
+                                          "endTokenPos": 824,
+                                          "endFilePos": 2234
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 826,
+                                          "startFilePos": 2236,
+                                          "endLine": 40,
+                                          "endTokenPos": 826,
+                                          "endFilePos": 2240,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 829,
+                                        "startFilePos": 2243,
+                                        "endLine": 40,
+                                        "endTokenPos": 829,
+                                        "endFilePos": 2250,
+                                        "kind": 2,
+                                        "rawValue": "\"n_name\""
+                                      },
+                                      "value": "n_name"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 40,
+                                    "startTokenPos": 833,
+                                    "startFilePos": 2254,
+                                    "endLine": 40,
+                                    "endTokenPos": 843,
+                                    "endFilePos": 2290
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 833,
+                                      "startFilePos": 2254,
+                                      "endLine": 40,
+                                      "endTokenPos": 833,
+                                      "endFilePos": 2264,
+                                      "kind": 2,
+                                      "rawValue": "\"c_address\""
+                                    },
+                                    "value": "c_address"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 837,
+                                      "startFilePos": 2269,
+                                      "endLine": 40,
+                                      "endTokenPos": 843,
+                                      "endFilePos": 2290
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 837,
+                                        "startFilePos": 2269,
+                                        "endLine": 40,
+                                        "endTokenPos": 840,
+                                        "endFilePos": 2277
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 837,
+                                          "startFilePos": 2269,
+                                          "endLine": 40,
+                                          "endTokenPos": 837,
+                                          "endFilePos": 2270
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 839,
+                                          "startFilePos": 2272,
+                                          "endLine": 40,
+                                          "endTokenPos": 839,
+                                          "endFilePos": 2276,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 842,
+                                        "startFilePos": 2279,
+                                        "endLine": 40,
+                                        "endTokenPos": 842,
+                                        "endFilePos": 2289,
+                                        "kind": 2,
+                                        "rawValue": "\"c_address\""
+                                      },
+                                      "value": "c_address"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 40,
+                                    "startTokenPos": 846,
+                                    "startFilePos": 2293,
+                                    "endLine": 40,
+                                    "endTokenPos": 856,
+                                    "endFilePos": 2325
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 846,
+                                      "startFilePos": 2293,
+                                      "endLine": 40,
+                                      "endTokenPos": 846,
+                                      "endFilePos": 2301,
+                                      "kind": 2,
+                                      "rawValue": "\"c_phone\""
+                                    },
+                                    "value": "c_phone"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 850,
+                                      "startFilePos": 2306,
+                                      "endLine": 40,
+                                      "endTokenPos": 856,
+                                      "endFilePos": 2325
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 850,
+                                        "startFilePos": 2306,
+                                        "endLine": 40,
+                                        "endTokenPos": 853,
+                                        "endFilePos": 2314
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 850,
+                                          "startFilePos": 2306,
+                                          "endLine": 40,
+                                          "endTokenPos": 850,
+                                          "endFilePos": 2307
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 852,
+                                          "startFilePos": 2309,
+                                          "endLine": 40,
+                                          "endTokenPos": 852,
+                                          "endFilePos": 2313,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 855,
+                                        "startFilePos": 2316,
+                                        "endLine": 40,
+                                        "endTokenPos": 855,
+                                        "endFilePos": 2324,
+                                        "kind": 2,
+                                        "rawValue": "\"c_phone\""
+                                      },
+                                      "value": "c_phone"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 40,
+                                    "startTokenPos": 859,
+                                    "startFilePos": 2328,
+                                    "endLine": 40,
+                                    "endTokenPos": 869,
+                                    "endFilePos": 2364
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 859,
+                                      "startFilePos": 2328,
+                                      "endLine": 40,
+                                      "endTokenPos": 859,
+                                      "endFilePos": 2338,
+                                      "kind": 2,
+                                      "rawValue": "\"c_comment\""
+                                    },
+                                    "value": "c_comment"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 40,
+                                      "startTokenPos": 863,
+                                      "startFilePos": 2343,
+                                      "endLine": 40,
+                                      "endTokenPos": 869,
+                                      "endFilePos": 2364
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 863,
+                                        "startFilePos": 2343,
+                                        "endLine": 40,
+                                        "endTokenPos": 866,
+                                        "endFilePos": 2351
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 863,
+                                          "startFilePos": 2343,
+                                          "endLine": 40,
+                                          "endTokenPos": 863,
+                                          "endFilePos": 2344
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 40,
+                                          "startTokenPos": 865,
+                                          "startFilePos": 2346,
+                                          "endLine": 40,
+                                          "endTokenPos": 865,
+                                          "endFilePos": 2350,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 40,
+                                        "startTokenPos": 868,
+                                        "startFilePos": 2353,
+                                        "endLine": 40,
+                                        "endTokenPos": 868,
+                                        "endFilePos": 2363,
+                                        "kind": 2,
+                                        "rawValue": "\"c_comment\""
+                                      },
+                                      "value": "c_comment"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 42,
+                  "startTokenPos": 876,
+                  "startFilePos": 2375,
+                  "endLine": 42,
+                  "endTokenPos": 908,
+                  "endFilePos": 2435
+                },
+                "expr": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 42,
+                    "startTokenPos": 876,
+                    "startFilePos": 2375,
+                    "endLine": 42,
+                    "endTokenPos": 907,
+                    "endFilePos": 2434
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 42,
+                      "startTokenPos": 876,
+                      "startFilePos": 2375,
+                      "endLine": 42,
+                      "endTokenPos": 876,
+                      "endFilePos": 2379
+                    },
+                    "name": "usort"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 42,
+                        "startTokenPos": 878,
+                        "startFilePos": 2381,
+                        "endLine": 42,
+                        "endTokenPos": 878,
+                        "endFilePos": 2387
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 42,
+                          "startTokenPos": 878,
+                          "startFilePos": 2381,
+                          "endLine": 42,
+                          "endTokenPos": 878,
+                          "endFilePos": 2387
+                        },
+                        "name": "result"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 42,
+                        "startTokenPos": 881,
+                        "startFilePos": 2390,
+                        "endLine": 42,
+                        "endTokenPos": 906,
+                        "endFilePos": 2433
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Closure",
+                        "attributes": {
+                          "startLine": 42,
+                          "startTokenPos": 881,
+                          "startFilePos": 2390,
+                          "endLine": 42,
+                          "endTokenPos": 906,
+                          "endFilePos": 2433
+                        },
+                        "static": false,
+                        "byRef": false,
+                        "params": [
+                          {
+                            "nodeType": "Param",
+                            "attributes": {
+                              "startLine": 42,
+                              "startTokenPos": 883,
+                              "startFilePos": 2399,
+                              "endLine": 42,
+                              "endTokenPos": 883,
+                              "endFilePos": 2400
+                            },
+                            "type": null,
+                            "byRef": false,
+                            "variadic": false,
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 42,
+                                "startTokenPos": 883,
+                                "startFilePos": 2399,
+                                "endLine": 42,
+                                "endTokenPos": 883,
+                                "endFilePos": 2400
+                              },
+                              "name": "a"
+                            },
+                            "default": null,
+                            "flags": 0,
+                            "attrGroups": [],
+                            "hooks": []
+                          },
+                          {
+                            "nodeType": "Param",
+                            "attributes": {
+                              "startLine": 42,
+                              "startTokenPos": 886,
+                              "startFilePos": 2403,
+                              "endLine": 42,
+                              "endTokenPos": 886,
+                              "endFilePos": 2404
+                            },
+                            "type": null,
+                            "byRef": false,
+                            "variadic": false,
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 42,
+                                "startTokenPos": 886,
+                                "startFilePos": 2403,
+                                "endLine": 42,
+                                "endTokenPos": 886,
+                                "endFilePos": 2404
+                              },
+                              "name": "b"
+                            },
+                            "default": null,
+                            "flags": 0,
+                            "attrGroups": [],
+                            "hooks": []
+                          }
+                        ],
+                        "uses": [],
+                        "returnType": null,
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Return",
+                            "attributes": {
+                              "startLine": 42,
+                              "startTokenPos": 891,
+                              "startFilePos": 2409,
+                              "endLine": 42,
+                              "endTokenPos": 904,
+                              "endFilePos": 2431
+                            },
+                            "expr": {
+                              "nodeType": "Expr_BinaryOp_Spaceship",
+                              "attributes": {
+                                "startLine": 42,
+                                "startTokenPos": 893,
+                                "startFilePos": 2416,
+                                "endLine": 42,
+                                "endTokenPos": 903,
+                                "endFilePos": 2430
+                              },
+                              "left": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 42,
+                                  "startTokenPos": 893,
+                                  "startFilePos": 2416,
+                                  "endLine": 42,
+                                  "endTokenPos": 896,
+                                  "endFilePos": 2420
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 42,
+                                    "startTokenPos": 893,
+                                    "startFilePos": 2416,
+                                    "endLine": 42,
+                                    "endTokenPos": 893,
+                                    "endFilePos": 2417
+                                  },
+                                  "name": "a"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 42,
+                                    "startTokenPos": 895,
+                                    "startFilePos": 2419,
+                                    "endLine": 42,
+                                    "endTokenPos": 895,
+                                    "endFilePos": 2419,
+                                    "rawValue": "0",
+                                    "kind": 10
+                                  },
+                                  "value": 0
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 42,
+                                  "startTokenPos": 900,
+                                  "startFilePos": 2426,
+                                  "endLine": 42,
+                                  "endTokenPos": 903,
+                                  "endFilePos": 2430
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 42,
+                                    "startTokenPos": 900,
+                                    "startFilePos": 2426,
+                                    "endLine": 42,
+                                    "endTokenPos": 900,
+                                    "endFilePos": 2427
+                                  },
+                                  "name": "b"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 42,
+                                    "startTokenPos": 902,
+                                    "startFilePos": 2429,
+                                    "endLine": 42,
+                                    "endTokenPos": 902,
+                                    "endFilePos": 2429,
+                                    "rawValue": "0",
+                                    "kind": 10
+                                  },
+                                  "value": 0
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "attrGroups": []
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 43,
+                  "startTokenPos": 910,
+                  "startFilePos": 2439,
+                  "endLine": 43,
+                  "endTokenPos": 931,
+                  "endFilePos": 2484
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 43,
+                    "startTokenPos": 910,
+                    "startFilePos": 2439,
+                    "endLine": 43,
+                    "endTokenPos": 930,
+                    "endFilePos": 2483
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 43,
+                      "startTokenPos": 910,
+                      "startFilePos": 2439,
+                      "endLine": 43,
+                      "endTokenPos": 910,
+                      "endFilePos": 2445
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 43,
+                      "startTokenPos": 914,
+                      "startFilePos": 2449,
+                      "endLine": 43,
+                      "endTokenPos": 930,
+                      "endFilePos": 2483
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 43,
+                        "startTokenPos": 914,
+                        "startFilePos": 2449,
+                        "endLine": 43,
+                        "endTokenPos": 914,
+                        "endFilePos": 2457
+                      },
+                      "name": "array_map"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 43,
+                          "startTokenPos": 916,
+                          "startFilePos": 2459,
+                          "endLine": 43,
+                          "endTokenPos": 926,
+                          "endFilePos": 2473
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrowFunction",
+                          "attributes": {
+                            "startLine": 43,
+                            "startTokenPos": 916,
+                            "startFilePos": 2459,
+                            "endLine": 43,
+                            "endTokenPos": 926,
+                            "endFilePos": 2473
+                          },
+                          "static": false,
+                          "byRef": false,
+                          "params": [
+                            {
+                              "nodeType": "Param",
+                              "attributes": {
+                                "startLine": 43,
+                                "startTokenPos": 918,
+                                "startFilePos": 2462,
+                                "endLine": 43,
+                                "endTokenPos": 918,
+                                "endFilePos": 2463
+                              },
+                              "type": null,
+                              "byRef": false,
+                              "variadic": false,
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 43,
+                                  "startTokenPos": 918,
+                                  "startFilePos": 2462,
+                                  "endLine": 43,
+                                  "endTokenPos": 918,
+                                  "endFilePos": 2463
+                                },
+                                "name": "r"
+                              },
+                              "default": null,
+                              "flags": 0,
+                              "attrGroups": [],
+                              "hooks": []
+                            }
+                          ],
+                          "returnType": null,
+                          "expr": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 43,
+                              "startTokenPos": 923,
+                              "startFilePos": 2469,
+                              "endLine": 43,
+                              "endTokenPos": 926,
+                              "endFilePos": 2473
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 43,
+                                "startTokenPos": 923,
+                                "startFilePos": 2469,
+                                "endLine": 43,
+                                "endTokenPos": 923,
+                                "endFilePos": 2470
+                              },
+                              "name": "r"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 43,
+                                "startTokenPos": 925,
+                                "startFilePos": 2472,
+                                "endLine": 43,
+                                "endTokenPos": 925,
+                                "endFilePos": 2472,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            }
+                          },
+                          "attrGroups": []
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 43,
+                          "startTokenPos": 929,
+                          "startFilePos": 2476,
+                          "endLine": 43,
+                          "endTokenPos": 929,
+                          "endFilePos": 2482
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 43,
+                            "startTokenPos": 929,
+                            "startFilePos": 2476,
+                            "endLine": 43,
+                            "endTokenPos": 929,
+                            "endFilePos": 2482
+                          },
+                          "name": "result"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 44,
+                  "startTokenPos": 933,
+                  "startFilePos": 2488,
+                  "endLine": 44,
+                  "endTokenPos": 936,
+                  "endFilePos": 2502
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 44,
+                    "startTokenPos": 935,
+                    "startFilePos": 2495,
+                    "endLine": 44,
+                    "endTokenPos": 935,
+                    "endFilePos": 2501
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 46,
+        "startTokenPos": 944,
+        "startFilePos": 2510,
+        "endLine": 46,
+        "endTokenPos": 1001,
+        "endFilePos": 2682
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 46,
+            "startTokenPos": 946,
+            "startFilePos": 2515,
+            "endLine": 46,
+            "endTokenPos": 997,
+            "endFilePos": 2672
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 46,
+              "startTokenPos": 946,
+              "startFilePos": 2515,
+              "endLine": 46,
+              "endTokenPos": 946,
+              "endFilePos": 2525
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 46,
+                "startTokenPos": 948,
+                "startFilePos": 2527,
+                "endLine": 46,
+                "endTokenPos": 948,
+                "endFilePos": 2533
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 46,
+                  "startTokenPos": 948,
+                  "startFilePos": 2527,
+                  "endLine": 46,
+                  "endTokenPos": 948,
+                  "endFilePos": 2533,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 46,
+                "startTokenPos": 951,
+                "startFilePos": 2536,
+                "endLine": 46,
+                "endTokenPos": 951,
+                "endFilePos": 2542
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 46,
+                  "startTokenPos": 951,
+                  "startFilePos": 2536,
+                  "endLine": 46,
+                  "endTokenPos": 951,
+                  "endFilePos": 2542,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 46,
+                "startTokenPos": 954,
+                "startFilePos": 2545,
+                "endLine": 46,
+                "endTokenPos": 996,
+                "endFilePos": 2671
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 46,
+                  "startTokenPos": 954,
+                  "startFilePos": 2545,
+                  "endLine": 46,
+                  "endTokenPos": 996,
+                  "endFilePos": 2671
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 46,
+                    "startTokenPos": 954,
+                    "startFilePos": 2545,
+                    "endLine": 46,
+                    "endTokenPos": 954,
+                    "endFilePos": 2555
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 46,
+                      "startTokenPos": 956,
+                      "startFilePos": 2557,
+                      "endLine": 46,
+                      "endTokenPos": 956,
+                      "endFilePos": 2562
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 46,
+                        "startTokenPos": 956,
+                        "startFilePos": 2557,
+                        "endLine": 46,
+                        "endTokenPos": 956,
+                        "endFilePos": 2562,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 46,
+                      "startTokenPos": 959,
+                      "startFilePos": 2565,
+                      "endLine": 46,
+                      "endTokenPos": 959,
+                      "endFilePos": 2570
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 46,
+                        "startTokenPos": 959,
+                        "startFilePos": 2565,
+                        "endLine": 46,
+                        "endTokenPos": 959,
+                        "endFilePos": 2570,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 46,
+                      "startTokenPos": 962,
+                      "startFilePos": 2573,
+                      "endLine": 46,
+                      "endTokenPos": 995,
+                      "endFilePos": 2670
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 46,
+                        "startTokenPos": 962,
+                        "startFilePos": 2573,
+                        "endLine": 46,
+                        "endTokenPos": 995,
+                        "endFilePos": 2670
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 46,
+                          "startTokenPos": 962,
+                          "startFilePos": 2573,
+                          "endLine": 46,
+                          "endTokenPos": 962,
+                          "endFilePos": 2583
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 46,
+                            "startTokenPos": 964,
+                            "startFilePos": 2585,
+                            "endLine": 46,
+                            "endTokenPos": 964,
+                            "endFilePos": 2588
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 46,
+                              "startTokenPos": 964,
+                              "startFilePos": 2585,
+                              "endLine": 46,
+                              "endTokenPos": 964,
+                              "endFilePos": 2588,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 46,
+                            "startTokenPos": 967,
+                            "startFilePos": 2591,
+                            "endLine": 46,
+                            "endTokenPos": 967,
+                            "endFilePos": 2593
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 46,
+                              "startTokenPos": 967,
+                              "startFilePos": 2591,
+                              "endLine": 46,
+                              "endTokenPos": 967,
+                              "endFilePos": 2593,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 46,
+                            "startTokenPos": 970,
+                            "startFilePos": 2596,
+                            "endLine": 46,
+                            "endTokenPos": 994,
+                            "endFilePos": 2669
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 46,
+                              "startTokenPos": 970,
+                              "startFilePos": 2596,
+                              "endLine": 46,
+                              "endTokenPos": 994,
+                              "endFilePos": 2669
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 46,
+                                "startTokenPos": 970,
+                                "startFilePos": 2596,
+                                "endLine": 46,
+                                "endTokenPos": 970,
+                                "endFilePos": 2606
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 46,
+                                  "startTokenPos": 972,
+                                  "startFilePos": 2608,
+                                  "endLine": 46,
+                                  "endTokenPos": 972,
+                                  "endFilePos": 2610
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 46,
+                                    "startTokenPos": 972,
+                                    "startFilePos": 2608,
+                                    "endLine": 46,
+                                    "endTokenPos": 972,
+                                    "endFilePos": 2610,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 46,
+                                  "startTokenPos": 975,
+                                  "startFilePos": 2613,
+                                  "endLine": 46,
+                                  "endTokenPos": 975,
+                                  "endFilePos": 2616
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 46,
+                                    "startTokenPos": 975,
+                                    "startFilePos": 2613,
+                                    "endLine": 46,
+                                    "endTokenPos": 975,
+                                    "endFilePos": 2616,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 46,
+                                  "startTokenPos": 978,
+                                  "startFilePos": 2619,
+                                  "endLine": 46,
+                                  "endTokenPos": 993,
+                                  "endFilePos": 2668
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 46,
+                                    "startTokenPos": 978,
+                                    "startFilePos": 2619,
+                                    "endLine": 46,
+                                    "endTokenPos": 993,
+                                    "endFilePos": 2668
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 46,
+                                      "startTokenPos": 978,
+                                      "startFilePos": 2619,
+                                      "endLine": 46,
+                                      "endTokenPos": 978,
+                                      "endFilePos": 2629
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 46,
+                                        "startTokenPos": 980,
+                                        "startFilePos": 2631,
+                                        "endLine": 46,
+                                        "endTokenPos": 980,
+                                        "endFilePos": 2633
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 46,
+                                          "startTokenPos": 980,
+                                          "startFilePos": 2631,
+                                          "endLine": 46,
+                                          "endTokenPos": 980,
+                                          "endFilePos": 2633,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 46,
+                                        "startTokenPos": 983,
+                                        "startFilePos": 2636,
+                                        "endLine": 46,
+                                        "endTokenPos": 983,
+                                        "endFilePos": 2639
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 46,
+                                          "startTokenPos": 983,
+                                          "startFilePos": 2636,
+                                          "endLine": 46,
+                                          "endTokenPos": 983,
+                                          "endFilePos": 2639,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 46,
+                                        "startTokenPos": 986,
+                                        "startFilePos": 2642,
+                                        "endLine": 46,
+                                        "endTokenPos": 992,
+                                        "endFilePos": 2667
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 46,
+                                          "startTokenPos": 986,
+                                          "startFilePos": 2642,
+                                          "endLine": 46,
+                                          "endTokenPos": 992,
+                                          "endFilePos": 2667
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 46,
+                                            "startTokenPos": 986,
+                                            "startFilePos": 2642,
+                                            "endLine": 46,
+                                            "endTokenPos": 986,
+                                            "endFilePos": 2652
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 46,
+                                              "startTokenPos": 988,
+                                              "startFilePos": 2654,
+                                              "endLine": 46,
+                                              "endTokenPos": 988,
+                                              "endFilePos": 2660
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 46,
+                                                "startTokenPos": 988,
+                                                "startFilePos": 2654,
+                                                "endLine": 46,
+                                                "endTokenPos": 988,
+                                                "endFilePos": 2660
+                                              },
+                                              "name": "result"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 46,
+                                              "startTokenPos": 991,
+                                              "startFilePos": 2663,
+                                              "endLine": 46,
+                                              "endTokenPos": 991,
+                                              "endFilePos": 2666
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 46,
+                                                "startTokenPos": 991,
+                                                "startFilePos": 2663,
+                                                "endLine": 46,
+                                                "endTokenPos": 991,
+                                                "endFilePos": 2666,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 46,
+            "startTokenPos": 1000,
+            "startFilePos": 2675,
+            "endLine": 46,
+            "endTokenPos": 1000,
+            "endFilePos": 2681
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 46,
+              "startTokenPos": 1000,
+              "startFilePos": 2675,
+              "endLine": 46,
+              "endTokenPos": 1000,
+              "endFilePos": 2681
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_multi_sort.php.json
+++ b/tests/json-ast/x/php/group_by_multi_sort.php.json
@@ -1,0 +1,3576 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 97,
+        "endFilePos": 159
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 96,
+          "endFilePos": 158
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 11
+          },
+          "name": "items"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 15,
+            "endLine": 2,
+            "endTokenPos": 96,
+            "endFilePos": 158,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 26,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 16,
+                  "endLine": 2,
+                  "endTokenPos": 26,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 17,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 26
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 17,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 19,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 24,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 26,
+                        "kind": 2,
+                        "rawValue": "\"x\""
+                      },
+                      "value": "x"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 29,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 36
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 31,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 36,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 36,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 39,
+                      "endLine": 2,
+                      "endTokenPos": 25,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 21,
+                        "startFilePos": 39,
+                        "endLine": 2,
+                        "endTokenPos": 21,
+                        "endFilePos": 43,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 48,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 48,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 29,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 49,
+                "endFilePos": 85
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 49,
+                  "endFilePos": 85,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 62
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 55,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 60,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 62,
+                        "kind": 2,
+                        "rawValue": "\"x\""
+                      },
+                      "value": "x"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 37,
+                      "startFilePos": 65,
+                      "endLine": 2,
+                      "endTokenPos": 41,
+                      "endFilePos": 72
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 37,
+                        "startFilePos": 65,
+                        "endLine": 2,
+                        "endTokenPos": 37,
+                        "endFilePos": 67,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 41,
+                        "startFilePos": 72,
+                        "endLine": 2,
+                        "endTokenPos": 41,
+                        "endFilePos": 72,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 44,
+                      "startFilePos": 75,
+                      "endLine": 2,
+                      "endTokenPos": 48,
+                      "endFilePos": 84
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 44,
+                        "startFilePos": 75,
+                        "endLine": 2,
+                        "endTokenPos": 44,
+                        "endFilePos": 79,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 48,
+                        "startFilePos": 84,
+                        "endLine": 2,
+                        "endTokenPos": 48,
+                        "endFilePos": 84,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 52,
+                "startFilePos": 88,
+                "endLine": 2,
+                "endTokenPos": 72,
+                "endFilePos": 121
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 52,
+                  "startFilePos": 88,
+                  "endLine": 2,
+                  "endTokenPos": 72,
+                  "endFilePos": 121,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 53,
+                      "startFilePos": 89,
+                      "endLine": 2,
+                      "endTokenPos": 57,
+                      "endFilePos": 98
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 53,
+                        "startFilePos": 89,
+                        "endLine": 2,
+                        "endTokenPos": 53,
+                        "endFilePos": 91,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 57,
+                        "startFilePos": 96,
+                        "endLine": 2,
+                        "endTokenPos": 57,
+                        "endFilePos": 98,
+                        "kind": 2,
+                        "rawValue": "\"y\""
+                      },
+                      "value": "y"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 60,
+                      "startFilePos": 101,
+                      "endLine": 2,
+                      "endTokenPos": 64,
+                      "endFilePos": 108
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 60,
+                        "startFilePos": 101,
+                        "endLine": 2,
+                        "endTokenPos": 60,
+                        "endFilePos": 103,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 64,
+                        "startFilePos": 108,
+                        "endLine": 2,
+                        "endTokenPos": 64,
+                        "endFilePos": 108,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 67,
+                      "startFilePos": 111,
+                      "endLine": 2,
+                      "endTokenPos": 71,
+                      "endFilePos": 120
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 67,
+                        "startFilePos": 111,
+                        "endLine": 2,
+                        "endTokenPos": 67,
+                        "endFilePos": 115,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 71,
+                        "startFilePos": 120,
+                        "endLine": 2,
+                        "endTokenPos": 71,
+                        "endFilePos": 120,
+                        "rawValue": "4",
+                        "kind": 10
+                      },
+                      "value": 4
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 75,
+                "startFilePos": 124,
+                "endLine": 2,
+                "endTokenPos": 95,
+                "endFilePos": 157
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 75,
+                  "startFilePos": 124,
+                  "endLine": 2,
+                  "endTokenPos": 95,
+                  "endFilePos": 157,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 76,
+                      "startFilePos": 125,
+                      "endLine": 2,
+                      "endTokenPos": 80,
+                      "endFilePos": 134
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 76,
+                        "startFilePos": 125,
+                        "endLine": 2,
+                        "endTokenPos": 76,
+                        "endFilePos": 127,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 80,
+                        "startFilePos": 132,
+                        "endLine": 2,
+                        "endTokenPos": 80,
+                        "endFilePos": 134,
+                        "kind": 2,
+                        "rawValue": "\"y\""
+                      },
+                      "value": "y"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 83,
+                      "startFilePos": 137,
+                      "endLine": 2,
+                      "endTokenPos": 87,
+                      "endFilePos": 144
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 83,
+                        "startFilePos": 137,
+                        "endLine": 2,
+                        "endTokenPos": 83,
+                        "endFilePos": 139,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 87,
+                        "startFilePos": 144,
+                        "endLine": 2,
+                        "endTokenPos": 87,
+                        "endFilePos": 144,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 90,
+                      "startFilePos": 147,
+                      "endLine": 2,
+                      "endTokenPos": 94,
+                      "endFilePos": 156
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 90,
+                        "startFilePos": 147,
+                        "endLine": 2,
+                        "endTokenPos": 90,
+                        "endFilePos": 151,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 94,
+                        "startFilePos": 156,
+                        "endLine": 2,
+                        "endTokenPos": 94,
+                        "endFilePos": 156,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 99,
+        "startFilePos": 161,
+        "endLine": 32,
+        "endTokenPos": 493,
+        "endFilePos": 997
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 99,
+          "startFilePos": 161,
+          "endLine": 32,
+          "endTokenPos": 492,
+          "endFilePos": 996
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 99,
+            "startFilePos": 161,
+            "endLine": 3,
+            "endTokenPos": 99,
+            "endFilePos": 168
+          },
+          "name": "grouped"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 103,
+            "startFilePos": 172,
+            "endLine": 32,
+            "endTokenPos": 492,
+            "endFilePos": 996
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 104,
+              "startFilePos": 173,
+              "endLine": 32,
+              "endTokenPos": 489,
+              "endFilePos": 993
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 111,
+                  "startFilePos": 189,
+                  "endLine": 3,
+                  "endTokenPos": 111,
+                  "endFilePos": 194
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 111,
+                    "startFilePos": 189,
+                    "endLine": 3,
+                    "endTokenPos": 111,
+                    "endFilePos": 194
+                  },
+                  "name": "items"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 116,
+                  "startFilePos": 201,
+                  "endLine": 4,
+                  "endTokenPos": 122,
+                  "endFilePos": 213
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 116,
+                    "startFilePos": 201,
+                    "endLine": 4,
+                    "endTokenPos": 121,
+                    "endFilePos": 212
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 116,
+                      "startFilePos": 201,
+                      "endLine": 4,
+                      "endTokenPos": 116,
+                      "endFilePos": 207
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 120,
+                      "startFilePos": 211,
+                      "endLine": 4,
+                      "endTokenPos": 121,
+                      "endFilePos": 212,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 124,
+                  "startFilePos": 217,
+                  "endLine": 12,
+                  "endTokenPos": 228,
+                  "endFilePos": 450
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 127,
+                    "startFilePos": 226,
+                    "endLine": 5,
+                    "endTokenPos": 127,
+                    "endFilePos": 231
+                  },
+                  "name": "items"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 131,
+                    "startFilePos": 236,
+                    "endLine": 5,
+                    "endTokenPos": 131,
+                    "endFilePos": 237
+                  },
+                  "name": "i"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 136,
+                      "startFilePos": 246,
+                      "endLine": 6,
+                      "endTokenPos": 160,
+                      "endFilePos": 285
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 136,
+                        "startFilePos": 246,
+                        "endLine": 6,
+                        "endTokenPos": 159,
+                        "endFilePos": 284
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 136,
+                          "startFilePos": 246,
+                          "endLine": 6,
+                          "endTokenPos": 136,
+                          "endFilePos": 249
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 140,
+                          "startFilePos": 253,
+                          "endLine": 6,
+                          "endTokenPos": 159,
+                          "endFilePos": 284,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 141,
+                              "startFilePos": 254,
+                              "endLine": 6,
+                              "endTokenPos": 148,
+                              "endFilePos": 267
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 6,
+                                "startTokenPos": 141,
+                                "startFilePos": 254,
+                                "endLine": 6,
+                                "endTokenPos": 141,
+                                "endFilePos": 256,
+                                "kind": 2,
+                                "rawValue": "\"a\""
+                              },
+                              "value": "a"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 6,
+                                "startTokenPos": 145,
+                                "startFilePos": 261,
+                                "endLine": 6,
+                                "endTokenPos": 148,
+                                "endFilePos": 267
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 145,
+                                  "startFilePos": 261,
+                                  "endLine": 6,
+                                  "endTokenPos": 145,
+                                  "endFilePos": 262
+                                },
+                                "name": "i"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 147,
+                                  "startFilePos": 264,
+                                  "endLine": 6,
+                                  "endTokenPos": 147,
+                                  "endFilePos": 266,
+                                  "kind": 2,
+                                  "rawValue": "\"a\""
+                                },
+                                "value": "a"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 151,
+                              "startFilePos": 270,
+                              "endLine": 6,
+                              "endTokenPos": 158,
+                              "endFilePos": 283
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 6,
+                                "startTokenPos": 151,
+                                "startFilePos": 270,
+                                "endLine": 6,
+                                "endTokenPos": 151,
+                                "endFilePos": 272,
+                                "kind": 2,
+                                "rawValue": "\"b\""
+                              },
+                              "value": "b"
+                            },
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 6,
+                                "startTokenPos": 155,
+                                "startFilePos": 277,
+                                "endLine": 6,
+                                "endTokenPos": 158,
+                                "endFilePos": 283
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 155,
+                                  "startFilePos": 277,
+                                  "endLine": 6,
+                                  "endTokenPos": 155,
+                                  "endFilePos": 278
+                                },
+                                "name": "i"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 157,
+                                  "startFilePos": 280,
+                                  "endLine": 6,
+                                  "endTokenPos": 157,
+                                  "endFilePos": 282,
+                                  "kind": 2,
+                                  "rawValue": "\"b\""
+                                },
+                                "value": "b"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 162,
+                      "startFilePos": 291,
+                      "endLine": 7,
+                      "endTokenPos": 170,
+                      "endFilePos": 313
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 162,
+                        "startFilePos": 291,
+                        "endLine": 7,
+                        "endTokenPos": 169,
+                        "endFilePos": 312
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 162,
+                          "startFilePos": 291,
+                          "endLine": 7,
+                          "endTokenPos": 162,
+                          "endFilePos": 292
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 166,
+                          "startFilePos": 296,
+                          "endLine": 7,
+                          "endTokenPos": 169,
+                          "endFilePos": 312
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 166,
+                            "startFilePos": 296,
+                            "endLine": 7,
+                            "endTokenPos": 166,
+                            "endFilePos": 306
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 168,
+                              "startFilePos": 308,
+                              "endLine": 7,
+                              "endTokenPos": 168,
+                              "endFilePos": 311
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 168,
+                                "startFilePos": 308,
+                                "endLine": 7,
+                                "endTokenPos": 168,
+                                "endFilePos": 311
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 172,
+                      "startFilePos": 319,
+                      "endLine": 10,
+                      "endTokenPos": 211,
+                      "endFilePos": 413
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 175,
+                        "startFilePos": 323,
+                        "endLine": 8,
+                        "endTokenPos": 182,
+                        "endFilePos": 352
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 176,
+                          "startFilePos": 324,
+                          "endLine": 8,
+                          "endTokenPos": 182,
+                          "endFilePos": 352
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 176,
+                            "startFilePos": 324,
+                            "endLine": 8,
+                            "endTokenPos": 176,
+                            "endFilePos": 339
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 178,
+                              "startFilePos": 341,
+                              "endLine": 8,
+                              "endTokenPos": 178,
+                              "endFilePos": 342
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 178,
+                                "startFilePos": 341,
+                                "endLine": 8,
+                                "endTokenPos": 178,
+                                "endFilePos": 342
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 181,
+                              "startFilePos": 345,
+                              "endLine": 8,
+                              "endTokenPos": 181,
+                              "endFilePos": 351
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 181,
+                                "startFilePos": 345,
+                                "endLine": 8,
+                                "endTokenPos": 181,
+                                "endFilePos": 351
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 187,
+                          "startFilePos": 363,
+                          "endLine": 9,
+                          "endTokenPos": 209,
+                          "endFilePos": 407
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 187,
+                            "startFilePos": 363,
+                            "endLine": 9,
+                            "endTokenPos": 208,
+                            "endFilePos": 406
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 187,
+                              "startFilePos": 363,
+                              "endLine": 9,
+                              "endTokenPos": 190,
+                              "endFilePos": 373
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 187,
+                                "startFilePos": 363,
+                                "endLine": 9,
+                                "endTokenPos": 187,
+                                "endFilePos": 369
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 189,
+                                "startFilePos": 371,
+                                "endLine": 9,
+                                "endTokenPos": 189,
+                                "endFilePos": 372
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 194,
+                              "startFilePos": 377,
+                              "endLine": 9,
+                              "endTokenPos": 208,
+                              "endFilePos": 406,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 195,
+                                  "startFilePos": 378,
+                                  "endLine": 9,
+                                  "endTokenPos": 199,
+                                  "endFilePos": 390
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 195,
+                                    "startFilePos": 378,
+                                    "endLine": 9,
+                                    "endTokenPos": 195,
+                                    "endFilePos": 382,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 199,
+                                    "startFilePos": 387,
+                                    "endLine": 9,
+                                    "endTokenPos": 199,
+                                    "endFilePos": 390
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 202,
+                                  "startFilePos": 393,
+                                  "endLine": 9,
+                                  "endTokenPos": 207,
+                                  "endFilePos": 405
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 202,
+                                    "startFilePos": 393,
+                                    "endLine": 9,
+                                    "endTokenPos": 202,
+                                    "endFilePos": 399,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 206,
+                                    "startFilePos": 404,
+                                    "endLine": 9,
+                                    "endTokenPos": 207,
+                                    "endFilePos": 405,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 213,
+                      "startFilePos": 419,
+                      "endLine": 11,
+                      "endTokenPos": 226,
+                      "endFilePos": 446
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 213,
+                        "startFilePos": 419,
+                        "endLine": 11,
+                        "endTokenPos": 225,
+                        "endFilePos": 445
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 213,
+                          "startFilePos": 419,
+                          "endLine": 11,
+                          "endTokenPos": 221,
+                          "endFilePos": 440
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 213,
+                            "startFilePos": 419,
+                            "endLine": 11,
+                            "endTokenPos": 219,
+                            "endFilePos": 438
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 213,
+                              "startFilePos": 419,
+                              "endLine": 11,
+                              "endTokenPos": 216,
+                              "endFilePos": 429
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 213,
+                                "startFilePos": 419,
+                                "endLine": 11,
+                                "endTokenPos": 213,
+                                "endFilePos": 425
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 215,
+                                "startFilePos": 427,
+                                "endLine": 11,
+                                "endTokenPos": 215,
+                                "endFilePos": 428
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 218,
+                              "startFilePos": 431,
+                              "endLine": 11,
+                              "endTokenPos": 218,
+                              "endFilePos": 437,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 225,
+                          "startFilePos": 444,
+                          "endLine": 11,
+                          "endTokenPos": 225,
+                          "endFilePos": 445
+                        },
+                        "name": "i"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 230,
+                  "startFilePos": 454,
+                  "endLine": 13,
+                  "endTokenPos": 236,
+                  "endFilePos": 466
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 230,
+                    "startFilePos": 454,
+                    "endLine": 13,
+                    "endTokenPos": 235,
+                    "endFilePos": 465
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 230,
+                      "startFilePos": 454,
+                      "endLine": 13,
+                      "endTokenPos": 230,
+                      "endFilePos": 460
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 234,
+                      "startFilePos": 464,
+                      "endLine": 13,
+                      "endTokenPos": 235,
+                      "endFilePos": 465,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 238,
+                  "startFilePos": 470,
+                  "endLine": 28,
+                  "endTokenPos": 425,
+                  "endFilePos": 860
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 241,
+                    "startFilePos": 479,
+                    "endLine": 14,
+                    "endTokenPos": 241,
+                    "endFilePos": 485
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 245,
+                    "startFilePos": 490,
+                    "endLine": 14,
+                    "endTokenPos": 245,
+                    "endFilePos": 491
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 250,
+                      "startFilePos": 502,
+                      "endLine": 27,
+                      "endTokenPos": 423,
+                      "endFilePos": 856
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 250,
+                        "startFilePos": 502,
+                        "endLine": 27,
+                        "endTokenPos": 422,
+                        "endFilePos": 855
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 250,
+                          "startFilePos": 502,
+                          "endLine": 15,
+                          "endTokenPos": 252,
+                          "endFilePos": 510
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 250,
+                            "startFilePos": 502,
+                            "endLine": 15,
+                            "endTokenPos": 250,
+                            "endFilePos": 508
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 256,
+                          "startFilePos": 514,
+                          "endLine": 27,
+                          "endTokenPos": 422,
+                          "endFilePos": 855,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 257,
+                              "startFilePos": 515,
+                              "endLine": 21,
+                              "endTokenPos": 322,
+                              "endFilePos": 654
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_UnaryMinus",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 257,
+                                "startFilePos": 515,
+                                "endLine": 21,
+                                "endTokenPos": 322,
+                                "endFilePos": 654
+                              },
+                              "expr": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 258,
+                                  "startFilePos": 516,
+                                  "endLine": 21,
+                                  "endTokenPos": 322,
+                                  "endFilePos": 654
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 258,
+                                    "startFilePos": 516,
+                                    "endLine": 15,
+                                    "endTokenPos": 258,
+                                    "endFilePos": 524
+                                  },
+                                  "name": "array_sum"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 260,
+                                      "startFilePos": 526,
+                                      "endLine": 21,
+                                      "endTokenPos": 321,
+                                      "endFilePos": 653
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 260,
+                                        "startFilePos": 526,
+                                        "endLine": 21,
+                                        "endTokenPos": 321,
+                                        "endFilePos": 653
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 261,
+                                          "startFilePos": 527,
+                                          "endLine": 21,
+                                          "endTokenPos": 318,
+                                          "endFilePos": 650
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 268,
+                                              "startFilePos": 543,
+                                              "endLine": 15,
+                                              "endTokenPos": 268,
+                                              "endFilePos": 544
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 268,
+                                                "startFilePos": 543,
+                                                "endLine": 15,
+                                                "endTokenPos": 268,
+                                                "endFilePos": 544
+                                              },
+                                              "name": "i"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 271,
+                                              "startFilePos": 547,
+                                              "endLine": 15,
+                                              "endTokenPos": 271,
+                                              "endFilePos": 548
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 271,
+                                                "startFilePos": 547,
+                                                "endLine": 15,
+                                                "endTokenPos": 271,
+                                                "endFilePos": 548
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 16,
+                                              "startTokenPos": 276,
+                                              "startFilePos": 555,
+                                              "endLine": 16,
+                                              "endTokenPos": 282,
+                                              "endFilePos": 567
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 16,
+                                                "startTokenPos": 276,
+                                                "startFilePos": 555,
+                                                "endLine": 16,
+                                                "endTokenPos": 281,
+                                                "endFilePos": 566
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 16,
+                                                  "startTokenPos": 276,
+                                                  "startFilePos": 555,
+                                                  "endLine": 16,
+                                                  "endTokenPos": 276,
+                                                  "endFilePos": 561
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 16,
+                                                  "startTokenPos": 280,
+                                                  "startFilePos": 565,
+                                                  "endLine": 16,
+                                                  "endTokenPos": 281,
+                                                  "endFilePos": 566,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 17,
+                                              "startTokenPos": 284,
+                                              "startFilePos": 571,
+                                              "endLine": 19,
+                                              "endTokenPos": 311,
+                                              "endFilePos": 630
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 287,
+                                                "startFilePos": 580,
+                                                "endLine": 17,
+                                                "endTokenPos": 290,
+                                                "endFilePos": 590
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 287,
+                                                  "startFilePos": 580,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 287,
+                                                  "endFilePos": 581
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 289,
+                                                  "startFilePos": 583,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 289,
+                                                  "endFilePos": 589,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 294,
+                                                "startFilePos": 595,
+                                                "endLine": 17,
+                                                "endTokenPos": 294,
+                                                "endFilePos": 596
+                                              },
+                                              "name": "x"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 299,
+                                                  "startFilePos": 605,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 309,
+                                                  "endFilePos": 626
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 299,
+                                                    "startFilePos": 605,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 308,
+                                                    "endFilePos": 625
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 18,
+                                                      "startTokenPos": 299,
+                                                      "startFilePos": 605,
+                                                      "endLine": 18,
+                                                      "endTokenPos": 301,
+                                                      "endFilePos": 613
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 299,
+                                                        "startFilePos": 605,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 299,
+                                                        "endFilePos": 611
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 18,
+                                                      "startTokenPos": 305,
+                                                      "startFilePos": 617,
+                                                      "endLine": 18,
+                                                      "endTokenPos": 308,
+                                                      "endFilePos": 625
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 305,
+                                                        "startFilePos": 617,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 305,
+                                                        "endFilePos": 618
+                                                      },
+                                                      "name": "x"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 307,
+                                                        "startFilePos": 620,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 307,
+                                                        "endFilePos": 624,
+                                                        "kind": 2,
+                                                        "rawValue": "\"val\""
+                                                      },
+                                                      "value": "val"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 313,
+                                              "startFilePos": 634,
+                                              "endLine": 20,
+                                              "endTokenPos": 316,
+                                              "endFilePos": 648
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 315,
+                                                "startFilePos": 641,
+                                                "endLine": 20,
+                                                "endTokenPos": 315,
+                                                "endFilePos": 647
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 325,
+                              "startFilePos": 657,
+                              "endLine": 27,
+                              "endTokenPos": 421,
+                              "endFilePos": 854
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 325,
+                                "startFilePos": 657,
+                                "endLine": 27,
+                                "endTokenPos": 421,
+                                "endFilePos": 854,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 326,
+                                    "startFilePos": 658,
+                                    "endLine": 21,
+                                    "endTokenPos": 336,
+                                    "endFilePos": 678
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 326,
+                                      "startFilePos": 658,
+                                      "endLine": 21,
+                                      "endTokenPos": 326,
+                                      "endFilePos": 660,
+                                      "kind": 2,
+                                      "rawValue": "\"a\""
+                                    },
+                                    "value": "a"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 330,
+                                      "startFilePos": 665,
+                                      "endLine": 21,
+                                      "endTokenPos": 336,
+                                      "endFilePos": 678
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 330,
+                                        "startFilePos": 665,
+                                        "endLine": 21,
+                                        "endTokenPos": 333,
+                                        "endFilePos": 673
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 330,
+                                          "startFilePos": 665,
+                                          "endLine": 21,
+                                          "endTokenPos": 330,
+                                          "endFilePos": 666
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 332,
+                                          "startFilePos": 668,
+                                          "endLine": 21,
+                                          "endTokenPos": 332,
+                                          "endFilePos": 672,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 335,
+                                        "startFilePos": 675,
+                                        "endLine": 21,
+                                        "endTokenPos": 335,
+                                        "endFilePos": 677,
+                                        "kind": 2,
+                                        "rawValue": "\"a\""
+                                      },
+                                      "value": "a"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 339,
+                                    "startFilePos": 681,
+                                    "endLine": 21,
+                                    "endTokenPos": 349,
+                                    "endFilePos": 701
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 339,
+                                      "startFilePos": 681,
+                                      "endLine": 21,
+                                      "endTokenPos": 339,
+                                      "endFilePos": 683,
+                                      "kind": 2,
+                                      "rawValue": "\"b\""
+                                    },
+                                    "value": "b"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 343,
+                                      "startFilePos": 688,
+                                      "endLine": 21,
+                                      "endTokenPos": 349,
+                                      "endFilePos": 701
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 343,
+                                        "startFilePos": 688,
+                                        "endLine": 21,
+                                        "endTokenPos": 346,
+                                        "endFilePos": 696
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 343,
+                                          "startFilePos": 688,
+                                          "endLine": 21,
+                                          "endTokenPos": 343,
+                                          "endFilePos": 689
+                                        },
+                                        "name": "g"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 345,
+                                          "startFilePos": 691,
+                                          "endLine": 21,
+                                          "endTokenPos": 345,
+                                          "endFilePos": 695,
+                                          "kind": 2,
+                                          "rawValue": "\"key\""
+                                        },
+                                        "value": "key"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 348,
+                                        "startFilePos": 698,
+                                        "endLine": 21,
+                                        "endTokenPos": 348,
+                                        "endFilePos": 700,
+                                        "kind": 2,
+                                        "rawValue": "\"b\""
+                                      },
+                                      "value": "b"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 352,
+                                    "startFilePos": 704,
+                                    "endLine": 27,
+                                    "endTokenPos": 420,
+                                    "endFilePos": 853
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 352,
+                                      "startFilePos": 704,
+                                      "endLine": 21,
+                                      "endTokenPos": 352,
+                                      "endFilePos": 710,
+                                      "kind": 2,
+                                      "rawValue": "\"total\""
+                                    },
+                                    "value": "total"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_FuncCall",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 356,
+                                      "startFilePos": 715,
+                                      "endLine": 27,
+                                      "endTokenPos": 420,
+                                      "endFilePos": 853
+                                    },
+                                    "name": {
+                                      "nodeType": "Name",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 356,
+                                        "startFilePos": 715,
+                                        "endLine": 21,
+                                        "endTokenPos": 356,
+                                        "endFilePos": 723
+                                      },
+                                      "name": "array_sum"
+                                    },
+                                    "args": [
+                                      {
+                                        "nodeType": "Arg",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 358,
+                                          "startFilePos": 725,
+                                          "endLine": 27,
+                                          "endTokenPos": 419,
+                                          "endFilePos": 852
+                                        },
+                                        "name": null,
+                                        "value": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 21,
+                                            "startTokenPos": 358,
+                                            "startFilePos": 725,
+                                            "endLine": 27,
+                                            "endTokenPos": 419,
+                                            "endFilePos": 852
+                                          },
+                                          "name": {
+                                            "nodeType": "Expr_Closure",
+                                            "attributes": {
+                                              "startLine": 21,
+                                              "startTokenPos": 359,
+                                              "startFilePos": 726,
+                                              "endLine": 27,
+                                              "endTokenPos": 416,
+                                              "endFilePos": 849
+                                            },
+                                            "static": false,
+                                            "byRef": false,
+                                            "params": [],
+                                            "uses": [
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 21,
+                                                  "startTokenPos": 366,
+                                                  "startFilePos": 742,
+                                                  "endLine": 21,
+                                                  "endTokenPos": 366,
+                                                  "endFilePos": 743
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 21,
+                                                    "startTokenPos": 366,
+                                                    "startFilePos": 742,
+                                                    "endLine": 21,
+                                                    "endTokenPos": 366,
+                                                    "endFilePos": 743
+                                                  },
+                                                  "name": "i"
+                                                },
+                                                "byRef": false
+                                              },
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 21,
+                                                  "startTokenPos": 369,
+                                                  "startFilePos": 746,
+                                                  "endLine": 21,
+                                                  "endTokenPos": 369,
+                                                  "endFilePos": 747
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 21,
+                                                    "startTokenPos": 369,
+                                                    "startFilePos": 746,
+                                                    "endLine": 21,
+                                                    "endTokenPos": 369,
+                                                    "endFilePos": 747
+                                                  },
+                                                  "name": "g"
+                                                },
+                                                "byRef": false
+                                              }
+                                            ],
+                                            "returnType": null,
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 22,
+                                                  "startTokenPos": 374,
+                                                  "startFilePos": 754,
+                                                  "endLine": 22,
+                                                  "endTokenPos": 380,
+                                                  "endFilePos": 766
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 22,
+                                                    "startTokenPos": 374,
+                                                    "startFilePos": 754,
+                                                    "endLine": 22,
+                                                    "endTokenPos": 379,
+                                                    "endFilePos": 765
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 22,
+                                                      "startTokenPos": 374,
+                                                      "startFilePos": 754,
+                                                      "endLine": 22,
+                                                      "endTokenPos": 374,
+                                                      "endFilePos": 760
+                                                    },
+                                                    "name": "result"
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_Array",
+                                                    "attributes": {
+                                                      "startLine": 22,
+                                                      "startTokenPos": 378,
+                                                      "startFilePos": 764,
+                                                      "endLine": 22,
+                                                      "endTokenPos": 379,
+                                                      "endFilePos": 765,
+                                                      "kind": 2
+                                                    },
+                                                    "items": []
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "nodeType": "Stmt_Foreach",
+                                                "attributes": {
+                                                  "startLine": 23,
+                                                  "startTokenPos": 382,
+                                                  "startFilePos": 770,
+                                                  "endLine": 25,
+                                                  "endTokenPos": 409,
+                                                  "endFilePos": 829
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 23,
+                                                    "startTokenPos": 385,
+                                                    "startFilePos": 779,
+                                                    "endLine": 23,
+                                                    "endTokenPos": 388,
+                                                    "endFilePos": 789
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 23,
+                                                      "startTokenPos": 385,
+                                                      "startFilePos": 779,
+                                                      "endLine": 23,
+                                                      "endTokenPos": 385,
+                                                      "endFilePos": 780
+                                                    },
+                                                    "name": "g"
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 23,
+                                                      "startTokenPos": 387,
+                                                      "startFilePos": 782,
+                                                      "endLine": 23,
+                                                      "endTokenPos": 387,
+                                                      "endFilePos": 788,
+                                                      "kind": 2,
+                                                      "rawValue": "\"items\""
+                                                    },
+                                                    "value": "items"
+                                                  }
+                                                },
+                                                "keyVar": null,
+                                                "byRef": false,
+                                                "valueVar": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 23,
+                                                    "startTokenPos": 392,
+                                                    "startFilePos": 794,
+                                                    "endLine": 23,
+                                                    "endTokenPos": 392,
+                                                    "endFilePos": 795
+                                                  },
+                                                  "name": "x"
+                                                },
+                                                "stmts": [
+                                                  {
+                                                    "nodeType": "Stmt_Expression",
+                                                    "attributes": {
+                                                      "startLine": 24,
+                                                      "startTokenPos": 397,
+                                                      "startFilePos": 804,
+                                                      "endLine": 24,
+                                                      "endTokenPos": 407,
+                                                      "endFilePos": 825
+                                                    },
+                                                    "expr": {
+                                                      "nodeType": "Expr_Assign",
+                                                      "attributes": {
+                                                        "startLine": 24,
+                                                        "startTokenPos": 397,
+                                                        "startFilePos": 804,
+                                                        "endLine": 24,
+                                                        "endTokenPos": 406,
+                                                        "endFilePos": 824
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 24,
+                                                          "startTokenPos": 397,
+                                                          "startFilePos": 804,
+                                                          "endLine": 24,
+                                                          "endTokenPos": 399,
+                                                          "endFilePos": 812
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_Variable",
+                                                          "attributes": {
+                                                            "startLine": 24,
+                                                            "startTokenPos": 397,
+                                                            "startFilePos": 804,
+                                                            "endLine": 24,
+                                                            "endTokenPos": 397,
+                                                            "endFilePos": 810
+                                                          },
+                                                          "name": "result"
+                                                        },
+                                                        "dim": null
+                                                      },
+                                                      "expr": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 24,
+                                                          "startTokenPos": 403,
+                                                          "startFilePos": 816,
+                                                          "endLine": 24,
+                                                          "endTokenPos": 406,
+                                                          "endFilePos": 824
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_Variable",
+                                                          "attributes": {
+                                                            "startLine": 24,
+                                                            "startTokenPos": 403,
+                                                            "startFilePos": 816,
+                                                            "endLine": 24,
+                                                            "endTokenPos": 403,
+                                                            "endFilePos": 817
+                                                          },
+                                                          "name": "x"
+                                                        },
+                                                        "dim": {
+                                                          "nodeType": "Scalar_String",
+                                                          "attributes": {
+                                                            "startLine": 24,
+                                                            "startTokenPos": 405,
+                                                            "startFilePos": 819,
+                                                            "endLine": 24,
+                                                            "endTokenPos": 405,
+                                                            "endFilePos": 823,
+                                                            "kind": 2,
+                                                            "rawValue": "\"val\""
+                                                          },
+                                                          "value": "val"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "nodeType": "Stmt_Return",
+                                                "attributes": {
+                                                  "startLine": 26,
+                                                  "startTokenPos": 411,
+                                                  "startFilePos": 833,
+                                                  "endLine": 26,
+                                                  "endTokenPos": 414,
+                                                  "endFilePos": 847
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 26,
+                                                    "startTokenPos": 413,
+                                                    "startFilePos": 840,
+                                                    "endLine": 26,
+                                                    "endTokenPos": 413,
+                                                    "endFilePos": 846
+                                                  },
+                                                  "name": "result"
+                                                }
+                                              }
+                                            ],
+                                            "attrGroups": []
+                                          },
+                                          "args": []
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      }
+                                    ]
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 427,
+                  "startFilePos": 864,
+                  "endLine": 29,
+                  "endTokenPos": 459,
+                  "endFilePos": 924
+                },
+                "expr": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 29,
+                    "startTokenPos": 427,
+                    "startFilePos": 864,
+                    "endLine": 29,
+                    "endTokenPos": 458,
+                    "endFilePos": 923
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 29,
+                      "startTokenPos": 427,
+                      "startFilePos": 864,
+                      "endLine": 29,
+                      "endTokenPos": 427,
+                      "endFilePos": 868
+                    },
+                    "name": "usort"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 29,
+                        "startTokenPos": 429,
+                        "startFilePos": 870,
+                        "endLine": 29,
+                        "endTokenPos": 429,
+                        "endFilePos": 876
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 29,
+                          "startTokenPos": 429,
+                          "startFilePos": 870,
+                          "endLine": 29,
+                          "endTokenPos": 429,
+                          "endFilePos": 876
+                        },
+                        "name": "result"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 29,
+                        "startTokenPos": 432,
+                        "startFilePos": 879,
+                        "endLine": 29,
+                        "endTokenPos": 457,
+                        "endFilePos": 922
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Closure",
+                        "attributes": {
+                          "startLine": 29,
+                          "startTokenPos": 432,
+                          "startFilePos": 879,
+                          "endLine": 29,
+                          "endTokenPos": 457,
+                          "endFilePos": 922
+                        },
+                        "static": false,
+                        "byRef": false,
+                        "params": [
+                          {
+                            "nodeType": "Param",
+                            "attributes": {
+                              "startLine": 29,
+                              "startTokenPos": 434,
+                              "startFilePos": 888,
+                              "endLine": 29,
+                              "endTokenPos": 434,
+                              "endFilePos": 889
+                            },
+                            "type": null,
+                            "byRef": false,
+                            "variadic": false,
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 29,
+                                "startTokenPos": 434,
+                                "startFilePos": 888,
+                                "endLine": 29,
+                                "endTokenPos": 434,
+                                "endFilePos": 889
+                              },
+                              "name": "a"
+                            },
+                            "default": null,
+                            "flags": 0,
+                            "attrGroups": [],
+                            "hooks": []
+                          },
+                          {
+                            "nodeType": "Param",
+                            "attributes": {
+                              "startLine": 29,
+                              "startTokenPos": 437,
+                              "startFilePos": 892,
+                              "endLine": 29,
+                              "endTokenPos": 437,
+                              "endFilePos": 893
+                            },
+                            "type": null,
+                            "byRef": false,
+                            "variadic": false,
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 29,
+                                "startTokenPos": 437,
+                                "startFilePos": 892,
+                                "endLine": 29,
+                                "endTokenPos": 437,
+                                "endFilePos": 893
+                              },
+                              "name": "b"
+                            },
+                            "default": null,
+                            "flags": 0,
+                            "attrGroups": [],
+                            "hooks": []
+                          }
+                        ],
+                        "uses": [],
+                        "returnType": null,
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Return",
+                            "attributes": {
+                              "startLine": 29,
+                              "startTokenPos": 442,
+                              "startFilePos": 898,
+                              "endLine": 29,
+                              "endTokenPos": 455,
+                              "endFilePos": 920
+                            },
+                            "expr": {
+                              "nodeType": "Expr_BinaryOp_Spaceship",
+                              "attributes": {
+                                "startLine": 29,
+                                "startTokenPos": 444,
+                                "startFilePos": 905,
+                                "endLine": 29,
+                                "endTokenPos": 454,
+                                "endFilePos": 919
+                              },
+                              "left": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 29,
+                                  "startTokenPos": 444,
+                                  "startFilePos": 905,
+                                  "endLine": 29,
+                                  "endTokenPos": 447,
+                                  "endFilePos": 909
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 444,
+                                    "startFilePos": 905,
+                                    "endLine": 29,
+                                    "endTokenPos": 444,
+                                    "endFilePos": 906
+                                  },
+                                  "name": "a"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 446,
+                                    "startFilePos": 908,
+                                    "endLine": 29,
+                                    "endTokenPos": 446,
+                                    "endFilePos": 908,
+                                    "rawValue": "0",
+                                    "kind": 10
+                                  },
+                                  "value": 0
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 29,
+                                  "startTokenPos": 451,
+                                  "startFilePos": 915,
+                                  "endLine": 29,
+                                  "endTokenPos": 454,
+                                  "endFilePos": 919
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 451,
+                                    "startFilePos": 915,
+                                    "endLine": 29,
+                                    "endTokenPos": 451,
+                                    "endFilePos": 916
+                                  },
+                                  "name": "b"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 453,
+                                    "startFilePos": 918,
+                                    "endLine": 29,
+                                    "endTokenPos": 453,
+                                    "endFilePos": 918,
+                                    "rawValue": "0",
+                                    "kind": 10
+                                  },
+                                  "value": 0
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "attrGroups": []
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 30,
+                  "startTokenPos": 461,
+                  "startFilePos": 928,
+                  "endLine": 30,
+                  "endTokenPos": 482,
+                  "endFilePos": 973
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 30,
+                    "startTokenPos": 461,
+                    "startFilePos": 928,
+                    "endLine": 30,
+                    "endTokenPos": 481,
+                    "endFilePos": 972
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 30,
+                      "startTokenPos": 461,
+                      "startFilePos": 928,
+                      "endLine": 30,
+                      "endTokenPos": 461,
+                      "endFilePos": 934
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 30,
+                      "startTokenPos": 465,
+                      "startFilePos": 938,
+                      "endLine": 30,
+                      "endTokenPos": 481,
+                      "endFilePos": 972
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 30,
+                        "startTokenPos": 465,
+                        "startFilePos": 938,
+                        "endLine": 30,
+                        "endTokenPos": 465,
+                        "endFilePos": 946
+                      },
+                      "name": "array_map"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 30,
+                          "startTokenPos": 467,
+                          "startFilePos": 948,
+                          "endLine": 30,
+                          "endTokenPos": 477,
+                          "endFilePos": 962
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrowFunction",
+                          "attributes": {
+                            "startLine": 30,
+                            "startTokenPos": 467,
+                            "startFilePos": 948,
+                            "endLine": 30,
+                            "endTokenPos": 477,
+                            "endFilePos": 962
+                          },
+                          "static": false,
+                          "byRef": false,
+                          "params": [
+                            {
+                              "nodeType": "Param",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 469,
+                                "startFilePos": 951,
+                                "endLine": 30,
+                                "endTokenPos": 469,
+                                "endFilePos": 952
+                              },
+                              "type": null,
+                              "byRef": false,
+                              "variadic": false,
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 30,
+                                  "startTokenPos": 469,
+                                  "startFilePos": 951,
+                                  "endLine": 30,
+                                  "endTokenPos": 469,
+                                  "endFilePos": 952
+                                },
+                                "name": "r"
+                              },
+                              "default": null,
+                              "flags": 0,
+                              "attrGroups": [],
+                              "hooks": []
+                            }
+                          ],
+                          "returnType": null,
+                          "expr": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 30,
+                              "startTokenPos": 474,
+                              "startFilePos": 958,
+                              "endLine": 30,
+                              "endTokenPos": 477,
+                              "endFilePos": 962
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 474,
+                                "startFilePos": 958,
+                                "endLine": 30,
+                                "endTokenPos": 474,
+                                "endFilePos": 959
+                              },
+                              "name": "r"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 476,
+                                "startFilePos": 961,
+                                "endLine": 30,
+                                "endTokenPos": 476,
+                                "endFilePos": 961,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            }
+                          },
+                          "attrGroups": []
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 30,
+                          "startTokenPos": 480,
+                          "startFilePos": 965,
+                          "endLine": 30,
+                          "endTokenPos": 480,
+                          "endFilePos": 971
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 30,
+                            "startTokenPos": 480,
+                            "startFilePos": 965,
+                            "endLine": 30,
+                            "endTokenPos": 480,
+                            "endFilePos": 971
+                          },
+                          "name": "result"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 484,
+                  "startFilePos": 977,
+                  "endLine": 31,
+                  "endTokenPos": 487,
+                  "endFilePos": 991
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 31,
+                    "startTokenPos": 486,
+                    "startFilePos": 984,
+                    "endLine": 31,
+                    "endTokenPos": 486,
+                    "endFilePos": 990
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 33,
+        "startTokenPos": 495,
+        "startFilePos": 999,
+        "endLine": 33,
+        "endTokenPos": 552,
+        "endFilePos": 1172
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 33,
+            "startTokenPos": 497,
+            "startFilePos": 1004,
+            "endLine": 33,
+            "endTokenPos": 548,
+            "endFilePos": 1162
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 33,
+              "startTokenPos": 497,
+              "startFilePos": 1004,
+              "endLine": 33,
+              "endTokenPos": 497,
+              "endFilePos": 1014
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 499,
+                "startFilePos": 1016,
+                "endLine": 33,
+                "endTokenPos": 499,
+                "endFilePos": 1022
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 499,
+                  "startFilePos": 1016,
+                  "endLine": 33,
+                  "endTokenPos": 499,
+                  "endFilePos": 1022,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 502,
+                "startFilePos": 1025,
+                "endLine": 33,
+                "endTokenPos": 502,
+                "endFilePos": 1031
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 502,
+                  "startFilePos": 1025,
+                  "endLine": 33,
+                  "endTokenPos": 502,
+                  "endFilePos": 1031,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 505,
+                "startFilePos": 1034,
+                "endLine": 33,
+                "endTokenPos": 547,
+                "endFilePos": 1161
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 505,
+                  "startFilePos": 1034,
+                  "endLine": 33,
+                  "endTokenPos": 547,
+                  "endFilePos": 1161
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 505,
+                    "startFilePos": 1034,
+                    "endLine": 33,
+                    "endTokenPos": 505,
+                    "endFilePos": 1044
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 507,
+                      "startFilePos": 1046,
+                      "endLine": 33,
+                      "endTokenPos": 507,
+                      "endFilePos": 1051
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 507,
+                        "startFilePos": 1046,
+                        "endLine": 33,
+                        "endTokenPos": 507,
+                        "endFilePos": 1051,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 510,
+                      "startFilePos": 1054,
+                      "endLine": 33,
+                      "endTokenPos": 510,
+                      "endFilePos": 1059
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 510,
+                        "startFilePos": 1054,
+                        "endLine": 33,
+                        "endTokenPos": 510,
+                        "endFilePos": 1059,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 513,
+                      "startFilePos": 1062,
+                      "endLine": 33,
+                      "endTokenPos": 546,
+                      "endFilePos": 1160
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 513,
+                        "startFilePos": 1062,
+                        "endLine": 33,
+                        "endTokenPos": 546,
+                        "endFilePos": 1160
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 513,
+                          "startFilePos": 1062,
+                          "endLine": 33,
+                          "endTokenPos": 513,
+                          "endFilePos": 1072
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 515,
+                            "startFilePos": 1074,
+                            "endLine": 33,
+                            "endTokenPos": 515,
+                            "endFilePos": 1077
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 515,
+                              "startFilePos": 1074,
+                              "endLine": 33,
+                              "endTokenPos": 515,
+                              "endFilePos": 1077,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 518,
+                            "startFilePos": 1080,
+                            "endLine": 33,
+                            "endTokenPos": 518,
+                            "endFilePos": 1082
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 518,
+                              "startFilePos": 1080,
+                              "endLine": 33,
+                              "endTokenPos": 518,
+                              "endFilePos": 1082,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 521,
+                            "startFilePos": 1085,
+                            "endLine": 33,
+                            "endTokenPos": 545,
+                            "endFilePos": 1159
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 521,
+                              "startFilePos": 1085,
+                              "endLine": 33,
+                              "endTokenPos": 545,
+                              "endFilePos": 1159
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 521,
+                                "startFilePos": 1085,
+                                "endLine": 33,
+                                "endTokenPos": 521,
+                                "endFilePos": 1095
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 523,
+                                  "startFilePos": 1097,
+                                  "endLine": 33,
+                                  "endTokenPos": 523,
+                                  "endFilePos": 1099
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 523,
+                                    "startFilePos": 1097,
+                                    "endLine": 33,
+                                    "endTokenPos": 523,
+                                    "endFilePos": 1099,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 526,
+                                  "startFilePos": 1102,
+                                  "endLine": 33,
+                                  "endTokenPos": 526,
+                                  "endFilePos": 1105
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 526,
+                                    "startFilePos": 1102,
+                                    "endLine": 33,
+                                    "endTokenPos": 526,
+                                    "endFilePos": 1105,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 529,
+                                  "startFilePos": 1108,
+                                  "endLine": 33,
+                                  "endTokenPos": 544,
+                                  "endFilePos": 1158
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 529,
+                                    "startFilePos": 1108,
+                                    "endLine": 33,
+                                    "endTokenPos": 544,
+                                    "endFilePos": 1158
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 33,
+                                      "startTokenPos": 529,
+                                      "startFilePos": 1108,
+                                      "endLine": 33,
+                                      "endTokenPos": 529,
+                                      "endFilePos": 1118
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 531,
+                                        "startFilePos": 1120,
+                                        "endLine": 33,
+                                        "endTokenPos": 531,
+                                        "endFilePos": 1122
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 531,
+                                          "startFilePos": 1120,
+                                          "endLine": 33,
+                                          "endTokenPos": 531,
+                                          "endFilePos": 1122,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 534,
+                                        "startFilePos": 1125,
+                                        "endLine": 33,
+                                        "endTokenPos": 534,
+                                        "endFilePos": 1128
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 534,
+                                          "startFilePos": 1125,
+                                          "endLine": 33,
+                                          "endTokenPos": 534,
+                                          "endFilePos": 1128,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 537,
+                                        "startFilePos": 1131,
+                                        "endLine": 33,
+                                        "endTokenPos": 543,
+                                        "endFilePos": 1157
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 537,
+                                          "startFilePos": 1131,
+                                          "endLine": 33,
+                                          "endTokenPos": 543,
+                                          "endFilePos": 1157
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 33,
+                                            "startTokenPos": 537,
+                                            "startFilePos": 1131,
+                                            "endLine": 33,
+                                            "endTokenPos": 537,
+                                            "endFilePos": 1141
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 33,
+                                              "startTokenPos": 539,
+                                              "startFilePos": 1143,
+                                              "endLine": 33,
+                                              "endTokenPos": 539,
+                                              "endFilePos": 1150
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 33,
+                                                "startTokenPos": 539,
+                                                "startFilePos": 1143,
+                                                "endLine": 33,
+                                                "endTokenPos": 539,
+                                                "endFilePos": 1150
+                                              },
+                                              "name": "grouped"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 33,
+                                              "startTokenPos": 542,
+                                              "startFilePos": 1153,
+                                              "endLine": 33,
+                                              "endTokenPos": 542,
+                                              "endFilePos": 1156
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 33,
+                                                "startTokenPos": 542,
+                                                "startFilePos": 1153,
+                                                "endLine": 33,
+                                                "endTokenPos": 542,
+                                                "endFilePos": 1156,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 33,
+            "startTokenPos": 551,
+            "startFilePos": 1165,
+            "endLine": 33,
+            "endTokenPos": 551,
+            "endFilePos": 1171
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 33,
+              "startTokenPos": 551,
+              "startFilePos": 1165,
+              "endLine": 33,
+              "endTokenPos": 551,
+              "endFilePos": 1171
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_by_sort.php.json
+++ b/tests/json-ast/x/php/group_by_sort.php.json
@@ -1,0 +1,3193 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 69,
+        "endFilePos": 127
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 68,
+          "endFilePos": 126
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 11
+          },
+          "name": "items"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 15,
+            "endLine": 2,
+            "endTokenPos": 68,
+            "endFilePos": 126,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 41
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 16,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 41,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 17,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 28
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 17,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 21,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 26,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 28,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 31,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 40
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 31,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 35,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 40,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 40,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 44,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 69
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 44,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 69,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 45,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 56
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 45,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 49,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 54,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 59,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 68
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 59,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 63,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 68,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 68,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 72,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 97
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 72,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 97,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 73,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 84
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 73,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 77,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 82,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 84,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 87,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 96
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 87,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 91,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 96,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 96,
+                        "rawValue": "5",
+                        "kind": 10
+                      },
+                      "value": 5
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 54,
+                "startFilePos": 100,
+                "endLine": 2,
+                "endTokenPos": 67,
+                "endFilePos": 125
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 54,
+                  "startFilePos": 100,
+                  "endLine": 2,
+                  "endTokenPos": 67,
+                  "endFilePos": 125,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 101,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 101,
+                        "endLine": 2,
+                        "endTokenPos": 55,
+                        "endFilePos": 105,
+                        "kind": 2,
+                        "rawValue": "\"cat\""
+                      },
+                      "value": "cat"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 59,
+                        "startFilePos": 110,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 62,
+                      "startFilePos": 115,
+                      "endLine": 2,
+                      "endTokenPos": 66,
+                      "endFilePos": 124
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 62,
+                        "startFilePos": 115,
+                        "endLine": 2,
+                        "endTokenPos": 62,
+                        "endFilePos": 119,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 66,
+                        "startFilePos": 124,
+                        "endLine": 2,
+                        "endTokenPos": 66,
+                        "endFilePos": 124,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 71,
+        "startFilePos": 129,
+        "endLine": 32,
+        "endTokenPos": 433,
+        "endFilePos": 916
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 71,
+          "startFilePos": 129,
+          "endLine": 32,
+          "endTokenPos": 432,
+          "endFilePos": 915
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 71,
+            "startFilePos": 129,
+            "endLine": 3,
+            "endTokenPos": 71,
+            "endFilePos": 136
+          },
+          "name": "grouped"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 75,
+            "startFilePos": 140,
+            "endLine": 32,
+            "endTokenPos": 432,
+            "endFilePos": 915
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 76,
+              "startFilePos": 141,
+              "endLine": 32,
+              "endTokenPos": 429,
+              "endFilePos": 912
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 83,
+                  "startFilePos": 157,
+                  "endLine": 3,
+                  "endTokenPos": 83,
+                  "endFilePos": 162
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 83,
+                    "startFilePos": 157,
+                    "endLine": 3,
+                    "endTokenPos": 83,
+                    "endFilePos": 162
+                  },
+                  "name": "items"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 88,
+                  "startFilePos": 169,
+                  "endLine": 4,
+                  "endTokenPos": 94,
+                  "endFilePos": 181
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 88,
+                    "startFilePos": 169,
+                    "endLine": 4,
+                    "endTokenPos": 93,
+                    "endFilePos": 180
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 88,
+                      "startFilePos": 169,
+                      "endLine": 4,
+                      "endTokenPos": 88,
+                      "endFilePos": 175
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 92,
+                      "startFilePos": 179,
+                      "endLine": 4,
+                      "endTokenPos": 93,
+                      "endFilePos": 180,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 96,
+                  "startFilePos": 185,
+                  "endLine": 12,
+                  "endTokenPos": 184,
+                  "endFilePos": 395
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 99,
+                    "startFilePos": 194,
+                    "endLine": 5,
+                    "endTokenPos": 99,
+                    "endFilePos": 199
+                  },
+                  "name": "items"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 103,
+                    "startFilePos": 204,
+                    "endLine": 5,
+                    "endTokenPos": 103,
+                    "endFilePos": 205
+                  },
+                  "name": "i"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 108,
+                      "startFilePos": 214,
+                      "endLine": 6,
+                      "endTokenPos": 116,
+                      "endFilePos": 230
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 108,
+                        "startFilePos": 214,
+                        "endLine": 6,
+                        "endTokenPos": 115,
+                        "endFilePos": 229
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 108,
+                          "startFilePos": 214,
+                          "endLine": 6,
+                          "endTokenPos": 108,
+                          "endFilePos": 217
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 112,
+                          "startFilePos": 221,
+                          "endLine": 6,
+                          "endTokenPos": 115,
+                          "endFilePos": 229
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 112,
+                            "startFilePos": 221,
+                            "endLine": 6,
+                            "endTokenPos": 112,
+                            "endFilePos": 222
+                          },
+                          "name": "i"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 114,
+                            "startFilePos": 224,
+                            "endLine": 6,
+                            "endTokenPos": 114,
+                            "endFilePos": 228,
+                            "kind": 2,
+                            "rawValue": "\"cat\""
+                          },
+                          "value": "cat"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 118,
+                      "startFilePos": 236,
+                      "endLine": 7,
+                      "endTokenPos": 126,
+                      "endFilePos": 258
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 118,
+                        "startFilePos": 236,
+                        "endLine": 7,
+                        "endTokenPos": 125,
+                        "endFilePos": 257
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 118,
+                          "startFilePos": 236,
+                          "endLine": 7,
+                          "endTokenPos": 118,
+                          "endFilePos": 237
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 122,
+                          "startFilePos": 241,
+                          "endLine": 7,
+                          "endTokenPos": 125,
+                          "endFilePos": 257
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 122,
+                            "startFilePos": 241,
+                            "endLine": 7,
+                            "endTokenPos": 122,
+                            "endFilePos": 251
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 124,
+                              "startFilePos": 253,
+                              "endLine": 7,
+                              "endTokenPos": 124,
+                              "endFilePos": 256
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 124,
+                                "startFilePos": 253,
+                                "endLine": 7,
+                                "endTokenPos": 124,
+                                "endFilePos": 256
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 128,
+                      "startFilePos": 264,
+                      "endLine": 10,
+                      "endTokenPos": 167,
+                      "endFilePos": 358
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 131,
+                        "startFilePos": 268,
+                        "endLine": 8,
+                        "endTokenPos": 138,
+                        "endFilePos": 297
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 132,
+                          "startFilePos": 269,
+                          "endLine": 8,
+                          "endTokenPos": 138,
+                          "endFilePos": 297
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 132,
+                            "startFilePos": 269,
+                            "endLine": 8,
+                            "endTokenPos": 132,
+                            "endFilePos": 284
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 134,
+                              "startFilePos": 286,
+                              "endLine": 8,
+                              "endTokenPos": 134,
+                              "endFilePos": 287
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 134,
+                                "startFilePos": 286,
+                                "endLine": 8,
+                                "endTokenPos": 134,
+                                "endFilePos": 287
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 137,
+                              "startFilePos": 290,
+                              "endLine": 8,
+                              "endTokenPos": 137,
+                              "endFilePos": 296
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 137,
+                                "startFilePos": 290,
+                                "endLine": 8,
+                                "endTokenPos": 137,
+                                "endFilePos": 296
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 143,
+                          "startFilePos": 308,
+                          "endLine": 9,
+                          "endTokenPos": 165,
+                          "endFilePos": 352
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 143,
+                            "startFilePos": 308,
+                            "endLine": 9,
+                            "endTokenPos": 164,
+                            "endFilePos": 351
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 143,
+                              "startFilePos": 308,
+                              "endLine": 9,
+                              "endTokenPos": 146,
+                              "endFilePos": 318
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 143,
+                                "startFilePos": 308,
+                                "endLine": 9,
+                                "endTokenPos": 143,
+                                "endFilePos": 314
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 145,
+                                "startFilePos": 316,
+                                "endLine": 9,
+                                "endTokenPos": 145,
+                                "endFilePos": 317
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 150,
+                              "startFilePos": 322,
+                              "endLine": 9,
+                              "endTokenPos": 164,
+                              "endFilePos": 351,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 151,
+                                  "startFilePos": 323,
+                                  "endLine": 9,
+                                  "endTokenPos": 155,
+                                  "endFilePos": 335
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 151,
+                                    "startFilePos": 323,
+                                    "endLine": 9,
+                                    "endTokenPos": 151,
+                                    "endFilePos": 327,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 155,
+                                    "startFilePos": 332,
+                                    "endLine": 9,
+                                    "endTokenPos": 155,
+                                    "endFilePos": 335
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 158,
+                                  "startFilePos": 338,
+                                  "endLine": 9,
+                                  "endTokenPos": 163,
+                                  "endFilePos": 350
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 158,
+                                    "startFilePos": 338,
+                                    "endLine": 9,
+                                    "endTokenPos": 158,
+                                    "endFilePos": 344,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 162,
+                                    "startFilePos": 349,
+                                    "endLine": 9,
+                                    "endTokenPos": 163,
+                                    "endFilePos": 350,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 169,
+                      "startFilePos": 364,
+                      "endLine": 11,
+                      "endTokenPos": 182,
+                      "endFilePos": 391
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 169,
+                        "startFilePos": 364,
+                        "endLine": 11,
+                        "endTokenPos": 181,
+                        "endFilePos": 390
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 169,
+                          "startFilePos": 364,
+                          "endLine": 11,
+                          "endTokenPos": 177,
+                          "endFilePos": 385
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 169,
+                            "startFilePos": 364,
+                            "endLine": 11,
+                            "endTokenPos": 175,
+                            "endFilePos": 383
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 169,
+                              "startFilePos": 364,
+                              "endLine": 11,
+                              "endTokenPos": 172,
+                              "endFilePos": 374
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 169,
+                                "startFilePos": 364,
+                                "endLine": 11,
+                                "endTokenPos": 169,
+                                "endFilePos": 370
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 171,
+                                "startFilePos": 372,
+                                "endLine": 11,
+                                "endTokenPos": 171,
+                                "endFilePos": 373
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 174,
+                              "startFilePos": 376,
+                              "endLine": 11,
+                              "endTokenPos": 174,
+                              "endFilePos": 382,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 181,
+                          "startFilePos": 389,
+                          "endLine": 11,
+                          "endTokenPos": 181,
+                          "endFilePos": 390
+                        },
+                        "name": "i"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 186,
+                  "startFilePos": 399,
+                  "endLine": 13,
+                  "endTokenPos": 192,
+                  "endFilePos": 411
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 186,
+                    "startFilePos": 399,
+                    "endLine": 13,
+                    "endTokenPos": 191,
+                    "endFilePos": 410
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 186,
+                      "startFilePos": 399,
+                      "endLine": 13,
+                      "endTokenPos": 186,
+                      "endFilePos": 405
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 190,
+                      "startFilePos": 409,
+                      "endLine": 13,
+                      "endTokenPos": 191,
+                      "endFilePos": 410,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 194,
+                  "startFilePos": 415,
+                  "endLine": 28,
+                  "endTokenPos": 365,
+                  "endFilePos": 779
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 197,
+                    "startFilePos": 424,
+                    "endLine": 14,
+                    "endTokenPos": 197,
+                    "endFilePos": 430
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 201,
+                    "startFilePos": 435,
+                    "endLine": 14,
+                    "endTokenPos": 201,
+                    "endFilePos": 436
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 206,
+                      "startFilePos": 447,
+                      "endLine": 27,
+                      "endTokenPos": 363,
+                      "endFilePos": 775
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 206,
+                        "startFilePos": 447,
+                        "endLine": 27,
+                        "endTokenPos": 362,
+                        "endFilePos": 774
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 206,
+                          "startFilePos": 447,
+                          "endLine": 15,
+                          "endTokenPos": 208,
+                          "endFilePos": 455
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 206,
+                            "startFilePos": 447,
+                            "endLine": 15,
+                            "endTokenPos": 206,
+                            "endFilePos": 453
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 212,
+                          "startFilePos": 459,
+                          "endLine": 27,
+                          "endTokenPos": 362,
+                          "endFilePos": 774,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 213,
+                              "startFilePos": 460,
+                              "endLine": 21,
+                              "endTokenPos": 278,
+                              "endFilePos": 599
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_UnaryMinus",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 213,
+                                "startFilePos": 460,
+                                "endLine": 21,
+                                "endTokenPos": 278,
+                                "endFilePos": 599
+                              },
+                              "expr": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 214,
+                                  "startFilePos": 461,
+                                  "endLine": 21,
+                                  "endTokenPos": 278,
+                                  "endFilePos": 599
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 214,
+                                    "startFilePos": 461,
+                                    "endLine": 15,
+                                    "endTokenPos": 214,
+                                    "endFilePos": 469
+                                  },
+                                  "name": "array_sum"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 216,
+                                      "startFilePos": 471,
+                                      "endLine": 21,
+                                      "endTokenPos": 277,
+                                      "endFilePos": 598
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 216,
+                                        "startFilePos": 471,
+                                        "endLine": 21,
+                                        "endTokenPos": 277,
+                                        "endFilePos": 598
+                                      },
+                                      "name": {
+                                        "nodeType": "Expr_Closure",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 217,
+                                          "startFilePos": 472,
+                                          "endLine": 21,
+                                          "endTokenPos": 274,
+                                          "endFilePos": 595
+                                        },
+                                        "static": false,
+                                        "byRef": false,
+                                        "params": [],
+                                        "uses": [
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 224,
+                                              "startFilePos": 488,
+                                              "endLine": 15,
+                                              "endTokenPos": 224,
+                                              "endFilePos": 489
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 224,
+                                                "startFilePos": 488,
+                                                "endLine": 15,
+                                                "endTokenPos": 224,
+                                                "endFilePos": 489
+                                              },
+                                              "name": "i"
+                                            },
+                                            "byRef": false
+                                          },
+                                          {
+                                            "nodeType": "ClosureUse",
+                                            "attributes": {
+                                              "startLine": 15,
+                                              "startTokenPos": 227,
+                                              "startFilePos": 492,
+                                              "endLine": 15,
+                                              "endTokenPos": 227,
+                                              "endFilePos": 493
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 15,
+                                                "startTokenPos": 227,
+                                                "startFilePos": 492,
+                                                "endLine": 15,
+                                                "endTokenPos": 227,
+                                                "endFilePos": 493
+                                              },
+                                              "name": "g"
+                                            },
+                                            "byRef": false
+                                          }
+                                        ],
+                                        "returnType": null,
+                                        "stmts": [
+                                          {
+                                            "nodeType": "Stmt_Expression",
+                                            "attributes": {
+                                              "startLine": 16,
+                                              "startTokenPos": 232,
+                                              "startFilePos": 500,
+                                              "endLine": 16,
+                                              "endTokenPos": 238,
+                                              "endFilePos": 512
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Assign",
+                                              "attributes": {
+                                                "startLine": 16,
+                                                "startTokenPos": 232,
+                                                "startFilePos": 500,
+                                                "endLine": 16,
+                                                "endTokenPos": 237,
+                                                "endFilePos": 511
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 16,
+                                                  "startTokenPos": 232,
+                                                  "startFilePos": 500,
+                                                  "endLine": 16,
+                                                  "endTokenPos": 232,
+                                                  "endFilePos": 506
+                                                },
+                                                "name": "result"
+                                              },
+                                              "expr": {
+                                                "nodeType": "Expr_Array",
+                                                "attributes": {
+                                                  "startLine": 16,
+                                                  "startTokenPos": 236,
+                                                  "startFilePos": 510,
+                                                  "endLine": 16,
+                                                  "endTokenPos": 237,
+                                                  "endFilePos": 511,
+                                                  "kind": 2
+                                                },
+                                                "items": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Foreach",
+                                            "attributes": {
+                                              "startLine": 17,
+                                              "startTokenPos": 240,
+                                              "startFilePos": 516,
+                                              "endLine": 19,
+                                              "endTokenPos": 267,
+                                              "endFilePos": 575
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 243,
+                                                "startFilePos": 525,
+                                                "endLine": 17,
+                                                "endTokenPos": 246,
+                                                "endFilePos": 535
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 243,
+                                                  "startFilePos": 525,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 243,
+                                                  "endFilePos": 526
+                                                },
+                                                "name": "g"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 17,
+                                                  "startTokenPos": 245,
+                                                  "startFilePos": 528,
+                                                  "endLine": 17,
+                                                  "endTokenPos": 245,
+                                                  "endFilePos": 534,
+                                                  "kind": 2,
+                                                  "rawValue": "\"items\""
+                                                },
+                                                "value": "items"
+                                              }
+                                            },
+                                            "keyVar": null,
+                                            "byRef": false,
+                                            "valueVar": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 17,
+                                                "startTokenPos": 250,
+                                                "startFilePos": 540,
+                                                "endLine": 17,
+                                                "endTokenPos": 250,
+                                                "endFilePos": 541
+                                              },
+                                              "name": "x"
+                                            },
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 18,
+                                                  "startTokenPos": 255,
+                                                  "startFilePos": 550,
+                                                  "endLine": 18,
+                                                  "endTokenPos": 265,
+                                                  "endFilePos": 571
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 18,
+                                                    "startTokenPos": 255,
+                                                    "startFilePos": 550,
+                                                    "endLine": 18,
+                                                    "endTokenPos": 264,
+                                                    "endFilePos": 570
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 18,
+                                                      "startTokenPos": 255,
+                                                      "startFilePos": 550,
+                                                      "endLine": 18,
+                                                      "endTokenPos": 257,
+                                                      "endFilePos": 558
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 255,
+                                                        "startFilePos": 550,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 255,
+                                                        "endFilePos": 556
+                                                      },
+                                                      "name": "result"
+                                                    },
+                                                    "dim": null
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 18,
+                                                      "startTokenPos": 261,
+                                                      "startFilePos": 562,
+                                                      "endLine": 18,
+                                                      "endTokenPos": 264,
+                                                      "endFilePos": 570
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 261,
+                                                        "startFilePos": 562,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 261,
+                                                        "endFilePos": 563
+                                                      },
+                                                      "name": "x"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 18,
+                                                        "startTokenPos": 263,
+                                                        "startFilePos": 565,
+                                                        "endLine": 18,
+                                                        "endTokenPos": 263,
+                                                        "endFilePos": 569,
+                                                        "kind": 2,
+                                                        "rawValue": "\"val\""
+                                                      },
+                                                      "value": "val"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "nodeType": "Stmt_Return",
+                                            "attributes": {
+                                              "startLine": 20,
+                                              "startTokenPos": 269,
+                                              "startFilePos": 579,
+                                              "endLine": 20,
+                                              "endTokenPos": 272,
+                                              "endFilePos": 593
+                                            },
+                                            "expr": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 20,
+                                                "startTokenPos": 271,
+                                                "startFilePos": 586,
+                                                "endLine": 20,
+                                                "endTokenPos": 271,
+                                                "endFilePos": 592
+                                              },
+                                              "name": "result"
+                                            }
+                                          }
+                                        ],
+                                        "attrGroups": []
+                                      },
+                                      "args": []
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 281,
+                              "startFilePos": 602,
+                              "endLine": 27,
+                              "endTokenPos": 361,
+                              "endFilePos": 773
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 281,
+                                "startFilePos": 602,
+                                "endLine": 27,
+                                "endTokenPos": 361,
+                                "endFilePos": 773,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 282,
+                                    "startFilePos": 603,
+                                    "endLine": 21,
+                                    "endTokenPos": 289,
+                                    "endFilePos": 620
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 282,
+                                      "startFilePos": 603,
+                                      "endLine": 21,
+                                      "endTokenPos": 282,
+                                      "endFilePos": 607,
+                                      "kind": 2,
+                                      "rawValue": "\"cat\""
+                                    },
+                                    "value": "cat"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 286,
+                                      "startFilePos": 612,
+                                      "endLine": 21,
+                                      "endTokenPos": 289,
+                                      "endFilePos": 620
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 286,
+                                        "startFilePos": 612,
+                                        "endLine": 21,
+                                        "endTokenPos": 286,
+                                        "endFilePos": 613
+                                      },
+                                      "name": "g"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 288,
+                                        "startFilePos": 615,
+                                        "endLine": 21,
+                                        "endTokenPos": 288,
+                                        "endFilePos": 619,
+                                        "kind": 2,
+                                        "rawValue": "\"key\""
+                                      },
+                                      "value": "key"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 21,
+                                    "startTokenPos": 292,
+                                    "startFilePos": 623,
+                                    "endLine": 27,
+                                    "endTokenPos": 360,
+                                    "endFilePos": 772
+                                  },
+                                  "key": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 292,
+                                      "startFilePos": 623,
+                                      "endLine": 21,
+                                      "endTokenPos": 292,
+                                      "endFilePos": 629,
+                                      "kind": 2,
+                                      "rawValue": "\"total\""
+                                    },
+                                    "value": "total"
+                                  },
+                                  "value": {
+                                    "nodeType": "Expr_FuncCall",
+                                    "attributes": {
+                                      "startLine": 21,
+                                      "startTokenPos": 296,
+                                      "startFilePos": 634,
+                                      "endLine": 27,
+                                      "endTokenPos": 360,
+                                      "endFilePos": 772
+                                    },
+                                    "name": {
+                                      "nodeType": "Name",
+                                      "attributes": {
+                                        "startLine": 21,
+                                        "startTokenPos": 296,
+                                        "startFilePos": 634,
+                                        "endLine": 21,
+                                        "endTokenPos": 296,
+                                        "endFilePos": 642
+                                      },
+                                      "name": "array_sum"
+                                    },
+                                    "args": [
+                                      {
+                                        "nodeType": "Arg",
+                                        "attributes": {
+                                          "startLine": 21,
+                                          "startTokenPos": 298,
+                                          "startFilePos": 644,
+                                          "endLine": 27,
+                                          "endTokenPos": 359,
+                                          "endFilePos": 771
+                                        },
+                                        "name": null,
+                                        "value": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 21,
+                                            "startTokenPos": 298,
+                                            "startFilePos": 644,
+                                            "endLine": 27,
+                                            "endTokenPos": 359,
+                                            "endFilePos": 771
+                                          },
+                                          "name": {
+                                            "nodeType": "Expr_Closure",
+                                            "attributes": {
+                                              "startLine": 21,
+                                              "startTokenPos": 299,
+                                              "startFilePos": 645,
+                                              "endLine": 27,
+                                              "endTokenPos": 356,
+                                              "endFilePos": 768
+                                            },
+                                            "static": false,
+                                            "byRef": false,
+                                            "params": [],
+                                            "uses": [
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 21,
+                                                  "startTokenPos": 306,
+                                                  "startFilePos": 661,
+                                                  "endLine": 21,
+                                                  "endTokenPos": 306,
+                                                  "endFilePos": 662
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 21,
+                                                    "startTokenPos": 306,
+                                                    "startFilePos": 661,
+                                                    "endLine": 21,
+                                                    "endTokenPos": 306,
+                                                    "endFilePos": 662
+                                                  },
+                                                  "name": "i"
+                                                },
+                                                "byRef": false
+                                              },
+                                              {
+                                                "nodeType": "ClosureUse",
+                                                "attributes": {
+                                                  "startLine": 21,
+                                                  "startTokenPos": 309,
+                                                  "startFilePos": 665,
+                                                  "endLine": 21,
+                                                  "endTokenPos": 309,
+                                                  "endFilePos": 666
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 21,
+                                                    "startTokenPos": 309,
+                                                    "startFilePos": 665,
+                                                    "endLine": 21,
+                                                    "endTokenPos": 309,
+                                                    "endFilePos": 666
+                                                  },
+                                                  "name": "g"
+                                                },
+                                                "byRef": false
+                                              }
+                                            ],
+                                            "returnType": null,
+                                            "stmts": [
+                                              {
+                                                "nodeType": "Stmt_Expression",
+                                                "attributes": {
+                                                  "startLine": 22,
+                                                  "startTokenPos": 314,
+                                                  "startFilePos": 673,
+                                                  "endLine": 22,
+                                                  "endTokenPos": 320,
+                                                  "endFilePos": 685
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Assign",
+                                                  "attributes": {
+                                                    "startLine": 22,
+                                                    "startTokenPos": 314,
+                                                    "startFilePos": 673,
+                                                    "endLine": 22,
+                                                    "endTokenPos": 319,
+                                                    "endFilePos": 684
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 22,
+                                                      "startTokenPos": 314,
+                                                      "startFilePos": 673,
+                                                      "endLine": 22,
+                                                      "endTokenPos": 314,
+                                                      "endFilePos": 679
+                                                    },
+                                                    "name": "result"
+                                                  },
+                                                  "expr": {
+                                                    "nodeType": "Expr_Array",
+                                                    "attributes": {
+                                                      "startLine": 22,
+                                                      "startTokenPos": 318,
+                                                      "startFilePos": 683,
+                                                      "endLine": 22,
+                                                      "endTokenPos": 319,
+                                                      "endFilePos": 684,
+                                                      "kind": 2
+                                                    },
+                                                    "items": []
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "nodeType": "Stmt_Foreach",
+                                                "attributes": {
+                                                  "startLine": 23,
+                                                  "startTokenPos": 322,
+                                                  "startFilePos": 689,
+                                                  "endLine": 25,
+                                                  "endTokenPos": 349,
+                                                  "endFilePos": 748
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 23,
+                                                    "startTokenPos": 325,
+                                                    "startFilePos": 698,
+                                                    "endLine": 23,
+                                                    "endTokenPos": 328,
+                                                    "endFilePos": 708
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 23,
+                                                      "startTokenPos": 325,
+                                                      "startFilePos": 698,
+                                                      "endLine": 23,
+                                                      "endTokenPos": 325,
+                                                      "endFilePos": 699
+                                                    },
+                                                    "name": "g"
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 23,
+                                                      "startTokenPos": 327,
+                                                      "startFilePos": 701,
+                                                      "endLine": 23,
+                                                      "endTokenPos": 327,
+                                                      "endFilePos": 707,
+                                                      "kind": 2,
+                                                      "rawValue": "\"items\""
+                                                    },
+                                                    "value": "items"
+                                                  }
+                                                },
+                                                "keyVar": null,
+                                                "byRef": false,
+                                                "valueVar": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 23,
+                                                    "startTokenPos": 332,
+                                                    "startFilePos": 713,
+                                                    "endLine": 23,
+                                                    "endTokenPos": 332,
+                                                    "endFilePos": 714
+                                                  },
+                                                  "name": "x"
+                                                },
+                                                "stmts": [
+                                                  {
+                                                    "nodeType": "Stmt_Expression",
+                                                    "attributes": {
+                                                      "startLine": 24,
+                                                      "startTokenPos": 337,
+                                                      "startFilePos": 723,
+                                                      "endLine": 24,
+                                                      "endTokenPos": 347,
+                                                      "endFilePos": 744
+                                                    },
+                                                    "expr": {
+                                                      "nodeType": "Expr_Assign",
+                                                      "attributes": {
+                                                        "startLine": 24,
+                                                        "startTokenPos": 337,
+                                                        "startFilePos": 723,
+                                                        "endLine": 24,
+                                                        "endTokenPos": 346,
+                                                        "endFilePos": 743
+                                                      },
+                                                      "var": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 24,
+                                                          "startTokenPos": 337,
+                                                          "startFilePos": 723,
+                                                          "endLine": 24,
+                                                          "endTokenPos": 339,
+                                                          "endFilePos": 731
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_Variable",
+                                                          "attributes": {
+                                                            "startLine": 24,
+                                                            "startTokenPos": 337,
+                                                            "startFilePos": 723,
+                                                            "endLine": 24,
+                                                            "endTokenPos": 337,
+                                                            "endFilePos": 729
+                                                          },
+                                                          "name": "result"
+                                                        },
+                                                        "dim": null
+                                                      },
+                                                      "expr": {
+                                                        "nodeType": "Expr_ArrayDimFetch",
+                                                        "attributes": {
+                                                          "startLine": 24,
+                                                          "startTokenPos": 343,
+                                                          "startFilePos": 735,
+                                                          "endLine": 24,
+                                                          "endTokenPos": 346,
+                                                          "endFilePos": 743
+                                                        },
+                                                        "var": {
+                                                          "nodeType": "Expr_Variable",
+                                                          "attributes": {
+                                                            "startLine": 24,
+                                                            "startTokenPos": 343,
+                                                            "startFilePos": 735,
+                                                            "endLine": 24,
+                                                            "endTokenPos": 343,
+                                                            "endFilePos": 736
+                                                          },
+                                                          "name": "x"
+                                                        },
+                                                        "dim": {
+                                                          "nodeType": "Scalar_String",
+                                                          "attributes": {
+                                                            "startLine": 24,
+                                                            "startTokenPos": 345,
+                                                            "startFilePos": 738,
+                                                            "endLine": 24,
+                                                            "endTokenPos": 345,
+                                                            "endFilePos": 742,
+                                                            "kind": 2,
+                                                            "rawValue": "\"val\""
+                                                          },
+                                                          "value": "val"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "nodeType": "Stmt_Return",
+                                                "attributes": {
+                                                  "startLine": 26,
+                                                  "startTokenPos": 351,
+                                                  "startFilePos": 752,
+                                                  "endLine": 26,
+                                                  "endTokenPos": 354,
+                                                  "endFilePos": 766
+                                                },
+                                                "expr": {
+                                                  "nodeType": "Expr_Variable",
+                                                  "attributes": {
+                                                    "startLine": 26,
+                                                    "startTokenPos": 353,
+                                                    "startFilePos": 759,
+                                                    "endLine": 26,
+                                                    "endTokenPos": 353,
+                                                    "endFilePos": 765
+                                                  },
+                                                  "name": "result"
+                                                }
+                                              }
+                                            ],
+                                            "attrGroups": []
+                                          },
+                                          "args": []
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      }
+                                    ]
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 367,
+                  "startFilePos": 783,
+                  "endLine": 29,
+                  "endTokenPos": 399,
+                  "endFilePos": 843
+                },
+                "expr": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 29,
+                    "startTokenPos": 367,
+                    "startFilePos": 783,
+                    "endLine": 29,
+                    "endTokenPos": 398,
+                    "endFilePos": 842
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 29,
+                      "startTokenPos": 367,
+                      "startFilePos": 783,
+                      "endLine": 29,
+                      "endTokenPos": 367,
+                      "endFilePos": 787
+                    },
+                    "name": "usort"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 29,
+                        "startTokenPos": 369,
+                        "startFilePos": 789,
+                        "endLine": 29,
+                        "endTokenPos": 369,
+                        "endFilePos": 795
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 29,
+                          "startTokenPos": 369,
+                          "startFilePos": 789,
+                          "endLine": 29,
+                          "endTokenPos": 369,
+                          "endFilePos": 795
+                        },
+                        "name": "result"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 29,
+                        "startTokenPos": 372,
+                        "startFilePos": 798,
+                        "endLine": 29,
+                        "endTokenPos": 397,
+                        "endFilePos": 841
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Closure",
+                        "attributes": {
+                          "startLine": 29,
+                          "startTokenPos": 372,
+                          "startFilePos": 798,
+                          "endLine": 29,
+                          "endTokenPos": 397,
+                          "endFilePos": 841
+                        },
+                        "static": false,
+                        "byRef": false,
+                        "params": [
+                          {
+                            "nodeType": "Param",
+                            "attributes": {
+                              "startLine": 29,
+                              "startTokenPos": 374,
+                              "startFilePos": 807,
+                              "endLine": 29,
+                              "endTokenPos": 374,
+                              "endFilePos": 808
+                            },
+                            "type": null,
+                            "byRef": false,
+                            "variadic": false,
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 29,
+                                "startTokenPos": 374,
+                                "startFilePos": 807,
+                                "endLine": 29,
+                                "endTokenPos": 374,
+                                "endFilePos": 808
+                              },
+                              "name": "a"
+                            },
+                            "default": null,
+                            "flags": 0,
+                            "attrGroups": [],
+                            "hooks": []
+                          },
+                          {
+                            "nodeType": "Param",
+                            "attributes": {
+                              "startLine": 29,
+                              "startTokenPos": 377,
+                              "startFilePos": 811,
+                              "endLine": 29,
+                              "endTokenPos": 377,
+                              "endFilePos": 812
+                            },
+                            "type": null,
+                            "byRef": false,
+                            "variadic": false,
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 29,
+                                "startTokenPos": 377,
+                                "startFilePos": 811,
+                                "endLine": 29,
+                                "endTokenPos": 377,
+                                "endFilePos": 812
+                              },
+                              "name": "b"
+                            },
+                            "default": null,
+                            "flags": 0,
+                            "attrGroups": [],
+                            "hooks": []
+                          }
+                        ],
+                        "uses": [],
+                        "returnType": null,
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Return",
+                            "attributes": {
+                              "startLine": 29,
+                              "startTokenPos": 382,
+                              "startFilePos": 817,
+                              "endLine": 29,
+                              "endTokenPos": 395,
+                              "endFilePos": 839
+                            },
+                            "expr": {
+                              "nodeType": "Expr_BinaryOp_Spaceship",
+                              "attributes": {
+                                "startLine": 29,
+                                "startTokenPos": 384,
+                                "startFilePos": 824,
+                                "endLine": 29,
+                                "endTokenPos": 394,
+                                "endFilePos": 838
+                              },
+                              "left": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 29,
+                                  "startTokenPos": 384,
+                                  "startFilePos": 824,
+                                  "endLine": 29,
+                                  "endTokenPos": 387,
+                                  "endFilePos": 828
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 384,
+                                    "startFilePos": 824,
+                                    "endLine": 29,
+                                    "endTokenPos": 384,
+                                    "endFilePos": 825
+                                  },
+                                  "name": "a"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 386,
+                                    "startFilePos": 827,
+                                    "endLine": 29,
+                                    "endTokenPos": 386,
+                                    "endFilePos": 827,
+                                    "rawValue": "0",
+                                    "kind": 10
+                                  },
+                                  "value": 0
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 29,
+                                  "startTokenPos": 391,
+                                  "startFilePos": 834,
+                                  "endLine": 29,
+                                  "endTokenPos": 394,
+                                  "endFilePos": 838
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 391,
+                                    "startFilePos": 834,
+                                    "endLine": 29,
+                                    "endTokenPos": 391,
+                                    "endFilePos": 835
+                                  },
+                                  "name": "b"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 29,
+                                    "startTokenPos": 393,
+                                    "startFilePos": 837,
+                                    "endLine": 29,
+                                    "endTokenPos": 393,
+                                    "endFilePos": 837,
+                                    "rawValue": "0",
+                                    "kind": 10
+                                  },
+                                  "value": 0
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "attrGroups": []
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 30,
+                  "startTokenPos": 401,
+                  "startFilePos": 847,
+                  "endLine": 30,
+                  "endTokenPos": 422,
+                  "endFilePos": 892
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 30,
+                    "startTokenPos": 401,
+                    "startFilePos": 847,
+                    "endLine": 30,
+                    "endTokenPos": 421,
+                    "endFilePos": 891
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 30,
+                      "startTokenPos": 401,
+                      "startFilePos": 847,
+                      "endLine": 30,
+                      "endTokenPos": 401,
+                      "endFilePos": 853
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 30,
+                      "startTokenPos": 405,
+                      "startFilePos": 857,
+                      "endLine": 30,
+                      "endTokenPos": 421,
+                      "endFilePos": 891
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 30,
+                        "startTokenPos": 405,
+                        "startFilePos": 857,
+                        "endLine": 30,
+                        "endTokenPos": 405,
+                        "endFilePos": 865
+                      },
+                      "name": "array_map"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 30,
+                          "startTokenPos": 407,
+                          "startFilePos": 867,
+                          "endLine": 30,
+                          "endTokenPos": 417,
+                          "endFilePos": 881
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrowFunction",
+                          "attributes": {
+                            "startLine": 30,
+                            "startTokenPos": 407,
+                            "startFilePos": 867,
+                            "endLine": 30,
+                            "endTokenPos": 417,
+                            "endFilePos": 881
+                          },
+                          "static": false,
+                          "byRef": false,
+                          "params": [
+                            {
+                              "nodeType": "Param",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 409,
+                                "startFilePos": 870,
+                                "endLine": 30,
+                                "endTokenPos": 409,
+                                "endFilePos": 871
+                              },
+                              "type": null,
+                              "byRef": false,
+                              "variadic": false,
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 30,
+                                  "startTokenPos": 409,
+                                  "startFilePos": 870,
+                                  "endLine": 30,
+                                  "endTokenPos": 409,
+                                  "endFilePos": 871
+                                },
+                                "name": "r"
+                              },
+                              "default": null,
+                              "flags": 0,
+                              "attrGroups": [],
+                              "hooks": []
+                            }
+                          ],
+                          "returnType": null,
+                          "expr": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 30,
+                              "startTokenPos": 414,
+                              "startFilePos": 877,
+                              "endLine": 30,
+                              "endTokenPos": 417,
+                              "endFilePos": 881
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 414,
+                                "startFilePos": 877,
+                                "endLine": 30,
+                                "endTokenPos": 414,
+                                "endFilePos": 878
+                              },
+                              "name": "r"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 30,
+                                "startTokenPos": 416,
+                                "startFilePos": 880,
+                                "endLine": 30,
+                                "endTokenPos": 416,
+                                "endFilePos": 880,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            }
+                          },
+                          "attrGroups": []
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 30,
+                          "startTokenPos": 420,
+                          "startFilePos": 884,
+                          "endLine": 30,
+                          "endTokenPos": 420,
+                          "endFilePos": 890
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 30,
+                            "startTokenPos": 420,
+                            "startFilePos": 884,
+                            "endLine": 30,
+                            "endTokenPos": 420,
+                            "endFilePos": 890
+                          },
+                          "name": "result"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 424,
+                  "startFilePos": 896,
+                  "endLine": 31,
+                  "endTokenPos": 427,
+                  "endFilePos": 910
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 31,
+                    "startTokenPos": 426,
+                    "startFilePos": 903,
+                    "endLine": 31,
+                    "endTokenPos": 426,
+                    "endFilePos": 909
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 33,
+        "startTokenPos": 435,
+        "startFilePos": 918,
+        "endLine": 33,
+        "endTokenPos": 492,
+        "endFilePos": 1091
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 33,
+            "startTokenPos": 437,
+            "startFilePos": 923,
+            "endLine": 33,
+            "endTokenPos": 488,
+            "endFilePos": 1081
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 33,
+              "startTokenPos": 437,
+              "startFilePos": 923,
+              "endLine": 33,
+              "endTokenPos": 437,
+              "endFilePos": 933
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 439,
+                "startFilePos": 935,
+                "endLine": 33,
+                "endTokenPos": 439,
+                "endFilePos": 941
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 439,
+                  "startFilePos": 935,
+                  "endLine": 33,
+                  "endTokenPos": 439,
+                  "endFilePos": 941,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 442,
+                "startFilePos": 944,
+                "endLine": 33,
+                "endTokenPos": 442,
+                "endFilePos": 950
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 442,
+                  "startFilePos": 944,
+                  "endLine": 33,
+                  "endTokenPos": 442,
+                  "endFilePos": 950,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 33,
+                "startTokenPos": 445,
+                "startFilePos": 953,
+                "endLine": 33,
+                "endTokenPos": 487,
+                "endFilePos": 1080
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 33,
+                  "startTokenPos": 445,
+                  "startFilePos": 953,
+                  "endLine": 33,
+                  "endTokenPos": 487,
+                  "endFilePos": 1080
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 33,
+                    "startTokenPos": 445,
+                    "startFilePos": 953,
+                    "endLine": 33,
+                    "endTokenPos": 445,
+                    "endFilePos": 963
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 447,
+                      "startFilePos": 965,
+                      "endLine": 33,
+                      "endTokenPos": 447,
+                      "endFilePos": 970
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 447,
+                        "startFilePos": 965,
+                        "endLine": 33,
+                        "endTokenPos": 447,
+                        "endFilePos": 970,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 450,
+                      "startFilePos": 973,
+                      "endLine": 33,
+                      "endTokenPos": 450,
+                      "endFilePos": 978
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 450,
+                        "startFilePos": 973,
+                        "endLine": 33,
+                        "endTokenPos": 450,
+                        "endFilePos": 978,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 33,
+                      "startTokenPos": 453,
+                      "startFilePos": 981,
+                      "endLine": 33,
+                      "endTokenPos": 486,
+                      "endFilePos": 1079
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 33,
+                        "startTokenPos": 453,
+                        "startFilePos": 981,
+                        "endLine": 33,
+                        "endTokenPos": 486,
+                        "endFilePos": 1079
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 33,
+                          "startTokenPos": 453,
+                          "startFilePos": 981,
+                          "endLine": 33,
+                          "endTokenPos": 453,
+                          "endFilePos": 991
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 455,
+                            "startFilePos": 993,
+                            "endLine": 33,
+                            "endTokenPos": 455,
+                            "endFilePos": 996
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 455,
+                              "startFilePos": 993,
+                              "endLine": 33,
+                              "endTokenPos": 455,
+                              "endFilePos": 996,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 458,
+                            "startFilePos": 999,
+                            "endLine": 33,
+                            "endTokenPos": 458,
+                            "endFilePos": 1001
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 458,
+                              "startFilePos": 999,
+                              "endLine": 33,
+                              "endTokenPos": 458,
+                              "endFilePos": 1001,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 33,
+                            "startTokenPos": 461,
+                            "startFilePos": 1004,
+                            "endLine": 33,
+                            "endTokenPos": 485,
+                            "endFilePos": 1078
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 33,
+                              "startTokenPos": 461,
+                              "startFilePos": 1004,
+                              "endLine": 33,
+                              "endTokenPos": 485,
+                              "endFilePos": 1078
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 33,
+                                "startTokenPos": 461,
+                                "startFilePos": 1004,
+                                "endLine": 33,
+                                "endTokenPos": 461,
+                                "endFilePos": 1014
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 463,
+                                  "startFilePos": 1016,
+                                  "endLine": 33,
+                                  "endTokenPos": 463,
+                                  "endFilePos": 1018
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 463,
+                                    "startFilePos": 1016,
+                                    "endLine": 33,
+                                    "endTokenPos": 463,
+                                    "endFilePos": 1018,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 466,
+                                  "startFilePos": 1021,
+                                  "endLine": 33,
+                                  "endTokenPos": 466,
+                                  "endFilePos": 1024
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 466,
+                                    "startFilePos": 1021,
+                                    "endLine": 33,
+                                    "endTokenPos": 466,
+                                    "endFilePos": 1024,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 33,
+                                  "startTokenPos": 469,
+                                  "startFilePos": 1027,
+                                  "endLine": 33,
+                                  "endTokenPos": 484,
+                                  "endFilePos": 1077
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 33,
+                                    "startTokenPos": 469,
+                                    "startFilePos": 1027,
+                                    "endLine": 33,
+                                    "endTokenPos": 484,
+                                    "endFilePos": 1077
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 33,
+                                      "startTokenPos": 469,
+                                      "startFilePos": 1027,
+                                      "endLine": 33,
+                                      "endTokenPos": 469,
+                                      "endFilePos": 1037
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 471,
+                                        "startFilePos": 1039,
+                                        "endLine": 33,
+                                        "endTokenPos": 471,
+                                        "endFilePos": 1041
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 471,
+                                          "startFilePos": 1039,
+                                          "endLine": 33,
+                                          "endTokenPos": 471,
+                                          "endFilePos": 1041,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 474,
+                                        "startFilePos": 1044,
+                                        "endLine": 33,
+                                        "endTokenPos": 474,
+                                        "endFilePos": 1047
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 474,
+                                          "startFilePos": 1044,
+                                          "endLine": 33,
+                                          "endTokenPos": 474,
+                                          "endFilePos": 1047,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 33,
+                                        "startTokenPos": 477,
+                                        "startFilePos": 1050,
+                                        "endLine": 33,
+                                        "endTokenPos": 483,
+                                        "endFilePos": 1076
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 33,
+                                          "startTokenPos": 477,
+                                          "startFilePos": 1050,
+                                          "endLine": 33,
+                                          "endTokenPos": 483,
+                                          "endFilePos": 1076
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 33,
+                                            "startTokenPos": 477,
+                                            "startFilePos": 1050,
+                                            "endLine": 33,
+                                            "endTokenPos": 477,
+                                            "endFilePos": 1060
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 33,
+                                              "startTokenPos": 479,
+                                              "startFilePos": 1062,
+                                              "endLine": 33,
+                                              "endTokenPos": 479,
+                                              "endFilePos": 1069
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 33,
+                                                "startTokenPos": 479,
+                                                "startFilePos": 1062,
+                                                "endLine": 33,
+                                                "endTokenPos": 479,
+                                                "endFilePos": 1069
+                                              },
+                                              "name": "grouped"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 33,
+                                              "startTokenPos": 482,
+                                              "startFilePos": 1072,
+                                              "endLine": 33,
+                                              "endTokenPos": 482,
+                                              "endFilePos": 1075
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 33,
+                                                "startTokenPos": 482,
+                                                "startFilePos": 1072,
+                                                "endLine": 33,
+                                                "endTokenPos": 482,
+                                                "endFilePos": 1075,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 33,
+            "startTokenPos": 491,
+            "startFilePos": 1084,
+            "endLine": 33,
+            "endTokenPos": 491,
+            "endFilePos": 1090
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 33,
+              "startTokenPos": 491,
+              "startFilePos": 1084,
+              "endLine": 33,
+              "endTokenPos": 491,
+              "endFilePos": 1090
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/group_items_iteration.php.json
+++ b/tests/json-ast/x/php/group_items_iteration.php.json
@@ -1,0 +1,2510 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 53,
+        "endFilePos": 98
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 52,
+          "endFilePos": 97
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "data"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 52,
+            "endFilePos": 97,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 40
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 40,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 16,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 27
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 16,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 20,
+                        "kind": 2,
+                        "rawValue": "\"tag\""
+                      },
+                      "value": "tag"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 25,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 27,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 30,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 39
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 30,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 34,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 39,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 39,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 43,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 68
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 43,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 68,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 44,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 55
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 44,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"tag\""
+                      },
+                      "value": "tag"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 55,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 58,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 67
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 58,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 62,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 67,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 67,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 71,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 96
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 71,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 96,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 72,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 83
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 72,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 76,
+                        "kind": 2,
+                        "rawValue": "\"tag\""
+                      },
+                      "value": "tag"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 81,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 83,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 86,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 95
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 86,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 90,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 95,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 95,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 55,
+        "startFilePos": 100,
+        "endLine": 18,
+        "endTokenPos": 210,
+        "endFilePos": 457
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 55,
+          "startFilePos": 100,
+          "endLine": 18,
+          "endTokenPos": 209,
+          "endFilePos": 456
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 100,
+            "endLine": 3,
+            "endTokenPos": 55,
+            "endFilePos": 106
+          },
+          "name": "groups"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 59,
+            "startFilePos": 110,
+            "endLine": 18,
+            "endTokenPos": 209,
+            "endFilePos": 456
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 60,
+              "startFilePos": 111,
+              "endLine": 18,
+              "endTokenPos": 206,
+              "endFilePos": 453
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 67,
+                  "startFilePos": 127,
+                  "endLine": 3,
+                  "endTokenPos": 67,
+                  "endFilePos": 131
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 67,
+                    "startFilePos": 127,
+                    "endLine": 3,
+                    "endTokenPos": 67,
+                    "endFilePos": 131
+                  },
+                  "name": "data"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 72,
+                  "startFilePos": 138,
+                  "endLine": 4,
+                  "endTokenPos": 78,
+                  "endFilePos": 150
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 72,
+                    "startFilePos": 138,
+                    "endLine": 4,
+                    "endTokenPos": 77,
+                    "endFilePos": 149
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 72,
+                      "startFilePos": 138,
+                      "endLine": 4,
+                      "endTokenPos": 72,
+                      "endFilePos": 144
+                    },
+                    "name": "groups"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 76,
+                      "startFilePos": 148,
+                      "endLine": 4,
+                      "endTokenPos": 77,
+                      "endFilePos": 149,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 80,
+                  "startFilePos": 154,
+                  "endLine": 12,
+                  "endTokenPos": 168,
+                  "endFilePos": 363
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 83,
+                    "startFilePos": 163,
+                    "endLine": 5,
+                    "endTokenPos": 83,
+                    "endFilePos": 167
+                  },
+                  "name": "data"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 87,
+                    "startFilePos": 172,
+                    "endLine": 5,
+                    "endTokenPos": 87,
+                    "endFilePos": 173
+                  },
+                  "name": "d"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 92,
+                      "startFilePos": 182,
+                      "endLine": 6,
+                      "endTokenPos": 100,
+                      "endFilePos": 198
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 92,
+                        "startFilePos": 182,
+                        "endLine": 6,
+                        "endTokenPos": 99,
+                        "endFilePos": 197
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 92,
+                          "startFilePos": 182,
+                          "endLine": 6,
+                          "endTokenPos": 92,
+                          "endFilePos": 185
+                        },
+                        "name": "key"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 96,
+                          "startFilePos": 189,
+                          "endLine": 6,
+                          "endTokenPos": 99,
+                          "endFilePos": 197
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 96,
+                            "startFilePos": 189,
+                            "endLine": 6,
+                            "endTokenPos": 96,
+                            "endFilePos": 190
+                          },
+                          "name": "d"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 98,
+                            "startFilePos": 192,
+                            "endLine": 6,
+                            "endTokenPos": 98,
+                            "endFilePos": 196,
+                            "kind": 2,
+                            "rawValue": "\"tag\""
+                          },
+                          "value": "tag"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 102,
+                      "startFilePos": 204,
+                      "endLine": 7,
+                      "endTokenPos": 110,
+                      "endFilePos": 226
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 102,
+                        "startFilePos": 204,
+                        "endLine": 7,
+                        "endTokenPos": 109,
+                        "endFilePos": 225
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 102,
+                          "startFilePos": 204,
+                          "endLine": 7,
+                          "endTokenPos": 102,
+                          "endFilePos": 205
+                        },
+                        "name": "k"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 106,
+                          "startFilePos": 209,
+                          "endLine": 7,
+                          "endTokenPos": 109,
+                          "endFilePos": 225
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 106,
+                            "startFilePos": 209,
+                            "endLine": 7,
+                            "endTokenPos": 106,
+                            "endFilePos": 219
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 108,
+                              "startFilePos": 221,
+                              "endLine": 7,
+                              "endTokenPos": 108,
+                              "endFilePos": 224
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 108,
+                                "startFilePos": 221,
+                                "endLine": 7,
+                                "endTokenPos": 108,
+                                "endFilePos": 224
+                              },
+                              "name": "key"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 112,
+                      "startFilePos": 232,
+                      "endLine": 10,
+                      "endTokenPos": 151,
+                      "endFilePos": 326
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 115,
+                        "startFilePos": 236,
+                        "endLine": 8,
+                        "endTokenPos": 122,
+                        "endFilePos": 265
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 116,
+                          "startFilePos": 237,
+                          "endLine": 8,
+                          "endTokenPos": 122,
+                          "endFilePos": 265
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 116,
+                            "startFilePos": 237,
+                            "endLine": 8,
+                            "endTokenPos": 116,
+                            "endFilePos": 252
+                          },
+                          "name": "array_key_exists"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 118,
+                              "startFilePos": 254,
+                              "endLine": 8,
+                              "endTokenPos": 118,
+                              "endFilePos": 255
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 118,
+                                "startFilePos": 254,
+                                "endLine": 8,
+                                "endTokenPos": 118,
+                                "endFilePos": 255
+                              },
+                              "name": "k"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 121,
+                              "startFilePos": 258,
+                              "endLine": 8,
+                              "endTokenPos": 121,
+                              "endFilePos": 264
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 121,
+                                "startFilePos": 258,
+                                "endLine": 8,
+                                "endTokenPos": 121,
+                                "endFilePos": 264
+                              },
+                              "name": "groups"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 127,
+                          "startFilePos": 276,
+                          "endLine": 9,
+                          "endTokenPos": 149,
+                          "endFilePos": 320
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 127,
+                            "startFilePos": 276,
+                            "endLine": 9,
+                            "endTokenPos": 148,
+                            "endFilePos": 319
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 127,
+                              "startFilePos": 276,
+                              "endLine": 9,
+                              "endTokenPos": 130,
+                              "endFilePos": 286
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 127,
+                                "startFilePos": 276,
+                                "endLine": 9,
+                                "endTokenPos": 127,
+                                "endFilePos": 282
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 129,
+                                "startFilePos": 284,
+                                "endLine": 9,
+                                "endTokenPos": 129,
+                                "endFilePos": 285
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 134,
+                              "startFilePos": 290,
+                              "endLine": 9,
+                              "endTokenPos": 148,
+                              "endFilePos": 319,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 135,
+                                  "startFilePos": 291,
+                                  "endLine": 9,
+                                  "endTokenPos": 139,
+                                  "endFilePos": 303
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 135,
+                                    "startFilePos": 291,
+                                    "endLine": 9,
+                                    "endTokenPos": 135,
+                                    "endFilePos": 295,
+                                    "kind": 1,
+                                    "rawValue": "'key'"
+                                  },
+                                  "value": "key"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 139,
+                                    "startFilePos": 300,
+                                    "endLine": 9,
+                                    "endTokenPos": 139,
+                                    "endFilePos": 303
+                                  },
+                                  "name": "key"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 142,
+                                  "startFilePos": 306,
+                                  "endLine": 9,
+                                  "endTokenPos": 147,
+                                  "endFilePos": 318
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 142,
+                                    "startFilePos": 306,
+                                    "endLine": 9,
+                                    "endTokenPos": 142,
+                                    "endFilePos": 312,
+                                    "kind": 1,
+                                    "rawValue": "'items'"
+                                  },
+                                  "value": "items"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Array",
+                                  "attributes": {
+                                    "startLine": 9,
+                                    "startTokenPos": 146,
+                                    "startFilePos": 317,
+                                    "endLine": 9,
+                                    "endTokenPos": 147,
+                                    "endFilePos": 318,
+                                    "kind": 2
+                                  },
+                                  "items": []
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 153,
+                      "startFilePos": 332,
+                      "endLine": 11,
+                      "endTokenPos": 166,
+                      "endFilePos": 359
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 153,
+                        "startFilePos": 332,
+                        "endLine": 11,
+                        "endTokenPos": 165,
+                        "endFilePos": 358
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 153,
+                          "startFilePos": 332,
+                          "endLine": 11,
+                          "endTokenPos": 161,
+                          "endFilePos": 353
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 153,
+                            "startFilePos": 332,
+                            "endLine": 11,
+                            "endTokenPos": 159,
+                            "endFilePos": 351
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 153,
+                              "startFilePos": 332,
+                              "endLine": 11,
+                              "endTokenPos": 156,
+                              "endFilePos": 342
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 153,
+                                "startFilePos": 332,
+                                "endLine": 11,
+                                "endTokenPos": 153,
+                                "endFilePos": 338
+                              },
+                              "name": "groups"
+                            },
+                            "dim": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 155,
+                                "startFilePos": 340,
+                                "endLine": 11,
+                                "endTokenPos": 155,
+                                "endFilePos": 341
+                              },
+                              "name": "k"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 158,
+                              "startFilePos": 344,
+                              "endLine": 11,
+                              "endTokenPos": 158,
+                              "endFilePos": 350,
+                              "kind": 1,
+                              "rawValue": "'items'"
+                            },
+                            "value": "items"
+                          }
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 165,
+                          "startFilePos": 357,
+                          "endLine": 11,
+                          "endTokenPos": 165,
+                          "endFilePos": 358
+                        },
+                        "name": "d"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 170,
+                  "startFilePos": 367,
+                  "endLine": 13,
+                  "endTokenPos": 176,
+                  "endFilePos": 379
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 170,
+                    "startFilePos": 367,
+                    "endLine": 13,
+                    "endTokenPos": 175,
+                    "endFilePos": 378
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 170,
+                      "startFilePos": 367,
+                      "endLine": 13,
+                      "endTokenPos": 170,
+                      "endFilePos": 373
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 174,
+                      "startFilePos": 377,
+                      "endLine": 13,
+                      "endTokenPos": 175,
+                      "endFilePos": 378,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 178,
+                  "startFilePos": 383,
+                  "endLine": 16,
+                  "endTokenPos": 199,
+                  "endFilePos": 433
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 181,
+                    "startFilePos": 392,
+                    "endLine": 14,
+                    "endTokenPos": 181,
+                    "endFilePos": 398
+                  },
+                  "name": "groups"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 185,
+                    "startFilePos": 403,
+                    "endLine": 14,
+                    "endTokenPos": 185,
+                    "endFilePos": 404
+                  },
+                  "name": "g"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 190,
+                      "startFilePos": 415,
+                      "endLine": 15,
+                      "endTokenPos": 197,
+                      "endFilePos": 429
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 190,
+                        "startFilePos": 415,
+                        "endLine": 15,
+                        "endTokenPos": 196,
+                        "endFilePos": 428
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 190,
+                          "startFilePos": 415,
+                          "endLine": 15,
+                          "endTokenPos": 192,
+                          "endFilePos": 423
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 190,
+                            "startFilePos": 415,
+                            "endLine": 15,
+                            "endTokenPos": 190,
+                            "endFilePos": 421
+                          },
+                          "name": "result"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 196,
+                          "startFilePos": 427,
+                          "endLine": 15,
+                          "endTokenPos": 196,
+                          "endFilePos": 428
+                        },
+                        "name": "g"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 17,
+                  "startTokenPos": 201,
+                  "startFilePos": 437,
+                  "endLine": 17,
+                  "endTokenPos": 204,
+                  "endFilePos": 451
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 203,
+                    "startFilePos": 444,
+                    "endLine": 17,
+                    "endTokenPos": 203,
+                    "endFilePos": 450
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 19,
+        "startTokenPos": 212,
+        "startFilePos": 459,
+        "endLine": 19,
+        "endTokenPos": 218,
+        "endFilePos": 468
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 19,
+          "startTokenPos": 212,
+          "startFilePos": 459,
+          "endLine": 19,
+          "endTokenPos": 217,
+          "endFilePos": 467
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 212,
+            "startFilePos": 459,
+            "endLine": 19,
+            "endTokenPos": 212,
+            "endFilePos": 462
+          },
+          "name": "tmp"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 216,
+            "startFilePos": 466,
+            "endLine": 19,
+            "endTokenPos": 217,
+            "endFilePos": 467,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 20,
+        "startTokenPos": 220,
+        "startFilePos": 470,
+        "endLine": 26,
+        "endTokenPos": 302,
+        "endFilePos": 647
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 20,
+          "startTokenPos": 223,
+          "startFilePos": 479,
+          "endLine": 20,
+          "endTokenPos": 223,
+          "endFilePos": 485
+        },
+        "name": "groups"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 20,
+          "startTokenPos": 227,
+          "startFilePos": 490,
+          "endLine": 20,
+          "endTokenPos": 227,
+          "endFilePos": 491
+        },
+        "name": "g"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 21,
+            "startTokenPos": 232,
+            "startFilePos": 498,
+            "endLine": 21,
+            "endTokenPos": 237,
+            "endFilePos": 508
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 21,
+              "startTokenPos": 232,
+              "startFilePos": 498,
+              "endLine": 21,
+              "endTokenPos": 236,
+              "endFilePos": 507
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 21,
+                "startTokenPos": 232,
+                "startFilePos": 498,
+                "endLine": 21,
+                "endTokenPos": 232,
+                "endFilePos": 503
+              },
+              "name": "total"
+            },
+            "expr": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 21,
+                "startTokenPos": 236,
+                "startFilePos": 507,
+                "endLine": 21,
+                "endTokenPos": 236,
+                "endFilePos": 507,
+                "rawValue": "0",
+                "kind": 10
+              },
+              "value": 0
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 22,
+            "startTokenPos": 239,
+            "startFilePos": 512,
+            "endLine": 24,
+            "endTokenPos": 268,
+            "endFilePos": 573
+          },
+          "expr": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 242,
+              "startFilePos": 521,
+              "endLine": 22,
+              "endTokenPos": 245,
+              "endFilePos": 531
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 22,
+                "startTokenPos": 242,
+                "startFilePos": 521,
+                "endLine": 22,
+                "endTokenPos": 242,
+                "endFilePos": 522
+              },
+              "name": "g"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 22,
+                "startTokenPos": 244,
+                "startFilePos": 524,
+                "endLine": 22,
+                "endTokenPos": 244,
+                "endFilePos": 530,
+                "kind": 2,
+                "rawValue": "\"items\""
+              },
+              "value": "items"
+            }
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 249,
+              "startFilePos": 536,
+              "endLine": 22,
+              "endTokenPos": 249,
+              "endFilePos": 537
+            },
+            "name": "x"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 23,
+                "startTokenPos": 254,
+                "startFilePos": 544,
+                "endLine": 23,
+                "endTokenPos": 266,
+                "endFilePos": 571
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 23,
+                  "startTokenPos": 254,
+                  "startFilePos": 544,
+                  "endLine": 23,
+                  "endTokenPos": 265,
+                  "endFilePos": 570
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 23,
+                    "startTokenPos": 254,
+                    "startFilePos": 544,
+                    "endLine": 23,
+                    "endTokenPos": 254,
+                    "endFilePos": 549
+                  },
+                  "name": "total"
+                },
+                "expr": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 23,
+                    "startTokenPos": 258,
+                    "startFilePos": 553,
+                    "endLine": 23,
+                    "endTokenPos": 265,
+                    "endFilePos": 570
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 23,
+                      "startTokenPos": 258,
+                      "startFilePos": 553,
+                      "endLine": 23,
+                      "endTokenPos": 258,
+                      "endFilePos": 558
+                    },
+                    "name": "total"
+                  },
+                  "right": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 23,
+                      "startTokenPos": 262,
+                      "startFilePos": 562,
+                      "endLine": 23,
+                      "endTokenPos": 265,
+                      "endFilePos": 570
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 262,
+                        "startFilePos": 562,
+                        "endLine": 23,
+                        "endTokenPos": 262,
+                        "endFilePos": 563
+                      },
+                      "name": "x"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 264,
+                        "startFilePos": 565,
+                        "endLine": 23,
+                        "endTokenPos": 264,
+                        "endFilePos": 569,
+                        "kind": 2,
+                        "rawValue": "\"val\""
+                      },
+                      "value": "val"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 25,
+            "startTokenPos": 271,
+            "startFilePos": 578,
+            "endLine": 25,
+            "endTokenPos": 300,
+            "endFilePos": 645
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 25,
+              "startTokenPos": 271,
+              "startFilePos": 578,
+              "endLine": 25,
+              "endTokenPos": 299,
+              "endFilePos": 644
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 25,
+                "startTokenPos": 271,
+                "startFilePos": 578,
+                "endLine": 25,
+                "endTokenPos": 271,
+                "endFilePos": 581
+              },
+              "name": "tmp"
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 25,
+                "startTokenPos": 275,
+                "startFilePos": 585,
+                "endLine": 25,
+                "endTokenPos": 299,
+                "endFilePos": 644
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 25,
+                  "startTokenPos": 275,
+                  "startFilePos": 585,
+                  "endLine": 25,
+                  "endTokenPos": 275,
+                  "endFilePos": 595
+                },
+                "name": "array_merge"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 25,
+                    "startTokenPos": 277,
+                    "startFilePos": 597,
+                    "endLine": 25,
+                    "endTokenPos": 277,
+                    "endFilePos": 600
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 25,
+                      "startTokenPos": 277,
+                      "startFilePos": 597,
+                      "endLine": 25,
+                      "endTokenPos": 277,
+                      "endFilePos": 600
+                    },
+                    "name": "tmp"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 25,
+                    "startTokenPos": 280,
+                    "startFilePos": 603,
+                    "endLine": 25,
+                    "endTokenPos": 298,
+                    "endFilePos": 643
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 25,
+                      "startTokenPos": 280,
+                      "startFilePos": 603,
+                      "endLine": 25,
+                      "endTokenPos": 298,
+                      "endFilePos": 643,
+                      "kind": 2
+                    },
+                    "items": [
+                      {
+                        "nodeType": "ArrayItem",
+                        "attributes": {
+                          "startLine": 25,
+                          "startTokenPos": 281,
+                          "startFilePos": 604,
+                          "endLine": 25,
+                          "endTokenPos": 297,
+                          "endFilePos": 642
+                        },
+                        "key": null,
+                        "value": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 25,
+                            "startTokenPos": 281,
+                            "startFilePos": 604,
+                            "endLine": 25,
+                            "endTokenPos": 297,
+                            "endFilePos": 642,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 282,
+                                "startFilePos": 605,
+                                "endLine": 25,
+                                "endTokenPos": 289,
+                                "endFilePos": 622
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 282,
+                                  "startFilePos": 605,
+                                  "endLine": 25,
+                                  "endTokenPos": 282,
+                                  "endFilePos": 609,
+                                  "kind": 2,
+                                  "rawValue": "\"tag\""
+                                },
+                                "value": "tag"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 286,
+                                  "startFilePos": 614,
+                                  "endLine": 25,
+                                  "endTokenPos": 289,
+                                  "endFilePos": 622
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 286,
+                                    "startFilePos": 614,
+                                    "endLine": 25,
+                                    "endTokenPos": 286,
+                                    "endFilePos": 615
+                                  },
+                                  "name": "g"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 288,
+                                    "startFilePos": 617,
+                                    "endLine": 25,
+                                    "endTokenPos": 288,
+                                    "endFilePos": 621,
+                                    "kind": 2,
+                                    "rawValue": "\"key\""
+                                  },
+                                  "value": "key"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 292,
+                                "startFilePos": 625,
+                                "endLine": 25,
+                                "endTokenPos": 296,
+                                "endFilePos": 641
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 292,
+                                  "startFilePos": 625,
+                                  "endLine": 25,
+                                  "endTokenPos": 292,
+                                  "endFilePos": 631,
+                                  "kind": 2,
+                                  "rawValue": "\"total\""
+                                },
+                                "value": "total"
+                              },
+                              "value": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 296,
+                                  "startFilePos": 636,
+                                  "endLine": 25,
+                                  "endTokenPos": 296,
+                                  "endFilePos": 641
+                                },
+                                "name": "total"
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 27,
+        "startTokenPos": 304,
+        "startFilePos": 649,
+        "endLine": 27,
+        "endTokenPos": 310,
+        "endFilePos": 661
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 27,
+          "startTokenPos": 304,
+          "startFilePos": 649,
+          "endLine": 27,
+          "endTokenPos": 309,
+          "endFilePos": 660
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 27,
+            "startTokenPos": 304,
+            "startFilePos": 649,
+            "endLine": 27,
+            "endTokenPos": 304,
+            "endFilePos": 655
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 27,
+            "startTokenPos": 308,
+            "startFilePos": 659,
+            "endLine": 27,
+            "endTokenPos": 309,
+            "endFilePos": 660,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 28,
+        "startTokenPos": 312,
+        "startFilePos": 663,
+        "endLine": 30,
+        "endTokenPos": 333,
+        "endFilePos": 704
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 28,
+          "startTokenPos": 315,
+          "startFilePos": 672,
+          "endLine": 28,
+          "endTokenPos": 315,
+          "endFilePos": 675
+        },
+        "name": "tmp"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 28,
+          "startTokenPos": 319,
+          "startFilePos": 680,
+          "endLine": 28,
+          "endTokenPos": 319,
+          "endFilePos": 681
+        },
+        "name": "r"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 29,
+            "startTokenPos": 324,
+            "startFilePos": 688,
+            "endLine": 29,
+            "endTokenPos": 331,
+            "endFilePos": 702
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 29,
+              "startTokenPos": 324,
+              "startFilePos": 688,
+              "endLine": 29,
+              "endTokenPos": 330,
+              "endFilePos": 701
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 29,
+                "startTokenPos": 324,
+                "startFilePos": 688,
+                "endLine": 29,
+                "endTokenPos": 326,
+                "endFilePos": 696
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 29,
+                  "startTokenPos": 324,
+                  "startFilePos": 688,
+                  "endLine": 29,
+                  "endTokenPos": 324,
+                  "endFilePos": 694
+                },
+                "name": "result"
+              },
+              "dim": null
+            },
+            "expr": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 29,
+                "startTokenPos": 330,
+                "startFilePos": 700,
+                "endLine": 29,
+                "endTokenPos": 330,
+                "endFilePos": 701
+              },
+              "name": "r"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 32,
+        "startTokenPos": 335,
+        "startFilePos": 707,
+        "endLine": 32,
+        "endTokenPos": 392,
+        "endFilePos": 879
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 337,
+            "startFilePos": 712,
+            "endLine": 32,
+            "endTokenPos": 388,
+            "endFilePos": 869
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 337,
+              "startFilePos": 712,
+              "endLine": 32,
+              "endTokenPos": 337,
+              "endFilePos": 722
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 339,
+                "startFilePos": 724,
+                "endLine": 32,
+                "endTokenPos": 339,
+                "endFilePos": 730
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 339,
+                  "startFilePos": 724,
+                  "endLine": 32,
+                  "endTokenPos": 339,
+                  "endFilePos": 730,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 342,
+                "startFilePos": 733,
+                "endLine": 32,
+                "endTokenPos": 342,
+                "endFilePos": 739
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 342,
+                  "startFilePos": 733,
+                  "endLine": 32,
+                  "endTokenPos": 342,
+                  "endFilePos": 739,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 345,
+                "startFilePos": 742,
+                "endLine": 32,
+                "endTokenPos": 387,
+                "endFilePos": 868
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 345,
+                  "startFilePos": 742,
+                  "endLine": 32,
+                  "endTokenPos": 387,
+                  "endFilePos": 868
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 32,
+                    "startTokenPos": 345,
+                    "startFilePos": 742,
+                    "endLine": 32,
+                    "endTokenPos": 345,
+                    "endFilePos": 752
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 347,
+                      "startFilePos": 754,
+                      "endLine": 32,
+                      "endTokenPos": 347,
+                      "endFilePos": 759
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 347,
+                        "startFilePos": 754,
+                        "endLine": 32,
+                        "endTokenPos": 347,
+                        "endFilePos": 759,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 350,
+                      "startFilePos": 762,
+                      "endLine": 32,
+                      "endTokenPos": 350,
+                      "endFilePos": 767
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 350,
+                        "startFilePos": 762,
+                        "endLine": 32,
+                        "endTokenPos": 350,
+                        "endFilePos": 767,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 353,
+                      "startFilePos": 770,
+                      "endLine": 32,
+                      "endTokenPos": 386,
+                      "endFilePos": 867
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 353,
+                        "startFilePos": 770,
+                        "endLine": 32,
+                        "endTokenPos": 386,
+                        "endFilePos": 867
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 32,
+                          "startTokenPos": 353,
+                          "startFilePos": 770,
+                          "endLine": 32,
+                          "endTokenPos": 353,
+                          "endFilePos": 780
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 32,
+                            "startTokenPos": 355,
+                            "startFilePos": 782,
+                            "endLine": 32,
+                            "endTokenPos": 355,
+                            "endFilePos": 785
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 32,
+                              "startTokenPos": 355,
+                              "startFilePos": 782,
+                              "endLine": 32,
+                              "endTokenPos": 355,
+                              "endFilePos": 785,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 32,
+                            "startTokenPos": 358,
+                            "startFilePos": 788,
+                            "endLine": 32,
+                            "endTokenPos": 358,
+                            "endFilePos": 790
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 32,
+                              "startTokenPos": 358,
+                              "startFilePos": 788,
+                              "endLine": 32,
+                              "endTokenPos": 358,
+                              "endFilePos": 790,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 32,
+                            "startTokenPos": 361,
+                            "startFilePos": 793,
+                            "endLine": 32,
+                            "endTokenPos": 385,
+                            "endFilePos": 866
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 32,
+                              "startTokenPos": 361,
+                              "startFilePos": 793,
+                              "endLine": 32,
+                              "endTokenPos": 385,
+                              "endFilePos": 866
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 32,
+                                "startTokenPos": 361,
+                                "startFilePos": 793,
+                                "endLine": 32,
+                                "endTokenPos": 361,
+                                "endFilePos": 803
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 32,
+                                  "startTokenPos": 363,
+                                  "startFilePos": 805,
+                                  "endLine": 32,
+                                  "endTokenPos": 363,
+                                  "endFilePos": 807
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 32,
+                                    "startTokenPos": 363,
+                                    "startFilePos": 805,
+                                    "endLine": 32,
+                                    "endTokenPos": 363,
+                                    "endFilePos": 807,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 32,
+                                  "startTokenPos": 366,
+                                  "startFilePos": 810,
+                                  "endLine": 32,
+                                  "endTokenPos": 366,
+                                  "endFilePos": 813
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 32,
+                                    "startTokenPos": 366,
+                                    "startFilePos": 810,
+                                    "endLine": 32,
+                                    "endTokenPos": 366,
+                                    "endFilePos": 813,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 32,
+                                  "startTokenPos": 369,
+                                  "startFilePos": 816,
+                                  "endLine": 32,
+                                  "endTokenPos": 384,
+                                  "endFilePos": 865
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 32,
+                                    "startTokenPos": 369,
+                                    "startFilePos": 816,
+                                    "endLine": 32,
+                                    "endTokenPos": 384,
+                                    "endFilePos": 865
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 32,
+                                      "startTokenPos": 369,
+                                      "startFilePos": 816,
+                                      "endLine": 32,
+                                      "endTokenPos": 369,
+                                      "endFilePos": 826
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 32,
+                                        "startTokenPos": 371,
+                                        "startFilePos": 828,
+                                        "endLine": 32,
+                                        "endTokenPos": 371,
+                                        "endFilePos": 830
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 32,
+                                          "startTokenPos": 371,
+                                          "startFilePos": 828,
+                                          "endLine": 32,
+                                          "endTokenPos": 371,
+                                          "endFilePos": 830,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 32,
+                                        "startTokenPos": 374,
+                                        "startFilePos": 833,
+                                        "endLine": 32,
+                                        "endTokenPos": 374,
+                                        "endFilePos": 836
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 32,
+                                          "startTokenPos": 374,
+                                          "startFilePos": 833,
+                                          "endLine": 32,
+                                          "endTokenPos": 374,
+                                          "endFilePos": 836,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 32,
+                                        "startTokenPos": 377,
+                                        "startFilePos": 839,
+                                        "endLine": 32,
+                                        "endTokenPos": 383,
+                                        "endFilePos": 864
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 32,
+                                          "startTokenPos": 377,
+                                          "startFilePos": 839,
+                                          "endLine": 32,
+                                          "endTokenPos": 383,
+                                          "endFilePos": 864
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 32,
+                                            "startTokenPos": 377,
+                                            "startFilePos": 839,
+                                            "endLine": 32,
+                                            "endTokenPos": 377,
+                                            "endFilePos": 849
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 32,
+                                              "startTokenPos": 379,
+                                              "startFilePos": 851,
+                                              "endLine": 32,
+                                              "endTokenPos": 379,
+                                              "endFilePos": 857
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 32,
+                                                "startTokenPos": 379,
+                                                "startFilePos": 851,
+                                                "endLine": 32,
+                                                "endTokenPos": 379,
+                                                "endFilePos": 857
+                                              },
+                                              "name": "result"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 32,
+                                              "startTokenPos": 382,
+                                              "startFilePos": 860,
+                                              "endLine": 32,
+                                              "endTokenPos": 382,
+                                              "endFilePos": 863
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 32,
+                                                "startTokenPos": 382,
+                                                "startFilePos": 860,
+                                                "endLine": 32,
+                                                "endTokenPos": 382,
+                                                "endFilePos": 863,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 391,
+            "startFilePos": 872,
+            "endLine": 32,
+            "endTokenPos": 391,
+            "endFilePos": 878
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 391,
+              "startFilePos": 872,
+              "endLine": 32,
+              "endTokenPos": 391,
+              "endFilePos": 878
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/if_else.php.json
+++ b/tests/json-ast/x/php/if_else.php.json
@@ -1,0 +1,216 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "5",
+            "kind": 10
+          },
+          "value": 5
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_If",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 7,
+        "endTokenPos": 42,
+        "endFilePos": 85
+      },
+      "cond": {
+        "nodeType": "Expr_BinaryOp_Greater",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 11,
+          "startFilePos": 18,
+          "endLine": 3,
+          "endTokenPos": 15,
+          "endFilePos": 23
+        },
+        "left": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 18,
+            "endLine": 3,
+            "endTokenPos": 11,
+            "endFilePos": 19
+          },
+          "name": "x"
+        },
+        "right": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 15,
+            "startFilePos": 23,
+            "endLine": 3,
+            "endTokenPos": 15,
+            "endFilePos": 23,
+            "rawValue": "3",
+            "kind": 10
+          },
+          "value": 3
+        }
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 20,
+            "startFilePos": 30,
+            "endLine": 4,
+            "endTokenPos": 26,
+            "endFilePos": 49
+          },
+          "exprs": [
+            {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 22,
+                "startFilePos": 35,
+                "endLine": 4,
+                "endTokenPos": 22,
+                "endFilePos": 39,
+                "kind": 2,
+                "rawValue": "\"big\""
+              },
+              "value": "big"
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 25,
+                "startFilePos": 42,
+                "endLine": 4,
+                "endTokenPos": 25,
+                "endFilePos": 48
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 25,
+                  "startFilePos": 42,
+                  "endLine": 4,
+                  "endTokenPos": 25,
+                  "endFilePos": 48
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ],
+      "elseifs": [],
+      "else": {
+        "nodeType": "Stmt_Else",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 30,
+          "startFilePos": 53,
+          "endLine": 7,
+          "endTokenPos": 42,
+          "endFilePos": 85
+        },
+        "stmts": [
+          {
+            "nodeType": "Stmt_Echo",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 34,
+              "startFilePos": 62,
+              "endLine": 6,
+              "endTokenPos": 40,
+              "endFilePos": 83
+            },
+            "exprs": [
+              {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 36,
+                  "startFilePos": 67,
+                  "endLine": 6,
+                  "endTokenPos": 36,
+                  "endFilePos": 73,
+                  "kind": 2,
+                  "rawValue": "\"small\""
+                },
+                "value": "small"
+              },
+              {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 39,
+                  "startFilePos": 76,
+                  "endLine": 6,
+                  "endTokenPos": 39,
+                  "endFilePos": 82
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 39,
+                    "startFilePos": 76,
+                    "endLine": 6,
+                    "endTokenPos": 39,
+                    "endFilePos": 82
+                  },
+                  "name": "PHP_EOL"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/php/if_then_else.php.json
+++ b/tests/json-ast/x/php/if_then_else.php.json
@@ -1,0 +1,210 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 13
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 12
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 12,
+            "rawValue": "12",
+            "kind": 10
+          },
+          "value": 12
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 15,
+        "endLine": 3,
+        "endTokenPos": 27,
+        "endFilePos": 46
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 15,
+          "endLine": 3,
+          "endTokenPos": 26,
+          "endFilePos": 45
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 15,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 18
+          },
+          "name": "msg"
+        },
+        "expr": {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 23,
+            "endLine": 3,
+            "endTokenPos": 25,
+            "endFilePos": 44
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Greater",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 13,
+              "startFilePos": 23,
+              "endLine": 3,
+              "endTokenPos": 17,
+              "endFilePos": 29
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 13,
+                "startFilePos": 23,
+                "endLine": 3,
+                "endTokenPos": 13,
+                "endFilePos": 24
+              },
+              "name": "x"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 28,
+                "endLine": 3,
+                "endTokenPos": 17,
+                "endFilePos": 29,
+                "rawValue": "10",
+                "kind": 10
+              },
+              "value": 10
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 21,
+              "startFilePos": 33,
+              "endLine": 3,
+              "endTokenPos": 21,
+              "endFilePos": 37,
+              "kind": 2,
+              "rawValue": "\"yes\""
+            },
+            "value": "yes"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 25,
+              "startFilePos": 41,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 44,
+              "kind": 2,
+              "rawValue": "\"no\""
+            },
+            "value": "no"
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 29,
+        "startFilePos": 48,
+        "endLine": 4,
+        "endTokenPos": 35,
+        "endFilePos": 66
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 31,
+            "startFilePos": 53,
+            "endLine": 4,
+            "endTokenPos": 31,
+            "endFilePos": 56
+          },
+          "name": "msg"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 34,
+            "startFilePos": 59,
+            "endLine": 4,
+            "endTokenPos": 34,
+            "endFilePos": 65
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 34,
+              "startFilePos": 59,
+              "endLine": 4,
+              "endTokenPos": 34,
+              "endFilePos": 65
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/if_then_else_nested.php.json
+++ b/tests/json-ast/x/php/if_then_else_nested.php.json
@@ -1,0 +1,272 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "8",
+            "kind": 10
+          },
+          "value": 8
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 3,
+        "endTokenPos": 41,
+        "endFilePos": 70
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 14,
+          "endLine": 3,
+          "endTokenPos": 40,
+          "endFilePos": 69
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 14,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 17
+          },
+          "name": "msg"
+        },
+        "expr": {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 22,
+            "endLine": 3,
+            "endTokenPos": 39,
+            "endFilePos": 68
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Greater",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 13,
+              "startFilePos": 22,
+              "endLine": 3,
+              "endTokenPos": 17,
+              "endFilePos": 28
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 3,
+                "endTokenPos": 13,
+                "endFilePos": 23
+              },
+              "name": "x"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 27,
+                "endLine": 3,
+                "endTokenPos": 17,
+                "endFilePos": 28,
+                "rawValue": "10",
+                "kind": 10
+              },
+              "value": 10
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 21,
+              "startFilePos": 32,
+              "endLine": 3,
+              "endTokenPos": 21,
+              "endFilePos": 36,
+              "kind": 2,
+              "rawValue": "\"big\""
+            },
+            "value": "big"
+          },
+          "else": {
+            "nodeType": "Expr_Ternary",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 26,
+              "startFilePos": 41,
+              "endLine": 3,
+              "endTokenPos": 38,
+              "endFilePos": 67
+            },
+            "cond": {
+              "nodeType": "Expr_BinaryOp_Greater",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 26,
+                "startFilePos": 41,
+                "endLine": 3,
+                "endTokenPos": 30,
+                "endFilePos": 46
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 26,
+                  "startFilePos": 41,
+                  "endLine": 3,
+                  "endTokenPos": 26,
+                  "endFilePos": 42
+                },
+                "name": "x"
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 30,
+                  "startFilePos": 46,
+                  "endLine": 3,
+                  "endTokenPos": 30,
+                  "endFilePos": 46,
+                  "rawValue": "5",
+                  "kind": 10
+                },
+                "value": 5
+              }
+            },
+            "if": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 34,
+                "startFilePos": 50,
+                "endLine": 3,
+                "endTokenPos": 34,
+                "endFilePos": 57,
+                "kind": 2,
+                "rawValue": "\"medium\""
+              },
+              "value": "medium"
+            },
+            "else": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 38,
+                "startFilePos": 61,
+                "endLine": 3,
+                "endTokenPos": 38,
+                "endFilePos": 67,
+                "kind": 2,
+                "rawValue": "\"small\""
+              },
+              "value": "small"
+            }
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 43,
+        "startFilePos": 72,
+        "endLine": 4,
+        "endTokenPos": 49,
+        "endFilePos": 90
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 45,
+            "startFilePos": 77,
+            "endLine": 4,
+            "endTokenPos": 45,
+            "endFilePos": 80
+          },
+          "name": "msg"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 48,
+            "startFilePos": 83,
+            "endLine": 4,
+            "endTokenPos": 48,
+            "endFilePos": 89
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 48,
+              "startFilePos": 83,
+              "endLine": 4,
+              "endTokenPos": 48,
+              "endFilePos": 89
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/in_operator.php.json
+++ b/tests/json-ast/x/php/in_operator.php.json
@@ -1,0 +1,713 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 21
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 20
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 8
+          },
+          "name": "xs"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 20,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 13,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 13
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 13,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 13,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 16
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 16,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 16,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 19,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 19
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 19,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 23,
+        "endLine": 3,
+        "endTokenPos": 38,
+        "endFilePos": 74
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 19,
+            "startFilePos": 29,
+            "endLine": 3,
+            "endTokenPos": 33,
+            "endFilePos": 63
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 19,
+              "startFilePos": 29,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 44
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 19,
+                "startFilePos": 29,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 36
+              },
+              "name": "in_array"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 21,
+                  "startFilePos": 38,
+                  "endLine": 3,
+                  "endTokenPos": 21,
+                  "endFilePos": 38
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 21,
+                    "startFilePos": 38,
+                    "endLine": 3,
+                    "endTokenPos": 21,
+                    "endFilePos": 38,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 24,
+                  "startFilePos": 41,
+                  "endLine": 3,
+                  "endTokenPos": 24,
+                  "endFilePos": 43
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 24,
+                    "startFilePos": 41,
+                    "endLine": 3,
+                    "endTokenPos": 24,
+                    "endFilePos": 43
+                  },
+                  "name": "xs"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 29,
+              "startFilePos": 48,
+              "endLine": 3,
+              "endTokenPos": 29,
+              "endFilePos": 53,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 33,
+              "startFilePos": 57,
+              "endLine": 3,
+              "endTokenPos": 33,
+              "endFilePos": 63,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 37,
+            "startFilePos": 67,
+            "endLine": 3,
+            "endTokenPos": 37,
+            "endFilePos": 73
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 37,
+              "startFilePos": 67,
+              "endLine": 3,
+              "endTokenPos": 37,
+              "endFilePos": 73
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 40,
+        "startFilePos": 76,
+        "endLine": 4,
+        "endTokenPos": 92,
+        "endFilePos": 184
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 43,
+            "startFilePos": 82,
+            "endLine": 4,
+            "endTokenPos": 87,
+            "endFilePos": 173
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 43,
+              "startFilePos": 82,
+              "endLine": 4,
+              "endTokenPos": 55,
+              "endFilePos": 110
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 43,
+                "startFilePos": 82,
+                "endLine": 4,
+                "endTokenPos": 43,
+                "endFilePos": 89
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 45,
+                  "startFilePos": 91,
+                  "endLine": 4,
+                  "endTokenPos": 54,
+                  "endFilePos": 109
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BooleanNot",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 45,
+                    "startFilePos": 91,
+                    "endLine": 4,
+                    "endTokenPos": 54,
+                    "endFilePos": 109
+                  },
+                  "expr": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 47,
+                      "startFilePos": 93,
+                      "endLine": 4,
+                      "endTokenPos": 53,
+                      "endFilePos": 108
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 47,
+                        "startFilePos": 93,
+                        "endLine": 4,
+                        "endTokenPos": 47,
+                        "endFilePos": 100
+                      },
+                      "name": "in_array"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 49,
+                          "startFilePos": 102,
+                          "endLine": 4,
+                          "endTokenPos": 49,
+                          "endFilePos": 102
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 49,
+                            "startFilePos": 102,
+                            "endLine": 4,
+                            "endTokenPos": 49,
+                            "endFilePos": 102,
+                            "rawValue": "5",
+                            "kind": 10
+                          },
+                          "value": 5
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 52,
+                          "startFilePos": 105,
+                          "endLine": 4,
+                          "endTokenPos": 52,
+                          "endFilePos": 107
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 52,
+                            "startFilePos": 105,
+                            "endLine": 4,
+                            "endTokenPos": 52,
+                            "endFilePos": 107
+                          },
+                          "name": "xs"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 59,
+              "startFilePos": 114,
+              "endLine": 4,
+              "endTokenPos": 74,
+              "endFilePos": 151
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 59,
+                "startFilePos": 114,
+                "endLine": 4,
+                "endTokenPos": 59,
+                "endFilePos": 124
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 61,
+                  "startFilePos": 126,
+                  "endLine": 4,
+                  "endTokenPos": 70,
+                  "endFilePos": 144
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BooleanNot",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 61,
+                    "startFilePos": 126,
+                    "endLine": 4,
+                    "endTokenPos": 70,
+                    "endFilePos": 144
+                  },
+                  "expr": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 63,
+                      "startFilePos": 128,
+                      "endLine": 4,
+                      "endTokenPos": 69,
+                      "endFilePos": 143
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 63,
+                        "startFilePos": 128,
+                        "endLine": 4,
+                        "endTokenPos": 63,
+                        "endFilePos": 135
+                      },
+                      "name": "in_array"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 65,
+                          "startFilePos": 137,
+                          "endLine": 4,
+                          "endTokenPos": 65,
+                          "endFilePos": 137
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 65,
+                            "startFilePos": 137,
+                            "endLine": 4,
+                            "endTokenPos": 65,
+                            "endFilePos": 137,
+                            "rawValue": "5",
+                            "kind": 10
+                          },
+                          "value": 5
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 68,
+                          "startFilePos": 140,
+                          "endLine": 4,
+                          "endTokenPos": 68,
+                          "endFilePos": 142
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 68,
+                            "startFilePos": 140,
+                            "endLine": 4,
+                            "endTokenPos": 68,
+                            "endFilePos": 142
+                          },
+                          "name": "xs"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 73,
+                  "startFilePos": 147,
+                  "endLine": 4,
+                  "endTokenPos": 73,
+                  "endFilePos": 150
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 73,
+                    "startFilePos": 147,
+                    "endLine": 4,
+                    "endTokenPos": 73,
+                    "endFilePos": 150,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BooleanNot",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 78,
+              "startFilePos": 155,
+              "endLine": 4,
+              "endTokenPos": 87,
+              "endFilePos": 173
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 80,
+                "startFilePos": 157,
+                "endLine": 4,
+                "endTokenPos": 86,
+                "endFilePos": 172
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 80,
+                  "startFilePos": 157,
+                  "endLine": 4,
+                  "endTokenPos": 80,
+                  "endFilePos": 164
+                },
+                "name": "in_array"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 82,
+                    "startFilePos": 166,
+                    "endLine": 4,
+                    "endTokenPos": 82,
+                    "endFilePos": 166
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 82,
+                      "startFilePos": 166,
+                      "endLine": 4,
+                      "endTokenPos": 82,
+                      "endFilePos": 166,
+                      "rawValue": "5",
+                      "kind": 10
+                    },
+                    "value": 5
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 85,
+                    "startFilePos": 169,
+                    "endLine": 4,
+                    "endTokenPos": 85,
+                    "endFilePos": 171
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 85,
+                      "startFilePos": 169,
+                      "endLine": 4,
+                      "endTokenPos": 85,
+                      "endFilePos": 171
+                    },
+                    "name": "xs"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 91,
+            "startFilePos": 177,
+            "endLine": 4,
+            "endTokenPos": 91,
+            "endFilePos": 183
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 91,
+              "startFilePos": 177,
+              "endLine": 4,
+              "endTokenPos": 91,
+              "endFilePos": 183
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/in_operator_extended.php.json
+++ b/tests/json-ast/x/php/in_operator_extended.php.json
@@ -1,0 +1,1418 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 21
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 20
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 8
+          },
+          "name": "xs"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 20,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 13,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 13
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 13,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 13,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 16
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 16,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 16,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 19,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 19
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 19,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 23,
+        "endLine": 3,
+        "endTokenPos": 22,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 16,
+          "startFilePos": 23,
+          "endLine": 3,
+          "endTokenPos": 21,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 16,
+            "startFilePos": 23,
+            "endLine": 3,
+            "endTokenPos": 16,
+            "endFilePos": 25
+          },
+          "name": "ys"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 20,
+            "startFilePos": 29,
+            "endLine": 3,
+            "endTokenPos": 21,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 24,
+        "startFilePos": 33,
+        "endLine": 8,
+        "endTokenPos": 63,
+        "endFilePos": 96
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 27,
+          "startFilePos": 42,
+          "endLine": 4,
+          "endTokenPos": 27,
+          "endFilePos": 44
+        },
+        "name": "xs"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 31,
+          "startFilePos": 49,
+          "endLine": 4,
+          "endTokenPos": 31,
+          "endFilePos": 50
+        },
+        "name": "x"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 36,
+            "startFilePos": 57,
+            "endLine": 7,
+            "endTokenPos": 61,
+            "endFilePos": 94
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Equal",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 39,
+              "startFilePos": 61,
+              "endLine": 5,
+              "endTokenPos": 47,
+              "endFilePos": 71
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_Mod",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 39,
+                "startFilePos": 61,
+                "endLine": 5,
+                "endTokenPos": 43,
+                "endFilePos": 66
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 39,
+                  "startFilePos": 61,
+                  "endLine": 5,
+                  "endTokenPos": 39,
+                  "endFilePos": 62
+                },
+                "name": "x"
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 43,
+                  "startFilePos": 66,
+                  "endLine": 5,
+                  "endTokenPos": 43,
+                  "endFilePos": 66,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 47,
+                "startFilePos": 71,
+                "endLine": 5,
+                "endTokenPos": 47,
+                "endFilePos": 71,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 52,
+                "startFilePos": 80,
+                "endLine": 6,
+                "endTokenPos": 59,
+                "endFilePos": 90
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 52,
+                  "startFilePos": 80,
+                  "endLine": 6,
+                  "endTokenPos": 58,
+                  "endFilePos": 89
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 52,
+                    "startFilePos": 80,
+                    "endLine": 6,
+                    "endTokenPos": 54,
+                    "endFilePos": 84
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 52,
+                      "startFilePos": 80,
+                      "endLine": 6,
+                      "endTokenPos": 52,
+                      "endFilePos": 82
+                    },
+                    "name": "ys"
+                  },
+                  "dim": null
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 58,
+                    "startFilePos": 88,
+                    "endLine": 6,
+                    "endTokenPos": 58,
+                    "endFilePos": 89
+                  },
+                  "name": "x"
+                }
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 65,
+        "startFilePos": 99,
+        "endLine": 10,
+        "endTokenPos": 87,
+        "endFilePos": 150
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 68,
+            "startFilePos": 105,
+            "endLine": 10,
+            "endTokenPos": 82,
+            "endFilePos": 139
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 10,
+              "startTokenPos": 68,
+              "startFilePos": 105,
+              "endLine": 10,
+              "endTokenPos": 74,
+              "endFilePos": 120
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 68,
+                "startFilePos": 105,
+                "endLine": 10,
+                "endTokenPos": 68,
+                "endFilePos": 112
+              },
+              "name": "in_array"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 70,
+                  "startFilePos": 114,
+                  "endLine": 10,
+                  "endTokenPos": 70,
+                  "endFilePos": 114
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 70,
+                    "startFilePos": 114,
+                    "endLine": 10,
+                    "endTokenPos": 70,
+                    "endFilePos": 114,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 73,
+                  "startFilePos": 117,
+                  "endLine": 10,
+                  "endTokenPos": 73,
+                  "endFilePos": 119
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 73,
+                    "startFilePos": 117,
+                    "endLine": 10,
+                    "endTokenPos": 73,
+                    "endFilePos": 119
+                  },
+                  "name": "ys"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 10,
+              "startTokenPos": 78,
+              "startFilePos": 124,
+              "endLine": 10,
+              "endTokenPos": 78,
+              "endFilePos": 129,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 10,
+              "startTokenPos": 82,
+              "startFilePos": 133,
+              "endLine": 10,
+              "endTokenPos": 82,
+              "endFilePos": 139,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 86,
+            "startFilePos": 143,
+            "endLine": 10,
+            "endTokenPos": 86,
+            "endFilePos": 149
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 10,
+              "startTokenPos": 86,
+              "startFilePos": 143,
+              "endLine": 10,
+              "endTokenPos": 86,
+              "endFilePos": 149
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 11,
+        "startTokenPos": 89,
+        "startFilePos": 152,
+        "endLine": 11,
+        "endTokenPos": 111,
+        "endFilePos": 203
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 92,
+            "startFilePos": 158,
+            "endLine": 11,
+            "endTokenPos": 106,
+            "endFilePos": 192
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 92,
+              "startFilePos": 158,
+              "endLine": 11,
+              "endTokenPos": 98,
+              "endFilePos": 173
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 92,
+                "startFilePos": 158,
+                "endLine": 11,
+                "endTokenPos": 92,
+                "endFilePos": 165
+              },
+              "name": "in_array"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 94,
+                  "startFilePos": 167,
+                  "endLine": 11,
+                  "endTokenPos": 94,
+                  "endFilePos": 167
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 94,
+                    "startFilePos": 167,
+                    "endLine": 11,
+                    "endTokenPos": 94,
+                    "endFilePos": 167,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 97,
+                  "startFilePos": 170,
+                  "endLine": 11,
+                  "endTokenPos": 97,
+                  "endFilePos": 172
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 97,
+                    "startFilePos": 170,
+                    "endLine": 11,
+                    "endTokenPos": 97,
+                    "endFilePos": 172
+                  },
+                  "name": "ys"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 102,
+              "startFilePos": 177,
+              "endLine": 11,
+              "endTokenPos": 102,
+              "endFilePos": 182,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 106,
+              "startFilePos": 186,
+              "endLine": 11,
+              "endTokenPos": 106,
+              "endFilePos": 192,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 110,
+            "startFilePos": 196,
+            "endLine": 11,
+            "endTokenPos": 110,
+            "endFilePos": 202
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 110,
+              "startFilePos": 196,
+              "endLine": 11,
+              "endTokenPos": 110,
+              "endFilePos": 202
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 12,
+        "startTokenPos": 113,
+        "startFilePos": 205,
+        "endLine": 12,
+        "endTokenPos": 124,
+        "endFilePos": 220
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 12,
+          "startTokenPos": 113,
+          "startFilePos": 205,
+          "endLine": 12,
+          "endTokenPos": 123,
+          "endFilePos": 219
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 113,
+            "startFilePos": 205,
+            "endLine": 12,
+            "endTokenPos": 113,
+            "endFilePos": 206
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 117,
+            "startFilePos": 210,
+            "endLine": 12,
+            "endTokenPos": 123,
+            "endFilePos": 219,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 118,
+                "startFilePos": 211,
+                "endLine": 12,
+                "endTokenPos": 122,
+                "endFilePos": 218
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 118,
+                  "startFilePos": 211,
+                  "endLine": 12,
+                  "endTokenPos": 118,
+                  "endFilePos": 213,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 122,
+                  "startFilePos": 218,
+                  "endLine": 12,
+                  "endTokenPos": 122,
+                  "endFilePos": 218,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 13,
+        "startTokenPos": 126,
+        "startFilePos": 222,
+        "endLine": 13,
+        "endTokenPos": 148,
+        "endFilePos": 282
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 129,
+            "startFilePos": 228,
+            "endLine": 13,
+            "endTokenPos": 143,
+            "endFilePos": 271
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 129,
+              "startFilePos": 228,
+              "endLine": 13,
+              "endTokenPos": 135,
+              "endFilePos": 252
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 129,
+                "startFilePos": 228,
+                "endLine": 13,
+                "endTokenPos": 129,
+                "endFilePos": 243
+              },
+              "name": "array_key_exists"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 131,
+                  "startFilePos": 245,
+                  "endLine": 13,
+                  "endTokenPos": 131,
+                  "endFilePos": 247
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 131,
+                    "startFilePos": 245,
+                    "endLine": 13,
+                    "endTokenPos": 131,
+                    "endFilePos": 247,
+                    "kind": 2,
+                    "rawValue": "\"a\""
+                  },
+                  "value": "a"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 134,
+                  "startFilePos": 250,
+                  "endLine": 13,
+                  "endTokenPos": 134,
+                  "endFilePos": 251
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 134,
+                    "startFilePos": 250,
+                    "endLine": 13,
+                    "endTokenPos": 134,
+                    "endFilePos": 251
+                  },
+                  "name": "m"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 139,
+              "startFilePos": 256,
+              "endLine": 13,
+              "endTokenPos": 139,
+              "endFilePos": 261,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 143,
+              "startFilePos": 265,
+              "endLine": 13,
+              "endTokenPos": 143,
+              "endFilePos": 271,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 147,
+            "startFilePos": 275,
+            "endLine": 13,
+            "endTokenPos": 147,
+            "endFilePos": 281
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 147,
+              "startFilePos": 275,
+              "endLine": 13,
+              "endTokenPos": 147,
+              "endFilePos": 281
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 14,
+        "startTokenPos": 150,
+        "startFilePos": 284,
+        "endLine": 14,
+        "endTokenPos": 172,
+        "endFilePos": 344
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 153,
+            "startFilePos": 290,
+            "endLine": 14,
+            "endTokenPos": 167,
+            "endFilePos": 333
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 153,
+              "startFilePos": 290,
+              "endLine": 14,
+              "endTokenPos": 159,
+              "endFilePos": 314
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 153,
+                "startFilePos": 290,
+                "endLine": 14,
+                "endTokenPos": 153,
+                "endFilePos": 305
+              },
+              "name": "array_key_exists"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 155,
+                  "startFilePos": 307,
+                  "endLine": 14,
+                  "endTokenPos": 155,
+                  "endFilePos": 309
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 155,
+                    "startFilePos": 307,
+                    "endLine": 14,
+                    "endTokenPos": 155,
+                    "endFilePos": 309,
+                    "kind": 2,
+                    "rawValue": "\"b\""
+                  },
+                  "value": "b"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 158,
+                  "startFilePos": 312,
+                  "endLine": 14,
+                  "endTokenPos": 158,
+                  "endFilePos": 313
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 158,
+                    "startFilePos": 312,
+                    "endLine": 14,
+                    "endTokenPos": 158,
+                    "endFilePos": 313
+                  },
+                  "name": "m"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 163,
+              "startFilePos": 318,
+              "endLine": 14,
+              "endTokenPos": 163,
+              "endFilePos": 323,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 167,
+              "startFilePos": 327,
+              "endLine": 14,
+              "endTokenPos": 167,
+              "endFilePos": 333,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 171,
+            "startFilePos": 337,
+            "endLine": 14,
+            "endTokenPos": 171,
+            "endFilePos": 343
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 171,
+              "startFilePos": 337,
+              "endLine": 14,
+              "endTokenPos": 171,
+              "endFilePos": 343
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 15,
+        "startTokenPos": 174,
+        "startFilePos": 346,
+        "endLine": 15,
+        "endTokenPos": 179,
+        "endFilePos": 358
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 15,
+          "startTokenPos": 174,
+          "startFilePos": 346,
+          "endLine": 15,
+          "endTokenPos": 178,
+          "endFilePos": 357
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 174,
+            "startFilePos": 346,
+            "endLine": 15,
+            "endTokenPos": 174,
+            "endFilePos": 347
+          },
+          "name": "s"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 178,
+            "startFilePos": 351,
+            "endLine": 15,
+            "endTokenPos": 178,
+            "endFilePos": 357,
+            "kind": 2,
+            "rawValue": "\"hello\""
+          },
+          "value": "hello"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 16,
+        "startTokenPos": 181,
+        "startFilePos": 360,
+        "endLine": 16,
+        "endTokenPos": 203,
+        "endFilePos": 418
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 184,
+            "startFilePos": 366,
+            "endLine": 16,
+            "endTokenPos": 198,
+            "endFilePos": 407
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 184,
+              "startFilePos": 366,
+              "endLine": 16,
+              "endTokenPos": 190,
+              "endFilePos": 388
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 184,
+                "startFilePos": 366,
+                "endLine": 16,
+                "endTokenPos": 184,
+                "endFilePos": 377
+              },
+              "name": "str_contains"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 186,
+                  "startFilePos": 379,
+                  "endLine": 16,
+                  "endTokenPos": 186,
+                  "endFilePos": 380
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 186,
+                    "startFilePos": 379,
+                    "endLine": 16,
+                    "endTokenPos": 186,
+                    "endFilePos": 380
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 189,
+                  "startFilePos": 383,
+                  "endLine": 16,
+                  "endTokenPos": 189,
+                  "endFilePos": 387
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 189,
+                    "startFilePos": 383,
+                    "endLine": 16,
+                    "endTokenPos": 189,
+                    "endFilePos": 387,
+                    "kind": 2,
+                    "rawValue": "\"ell\""
+                  },
+                  "value": "ell"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 194,
+              "startFilePos": 392,
+              "endLine": 16,
+              "endTokenPos": 194,
+              "endFilePos": 397,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 198,
+              "startFilePos": 401,
+              "endLine": 16,
+              "endTokenPos": 198,
+              "endFilePos": 407,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 202,
+            "startFilePos": 411,
+            "endLine": 16,
+            "endTokenPos": 202,
+            "endFilePos": 417
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 202,
+              "startFilePos": 411,
+              "endLine": 16,
+              "endTokenPos": 202,
+              "endFilePos": 417
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 17,
+        "startTokenPos": 205,
+        "startFilePos": 420,
+        "endLine": 17,
+        "endTokenPos": 227,
+        "endFilePos": 478
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 17,
+            "startTokenPos": 208,
+            "startFilePos": 426,
+            "endLine": 17,
+            "endTokenPos": 222,
+            "endFilePos": 467
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 208,
+              "startFilePos": 426,
+              "endLine": 17,
+              "endTokenPos": 214,
+              "endFilePos": 448
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 17,
+                "startTokenPos": 208,
+                "startFilePos": 426,
+                "endLine": 17,
+                "endTokenPos": 208,
+                "endFilePos": 437
+              },
+              "name": "str_contains"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 17,
+                  "startTokenPos": 210,
+                  "startFilePos": 439,
+                  "endLine": 17,
+                  "endTokenPos": 210,
+                  "endFilePos": 440
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 210,
+                    "startFilePos": 439,
+                    "endLine": 17,
+                    "endTokenPos": 210,
+                    "endFilePos": 440
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 17,
+                  "startTokenPos": 213,
+                  "startFilePos": 443,
+                  "endLine": 17,
+                  "endTokenPos": 213,
+                  "endFilePos": 447
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 213,
+                    "startFilePos": 443,
+                    "endLine": 17,
+                    "endTokenPos": 213,
+                    "endFilePos": 447,
+                    "kind": 2,
+                    "rawValue": "\"foo\""
+                  },
+                  "value": "foo"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 218,
+              "startFilePos": 452,
+              "endLine": 17,
+              "endTokenPos": 218,
+              "endFilePos": 457,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 222,
+              "startFilePos": 461,
+              "endLine": 17,
+              "endTokenPos": 222,
+              "endFilePos": 467,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 17,
+            "startTokenPos": 226,
+            "startFilePos": 471,
+            "endLine": 17,
+            "endTokenPos": 226,
+            "endFilePos": 477
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 226,
+              "startFilePos": 471,
+              "endLine": 17,
+              "endTokenPos": 226,
+              "endFilePos": 477
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/inner_join.php.json
+++ b/tests/json-ast/x/php/inner_join.php.json
@@ -1,0 +1,2542 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 53,
+        "endFilePos": 115
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 52,
+          "endFilePos": 114
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 52,
+            "endFilePos": 114,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 82,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 113
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 82,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 113,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 83,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 86,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 91,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 91,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 94,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 99,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 104,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 55,
+        "startFilePos": 117,
+        "endLine": 3,
+        "endTokenPos": 151,
+        "endFilePos": 326
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 55,
+          "startFilePos": 117,
+          "endLine": 3,
+          "endTokenPos": 150,
+          "endFilePos": 325
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 117,
+            "endLine": 3,
+            "endTokenPos": 55,
+            "endFilePos": 123
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 59,
+            "startFilePos": 127,
+            "endLine": 3,
+            "endTokenPos": 150,
+            "endFilePos": 325,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 128,
+                "endLine": 3,
+                "endTokenPos": 80,
+                "endFilePos": 175
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 80,
+                  "endFilePos": 175,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 139
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 132,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 139,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 142,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 158
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 142,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 158,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 75,
+                      "startFilePos": 161,
+                      "endLine": 3,
+                      "endTokenPos": 79,
+                      "endFilePos": 174
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 75,
+                        "startFilePos": 161,
+                        "endLine": 3,
+                        "endTokenPos": 75,
+                        "endFilePos": 167,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 79,
+                        "startFilePos": 172,
+                        "endLine": 3,
+                        "endTokenPos": 79,
+                        "endFilePos": 174,
+                        "rawValue": "250",
+                        "kind": 10
+                      },
+                      "value": 250
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 83,
+                "startFilePos": 178,
+                "endLine": 3,
+                "endTokenPos": 103,
+                "endFilePos": 225
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 83,
+                  "startFilePos": 178,
+                  "endLine": 3,
+                  "endTokenPos": 103,
+                  "endFilePos": 225,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 179,
+                      "endLine": 3,
+                      "endTokenPos": 88,
+                      "endFilePos": 189
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 84,
+                        "startFilePos": 179,
+                        "endLine": 3,
+                        "endTokenPos": 84,
+                        "endFilePos": 182,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 88,
+                        "startFilePos": 187,
+                        "endLine": 3,
+                        "endTokenPos": 88,
+                        "endFilePos": 189,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 91,
+                      "startFilePos": 192,
+                      "endLine": 3,
+                      "endTokenPos": 95,
+                      "endFilePos": 208
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 91,
+                        "startFilePos": 192,
+                        "endLine": 3,
+                        "endTokenPos": 91,
+                        "endFilePos": 203,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 95,
+                        "startFilePos": 208,
+                        "endLine": 3,
+                        "endTokenPos": 95,
+                        "endFilePos": 208,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 98,
+                      "startFilePos": 211,
+                      "endLine": 3,
+                      "endTokenPos": 102,
+                      "endFilePos": 224
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 98,
+                        "startFilePos": 211,
+                        "endLine": 3,
+                        "endTokenPos": 98,
+                        "endFilePos": 217,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 102,
+                        "startFilePos": 222,
+                        "endLine": 3,
+                        "endTokenPos": 102,
+                        "endFilePos": 224,
+                        "rawValue": "125",
+                        "kind": 10
+                      },
+                      "value": 125
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 106,
+                "startFilePos": 228,
+                "endLine": 3,
+                "endTokenPos": 126,
+                "endFilePos": 275
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 106,
+                  "startFilePos": 228,
+                  "endLine": 3,
+                  "endTokenPos": 126,
+                  "endFilePos": 275,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 107,
+                      "startFilePos": 229,
+                      "endLine": 3,
+                      "endTokenPos": 111,
+                      "endFilePos": 239
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 107,
+                        "startFilePos": 229,
+                        "endLine": 3,
+                        "endTokenPos": 107,
+                        "endFilePos": 232,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 111,
+                        "startFilePos": 237,
+                        "endLine": 3,
+                        "endTokenPos": 111,
+                        "endFilePos": 239,
+                        "rawValue": "102",
+                        "kind": 10
+                      },
+                      "value": 102
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 114,
+                      "startFilePos": 242,
+                      "endLine": 3,
+                      "endTokenPos": 118,
+                      "endFilePos": 258
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 114,
+                        "startFilePos": 242,
+                        "endLine": 3,
+                        "endTokenPos": 114,
+                        "endFilePos": 253,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 118,
+                        "startFilePos": 258,
+                        "endLine": 3,
+                        "endTokenPos": 118,
+                        "endFilePos": 258,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 121,
+                      "startFilePos": 261,
+                      "endLine": 3,
+                      "endTokenPos": 125,
+                      "endFilePos": 274
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 121,
+                        "startFilePos": 261,
+                        "endLine": 3,
+                        "endTokenPos": 121,
+                        "endFilePos": 267,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 125,
+                        "startFilePos": 272,
+                        "endLine": 3,
+                        "endTokenPos": 125,
+                        "endFilePos": 274,
+                        "rawValue": "300",
+                        "kind": 10
+                      },
+                      "value": 300
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 129,
+                "startFilePos": 278,
+                "endLine": 3,
+                "endTokenPos": 149,
+                "endFilePos": 324
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 129,
+                  "startFilePos": 278,
+                  "endLine": 3,
+                  "endTokenPos": 149,
+                  "endFilePos": 324,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 130,
+                      "startFilePos": 279,
+                      "endLine": 3,
+                      "endTokenPos": 134,
+                      "endFilePos": 289
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 130,
+                        "startFilePos": 279,
+                        "endLine": 3,
+                        "endTokenPos": 130,
+                        "endFilePos": 282,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 134,
+                        "startFilePos": 287,
+                        "endLine": 3,
+                        "endTokenPos": 134,
+                        "endFilePos": 289,
+                        "rawValue": "103",
+                        "kind": 10
+                      },
+                      "value": 103
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 137,
+                      "startFilePos": 292,
+                      "endLine": 3,
+                      "endTokenPos": 141,
+                      "endFilePos": 308
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 137,
+                        "startFilePos": 292,
+                        "endLine": 3,
+                        "endTokenPos": 137,
+                        "endFilePos": 303,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 141,
+                        "startFilePos": 308,
+                        "endLine": 3,
+                        "endTokenPos": 141,
+                        "endFilePos": 308,
+                        "rawValue": "4",
+                        "kind": 10
+                      },
+                      "value": 4
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 144,
+                      "startFilePos": 311,
+                      "endLine": 3,
+                      "endTokenPos": 148,
+                      "endFilePos": 323
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 144,
+                        "startFilePos": 311,
+                        "endLine": 3,
+                        "endTokenPos": 144,
+                        "endFilePos": 317,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 148,
+                        "startFilePos": 322,
+                        "endLine": 3,
+                        "endTokenPos": 148,
+                        "endFilePos": 323,
+                        "rawValue": "80",
+                        "kind": 10
+                      },
+                      "value": 80
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 153,
+        "startFilePos": 328,
+        "endLine": 4,
+        "endTokenPos": 159,
+        "endFilePos": 340
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 153,
+          "startFilePos": 328,
+          "endLine": 4,
+          "endTokenPos": 158,
+          "endFilePos": 339
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 153,
+            "startFilePos": 328,
+            "endLine": 4,
+            "endTokenPos": 153,
+            "endFilePos": 334
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 157,
+            "startFilePos": 338,
+            "endLine": 4,
+            "endTokenPos": 158,
+            "endFilePos": 339,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 161,
+        "startFilePos": 342,
+        "endLine": 11,
+        "endTokenPos": 245,
+        "endFilePos": 546
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 164,
+          "startFilePos": 351,
+          "endLine": 5,
+          "endTokenPos": 164,
+          "endFilePos": 357
+        },
+        "name": "orders"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 168,
+          "startFilePos": 362,
+          "endLine": 5,
+          "endTokenPos": 168,
+          "endFilePos": 363
+        },
+        "name": "o"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 173,
+            "startFilePos": 370,
+            "endLine": 10,
+            "endTokenPos": 243,
+            "endFilePos": 544
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 176,
+              "startFilePos": 379,
+              "endLine": 6,
+              "endTokenPos": 176,
+              "endFilePos": 388
+            },
+            "name": "customers"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 180,
+              "startFilePos": 393,
+              "endLine": 6,
+              "endTokenPos": 180,
+              "endFilePos": 394
+            },
+            "name": "c"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_If",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 185,
+                "startFilePos": 403,
+                "endLine": 9,
+                "endTokenPos": 241,
+                "endFilePos": 540
+              },
+              "cond": {
+                "nodeType": "Expr_BinaryOp_Equal",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 188,
+                  "startFilePos": 407,
+                  "endLine": 7,
+                  "endTokenPos": 198,
+                  "endFilePos": 434
+                },
+                "left": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 188,
+                    "startFilePos": 407,
+                    "endLine": 7,
+                    "endTokenPos": 191,
+                    "endFilePos": 422
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 188,
+                      "startFilePos": 407,
+                      "endLine": 7,
+                      "endTokenPos": 188,
+                      "endFilePos": 408
+                    },
+                    "name": "o"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 190,
+                      "startFilePos": 410,
+                      "endLine": 7,
+                      "endTokenPos": 190,
+                      "endFilePos": 421,
+                      "kind": 2,
+                      "rawValue": "\"customerId\""
+                    },
+                    "value": "customerId"
+                  }
+                },
+                "right": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 195,
+                    "startFilePos": 427,
+                    "endLine": 7,
+                    "endTokenPos": 198,
+                    "endFilePos": 434
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 195,
+                      "startFilePos": 427,
+                      "endLine": 7,
+                      "endTokenPos": 195,
+                      "endFilePos": 428
+                    },
+                    "name": "c"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 197,
+                      "startFilePos": 430,
+                      "endLine": 7,
+                      "endTokenPos": 197,
+                      "endFilePos": 433,
+                      "kind": 2,
+                      "rawValue": "\"id\""
+                    },
+                    "value": "id"
+                  }
+                }
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_Expression",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 203,
+                    "startFilePos": 445,
+                    "endLine": 8,
+                    "endTokenPos": 239,
+                    "endFilePos": 534
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Assign",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 203,
+                      "startFilePos": 445,
+                      "endLine": 8,
+                      "endTokenPos": 238,
+                      "endFilePos": 533
+                    },
+                    "var": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 203,
+                        "startFilePos": 445,
+                        "endLine": 8,
+                        "endTokenPos": 205,
+                        "endFilePos": 453
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 203,
+                          "startFilePos": 445,
+                          "endLine": 8,
+                          "endTokenPos": 203,
+                          "endFilePos": 451
+                        },
+                        "name": "result"
+                      },
+                      "dim": null
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Array",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 209,
+                        "startFilePos": 457,
+                        "endLine": 8,
+                        "endTokenPos": 238,
+                        "endFilePos": 533,
+                        "kind": 2
+                      },
+                      "items": [
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 210,
+                            "startFilePos": 458,
+                            "endLine": 8,
+                            "endTokenPos": 217,
+                            "endFilePos": 478
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 210,
+                              "startFilePos": 458,
+                              "endLine": 8,
+                              "endTokenPos": 210,
+                              "endFilePos": 466,
+                              "kind": 2,
+                              "rawValue": "\"orderId\""
+                            },
+                            "value": "orderId"
+                          },
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 214,
+                              "startFilePos": 471,
+                              "endLine": 8,
+                              "endTokenPos": 217,
+                              "endFilePos": 478
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 214,
+                                "startFilePos": 471,
+                                "endLine": 8,
+                                "endTokenPos": 214,
+                                "endFilePos": 472
+                              },
+                              "name": "o"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 216,
+                                "startFilePos": 474,
+                                "endLine": 8,
+                                "endTokenPos": 216,
+                                "endFilePos": 477,
+                                "kind": 2,
+                                "rawValue": "\"id\""
+                              },
+                              "value": "id"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 220,
+                            "startFilePos": 481,
+                            "endLine": 8,
+                            "endTokenPos": 227,
+                            "endFilePos": 508
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 220,
+                              "startFilePos": 481,
+                              "endLine": 8,
+                              "endTokenPos": 220,
+                              "endFilePos": 494,
+                              "kind": 2,
+                              "rawValue": "\"customerName\""
+                            },
+                            "value": "customerName"
+                          },
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 224,
+                              "startFilePos": 499,
+                              "endLine": 8,
+                              "endTokenPos": 227,
+                              "endFilePos": 508
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 224,
+                                "startFilePos": 499,
+                                "endLine": 8,
+                                "endTokenPos": 224,
+                                "endFilePos": 500
+                              },
+                              "name": "c"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 226,
+                                "startFilePos": 502,
+                                "endLine": 8,
+                                "endTokenPos": 226,
+                                "endFilePos": 507,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "ArrayItem",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 230,
+                            "startFilePos": 511,
+                            "endLine": 8,
+                            "endTokenPos": 237,
+                            "endFilePos": 532
+                          },
+                          "key": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 230,
+                              "startFilePos": 511,
+                              "endLine": 8,
+                              "endTokenPos": 230,
+                              "endFilePos": 517,
+                              "kind": 2,
+                              "rawValue": "\"total\""
+                            },
+                            "value": "total"
+                          },
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 234,
+                              "startFilePos": 522,
+                              "endLine": 8,
+                              "endTokenPos": 237,
+                              "endFilePos": 532
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 234,
+                                "startFilePos": 522,
+                                "endLine": 8,
+                                "endTokenPos": 234,
+                                "endFilePos": 523
+                              },
+                              "name": "o"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 236,
+                                "startFilePos": 525,
+                                "endLine": 8,
+                                "endTokenPos": 236,
+                                "endFilePos": 531,
+                                "kind": 2,
+                                "rawValue": "\"total\""
+                              },
+                              "value": "total"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "elseifs": [],
+              "else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 13,
+        "startTokenPos": 247,
+        "startFilePos": 549,
+        "endLine": 13,
+        "endTokenPos": 253,
+        "endFilePos": 598
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 249,
+            "startFilePos": 554,
+            "endLine": 13,
+            "endTokenPos": 249,
+            "endFilePos": 588,
+            "kind": 2,
+            "rawValue": "\"--- Orders with customer info ---\""
+          },
+          "value": "--- Orders with customer info ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 252,
+            "startFilePos": 591,
+            "endLine": 13,
+            "endTokenPos": 252,
+            "endFilePos": 597
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 252,
+              "startFilePos": 591,
+              "endLine": 13,
+              "endTokenPos": 252,
+              "endFilePos": 597
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 14,
+        "startTokenPos": 255,
+        "startFilePos": 600,
+        "endLine": 16,
+        "endTokenPos": 399,
+        "endFilePos": 982
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 14,
+          "startTokenPos": 258,
+          "startFilePos": 609,
+          "endLine": 14,
+          "endTokenPos": 258,
+          "endFilePos": 615
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 14,
+          "startTokenPos": 262,
+          "startFilePos": 620,
+          "endLine": 14,
+          "endTokenPos": 262,
+          "endFilePos": 625
+        },
+        "name": "entry"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 267,
+            "startFilePos": 632,
+            "endLine": 15,
+            "endTokenPos": 397,
+            "endFilePos": 980
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 269,
+                "startFilePos": 637,
+                "endLine": 15,
+                "endTokenPos": 393,
+                "endFilePos": 970
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 269,
+                  "startFilePos": 637,
+                  "endLine": 15,
+                  "endTokenPos": 361,
+                  "endFilePos": 885
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 269,
+                    "startFilePos": 637,
+                    "endLine": 15,
+                    "endTokenPos": 357,
+                    "endFilePos": 879
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 269,
+                      "startFilePos": 637,
+                      "endLine": 15,
+                      "endTokenPos": 353,
+                      "endFilePos": 871
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 269,
+                        "startFilePos": 637,
+                        "endLine": 15,
+                        "endTokenPos": 349,
+                        "endFilePos": 865
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 269,
+                          "startFilePos": 637,
+                          "endLine": 15,
+                          "endTokenPos": 317,
+                          "endFilePos": 759
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 269,
+                            "startFilePos": 637,
+                            "endLine": 15,
+                            "endTokenPos": 313,
+                            "endFilePos": 753
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 269,
+                              "startFilePos": 637,
+                              "endLine": 15,
+                              "endTokenPos": 309,
+                              "endFilePos": 746
+                            },
+                            "left": {
+                              "nodeType": "Expr_BinaryOp_Concat",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 269,
+                                "startFilePos": 637,
+                                "endLine": 15,
+                                "endTokenPos": 305,
+                                "endFilePos": 740
+                              },
+                              "left": {
+                                "nodeType": "Expr_BinaryOp_Concat",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 269,
+                                  "startFilePos": 637,
+                                  "endLine": 15,
+                                  "endTokenPos": 273,
+                                  "endFilePos": 649
+                                },
+                                "left": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 269,
+                                    "startFilePos": 637,
+                                    "endLine": 15,
+                                    "endTokenPos": 269,
+                                    "endFilePos": 643,
+                                    "kind": 2,
+                                    "rawValue": "\"Order\""
+                                  },
+                                  "value": "Order"
+                                },
+                                "right": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 273,
+                                    "startFilePos": 647,
+                                    "endLine": 15,
+                                    "endTokenPos": 273,
+                                    "endFilePos": 649,
+                                    "kind": 2,
+                                    "rawValue": "\" \""
+                                  },
+                                  "value": " "
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_Ternary",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 278,
+                                  "startFilePos": 654,
+                                  "endLine": 15,
+                                  "endTokenPos": 304,
+                                  "endFilePos": 739
+                                },
+                                "cond": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 278,
+                                    "startFilePos": 654,
+                                    "endLine": 15,
+                                    "endTokenPos": 284,
+                                    "endFilePos": 680
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 278,
+                                      "startFilePos": 654,
+                                      "endLine": 15,
+                                      "endTokenPos": 278,
+                                      "endFilePos": 661
+                                    },
+                                    "name": "is_float"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 280,
+                                        "startFilePos": 663,
+                                        "endLine": 15,
+                                        "endTokenPos": 283,
+                                        "endFilePos": 679
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 280,
+                                          "startFilePos": 663,
+                                          "endLine": 15,
+                                          "endTokenPos": 283,
+                                          "endFilePos": 679
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 15,
+                                            "startTokenPos": 280,
+                                            "startFilePos": 663,
+                                            "endLine": 15,
+                                            "endTokenPos": 280,
+                                            "endFilePos": 668
+                                          },
+                                          "name": "entry"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 15,
+                                            "startTokenPos": 282,
+                                            "startFilePos": 670,
+                                            "endLine": 15,
+                                            "endTokenPos": 282,
+                                            "endFilePos": 678,
+                                            "kind": 2,
+                                            "rawValue": "\"orderId\""
+                                          },
+                                          "value": "orderId"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "if": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 288,
+                                    "startFilePos": 684,
+                                    "endLine": 15,
+                                    "endTokenPos": 297,
+                                    "endFilePos": 719
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 288,
+                                      "startFilePos": 684,
+                                      "endLine": 15,
+                                      "endTokenPos": 288,
+                                      "endFilePos": 694
+                                    },
+                                    "name": "json_encode"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 290,
+                                        "startFilePos": 696,
+                                        "endLine": 15,
+                                        "endTokenPos": 293,
+                                        "endFilePos": 712
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 290,
+                                          "startFilePos": 696,
+                                          "endLine": 15,
+                                          "endTokenPos": 293,
+                                          "endFilePos": 712
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 15,
+                                            "startTokenPos": 290,
+                                            "startFilePos": 696,
+                                            "endLine": 15,
+                                            "endTokenPos": 290,
+                                            "endFilePos": 701
+                                          },
+                                          "name": "entry"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 15,
+                                            "startTokenPos": 292,
+                                            "startFilePos": 703,
+                                            "endLine": 15,
+                                            "endTokenPos": 292,
+                                            "endFilePos": 711,
+                                            "kind": 2,
+                                            "rawValue": "\"orderId\""
+                                          },
+                                          "value": "orderId"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 15,
+                                        "startTokenPos": 296,
+                                        "startFilePos": 715,
+                                        "endLine": 15,
+                                        "endTokenPos": 296,
+                                        "endFilePos": 718
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_Int",
+                                        "attributes": {
+                                          "startLine": 15,
+                                          "startTokenPos": 296,
+                                          "startFilePos": 715,
+                                          "endLine": 15,
+                                          "endTokenPos": 296,
+                                          "endFilePos": 718,
+                                          "rawValue": "1344",
+                                          "kind": 10
+                                        },
+                                        "value": 1344
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "else": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 301,
+                                    "startFilePos": 723,
+                                    "endLine": 15,
+                                    "endTokenPos": 304,
+                                    "endFilePos": 739
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 301,
+                                      "startFilePos": 723,
+                                      "endLine": 15,
+                                      "endTokenPos": 301,
+                                      "endFilePos": 728
+                                    },
+                                    "name": "entry"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 303,
+                                      "startFilePos": 730,
+                                      "endLine": 15,
+                                      "endTokenPos": 303,
+                                      "endFilePos": 738,
+                                      "kind": 2,
+                                      "rawValue": "\"orderId\""
+                                    },
+                                    "value": "orderId"
+                                  }
+                                }
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 309,
+                                "startFilePos": 744,
+                                "endLine": 15,
+                                "endTokenPos": 309,
+                                "endFilePos": 746,
+                                "kind": 2,
+                                "rawValue": "\" \""
+                              },
+                              "value": " "
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 313,
+                              "startFilePos": 750,
+                              "endLine": 15,
+                              "endTokenPos": 313,
+                              "endFilePos": 753,
+                              "kind": 2,
+                              "rawValue": "\"by\""
+                            },
+                            "value": "by"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 317,
+                            "startFilePos": 757,
+                            "endLine": 15,
+                            "endTokenPos": 317,
+                            "endFilePos": 759,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_Ternary",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 322,
+                          "startFilePos": 764,
+                          "endLine": 15,
+                          "endTokenPos": 348,
+                          "endFilePos": 864
+                        },
+                        "cond": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 322,
+                            "startFilePos": 764,
+                            "endLine": 15,
+                            "endTokenPos": 328,
+                            "endFilePos": 795
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 322,
+                              "startFilePos": 764,
+                              "endLine": 15,
+                              "endTokenPos": 322,
+                              "endFilePos": 771
+                            },
+                            "name": "is_float"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 324,
+                                "startFilePos": 773,
+                                "endLine": 15,
+                                "endTokenPos": 327,
+                                "endFilePos": 794
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 324,
+                                  "startFilePos": 773,
+                                  "endLine": 15,
+                                  "endTokenPos": 327,
+                                  "endFilePos": 794
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 324,
+                                    "startFilePos": 773,
+                                    "endLine": 15,
+                                    "endTokenPos": 324,
+                                    "endFilePos": 778
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 326,
+                                    "startFilePos": 780,
+                                    "endLine": 15,
+                                    "endTokenPos": 326,
+                                    "endFilePos": 793,
+                                    "kind": 2,
+                                    "rawValue": "\"customerName\""
+                                  },
+                                  "value": "customerName"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "if": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 332,
+                            "startFilePos": 799,
+                            "endLine": 15,
+                            "endTokenPos": 341,
+                            "endFilePos": 839
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 332,
+                              "startFilePos": 799,
+                              "endLine": 15,
+                              "endTokenPos": 332,
+                              "endFilePos": 809
+                            },
+                            "name": "json_encode"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 334,
+                                "startFilePos": 811,
+                                "endLine": 15,
+                                "endTokenPos": 337,
+                                "endFilePos": 832
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 334,
+                                  "startFilePos": 811,
+                                  "endLine": 15,
+                                  "endTokenPos": 337,
+                                  "endFilePos": 832
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 334,
+                                    "startFilePos": 811,
+                                    "endLine": 15,
+                                    "endTokenPos": 334,
+                                    "endFilePos": 816
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 336,
+                                    "startFilePos": 818,
+                                    "endLine": 15,
+                                    "endTokenPos": 336,
+                                    "endFilePos": 831,
+                                    "kind": 2,
+                                    "rawValue": "\"customerName\""
+                                  },
+                                  "value": "customerName"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 340,
+                                "startFilePos": 835,
+                                "endLine": 15,
+                                "endTokenPos": 340,
+                                "endFilePos": 838
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 340,
+                                  "startFilePos": 835,
+                                  "endLine": 15,
+                                  "endTokenPos": 340,
+                                  "endFilePos": 838,
+                                  "rawValue": "1344",
+                                  "kind": 10
+                                },
+                                "value": 1344
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "else": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 345,
+                            "startFilePos": 843,
+                            "endLine": 15,
+                            "endTokenPos": 348,
+                            "endFilePos": 864
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 345,
+                              "startFilePos": 843,
+                              "endLine": 15,
+                              "endTokenPos": 345,
+                              "endFilePos": 848
+                            },
+                            "name": "entry"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 347,
+                              "startFilePos": 850,
+                              "endLine": 15,
+                              "endTokenPos": 347,
+                              "endFilePos": 863,
+                              "kind": 2,
+                              "rawValue": "\"customerName\""
+                            },
+                            "value": "customerName"
+                          }
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 353,
+                        "startFilePos": 869,
+                        "endLine": 15,
+                        "endTokenPos": 353,
+                        "endFilePos": 871,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 357,
+                      "startFilePos": 875,
+                      "endLine": 15,
+                      "endTokenPos": 357,
+                      "endFilePos": 879,
+                      "kind": 2,
+                      "rawValue": "\"- $\""
+                    },
+                    "value": "- $"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 361,
+                    "startFilePos": 883,
+                    "endLine": 15,
+                    "endTokenPos": 361,
+                    "endFilePos": 885,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 366,
+                  "startFilePos": 890,
+                  "endLine": 15,
+                  "endTokenPos": 392,
+                  "endFilePos": 969
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 366,
+                    "startFilePos": 890,
+                    "endLine": 15,
+                    "endTokenPos": 372,
+                    "endFilePos": 914
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 366,
+                      "startFilePos": 890,
+                      "endLine": 15,
+                      "endTokenPos": 366,
+                      "endFilePos": 897
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 368,
+                        "startFilePos": 899,
+                        "endLine": 15,
+                        "endTokenPos": 371,
+                        "endFilePos": 913
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 368,
+                          "startFilePos": 899,
+                          "endLine": 15,
+                          "endTokenPos": 371,
+                          "endFilePos": 913
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 368,
+                            "startFilePos": 899,
+                            "endLine": 15,
+                            "endTokenPos": 368,
+                            "endFilePos": 904
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 370,
+                            "startFilePos": 906,
+                            "endLine": 15,
+                            "endTokenPos": 370,
+                            "endFilePos": 912,
+                            "kind": 2,
+                            "rawValue": "\"total\""
+                          },
+                          "value": "total"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 376,
+                    "startFilePos": 918,
+                    "endLine": 15,
+                    "endTokenPos": 385,
+                    "endFilePos": 951
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 376,
+                      "startFilePos": 918,
+                      "endLine": 15,
+                      "endTokenPos": 376,
+                      "endFilePos": 928
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 378,
+                        "startFilePos": 930,
+                        "endLine": 15,
+                        "endTokenPos": 381,
+                        "endFilePos": 944
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 378,
+                          "startFilePos": 930,
+                          "endLine": 15,
+                          "endTokenPos": 381,
+                          "endFilePos": 944
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 378,
+                            "startFilePos": 930,
+                            "endLine": 15,
+                            "endTokenPos": 378,
+                            "endFilePos": 935
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 380,
+                            "startFilePos": 937,
+                            "endLine": 15,
+                            "endTokenPos": 380,
+                            "endFilePos": 943,
+                            "kind": 2,
+                            "rawValue": "\"total\""
+                          },
+                          "value": "total"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 15,
+                        "startTokenPos": 384,
+                        "startFilePos": 947,
+                        "endLine": 15,
+                        "endTokenPos": 384,
+                        "endFilePos": 950
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 384,
+                          "startFilePos": 947,
+                          "endLine": 15,
+                          "endTokenPos": 384,
+                          "endFilePos": 950,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 389,
+                    "startFilePos": 955,
+                    "endLine": 15,
+                    "endTokenPos": 392,
+                    "endFilePos": 969
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 389,
+                      "startFilePos": 955,
+                      "endLine": 15,
+                      "endTokenPos": 389,
+                      "endFilePos": 960
+                    },
+                    "name": "entry"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 391,
+                      "startFilePos": 962,
+                      "endLine": 15,
+                      "endTokenPos": 391,
+                      "endFilePos": 968,
+                      "kind": 2,
+                      "rawValue": "\"total\""
+                    },
+                    "value": "total"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 396,
+                "startFilePos": 973,
+                "endLine": 15,
+                "endTokenPos": 396,
+                "endFilePos": 979
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 396,
+                  "startFilePos": 973,
+                  "endLine": 15,
+                  "endTokenPos": 396,
+                  "endFilePos": 979
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/join_multi.php.json
+++ b/tests/json-ast/x/php/join_multi.php.json
@@ -1,0 +1,2023 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 37,
+        "endFilePos": 81
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 36,
+          "endFilePos": 80
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 36,
+            "endFilePos": 80,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 39,
+        "startFilePos": 83,
+        "endLine": 3,
+        "endTokenPos": 75,
+        "endFilePos": 161
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 39,
+          "startFilePos": 83,
+          "endLine": 3,
+          "endTokenPos": 74,
+          "endFilePos": 160
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 39,
+            "startFilePos": 83,
+            "endLine": 3,
+            "endTokenPos": 39,
+            "endFilePos": 89
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 43,
+            "startFilePos": 93,
+            "endLine": 3,
+            "endTokenPos": 74,
+            "endFilePos": 160,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 44,
+                "startFilePos": 94,
+                "endLine": 3,
+                "endTokenPos": 57,
+                "endFilePos": 125
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 94,
+                  "endLine": 3,
+                  "endTokenPos": 57,
+                  "endFilePos": 125,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 45,
+                      "startFilePos": 95,
+                      "endLine": 3,
+                      "endTokenPos": 49,
+                      "endFilePos": 105
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 45,
+                        "startFilePos": 95,
+                        "endLine": 3,
+                        "endTokenPos": 45,
+                        "endFilePos": 98,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 49,
+                        "startFilePos": 103,
+                        "endLine": 3,
+                        "endTokenPos": 49,
+                        "endFilePos": 105,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 52,
+                      "startFilePos": 108,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 124
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 52,
+                        "startFilePos": 108,
+                        "endLine": 3,
+                        "endTokenPos": 52,
+                        "endFilePos": 119,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 56,
+                        "startFilePos": 124,
+                        "endLine": 3,
+                        "endTokenPos": 56,
+                        "endFilePos": 124,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 128,
+                "endLine": 3,
+                "endTokenPos": 73,
+                "endFilePos": 159
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 73,
+                  "endFilePos": 159,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 139
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 132,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 139,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 142,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 158
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 142,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 158,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 77,
+        "startFilePos": 163,
+        "endLine": 4,
+        "endTokenPos": 113,
+        "endFilePos": 240
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 77,
+          "startFilePos": 163,
+          "endLine": 4,
+          "endTokenPos": 112,
+          "endFilePos": 239
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 77,
+            "startFilePos": 163,
+            "endLine": 4,
+            "endTokenPos": 77,
+            "endFilePos": 168
+          },
+          "name": "items"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 81,
+            "startFilePos": 172,
+            "endLine": 4,
+            "endTokenPos": 112,
+            "endFilePos": 239,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 82,
+                "startFilePos": 173,
+                "endLine": 4,
+                "endTokenPos": 95,
+                "endFilePos": 204
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 82,
+                  "startFilePos": 173,
+                  "endLine": 4,
+                  "endTokenPos": 95,
+                  "endFilePos": 204,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 83,
+                      "startFilePos": 174,
+                      "endLine": 4,
+                      "endTokenPos": 87,
+                      "endFilePos": 189
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 83,
+                        "startFilePos": 174,
+                        "endLine": 4,
+                        "endTokenPos": 83,
+                        "endFilePos": 182,
+                        "kind": 2,
+                        "rawValue": "\"orderId\""
+                      },
+                      "value": "orderId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 87,
+                        "startFilePos": 187,
+                        "endLine": 4,
+                        "endTokenPos": 87,
+                        "endFilePos": 189,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 90,
+                      "startFilePos": 192,
+                      "endLine": 4,
+                      "endTokenPos": 94,
+                      "endFilePos": 203
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 90,
+                        "startFilePos": 192,
+                        "endLine": 4,
+                        "endTokenPos": 90,
+                        "endFilePos": 196,
+                        "kind": 2,
+                        "rawValue": "\"sku\""
+                      },
+                      "value": "sku"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 94,
+                        "startFilePos": 201,
+                        "endLine": 4,
+                        "endTokenPos": 94,
+                        "endFilePos": 203,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 98,
+                "startFilePos": 207,
+                "endLine": 4,
+                "endTokenPos": 111,
+                "endFilePos": 238
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 98,
+                  "startFilePos": 207,
+                  "endLine": 4,
+                  "endTokenPos": 111,
+                  "endFilePos": 238,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 99,
+                      "startFilePos": 208,
+                      "endLine": 4,
+                      "endTokenPos": 103,
+                      "endFilePos": 223
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 99,
+                        "startFilePos": 208,
+                        "endLine": 4,
+                        "endTokenPos": 99,
+                        "endFilePos": 216,
+                        "kind": 2,
+                        "rawValue": "\"orderId\""
+                      },
+                      "value": "orderId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 103,
+                        "startFilePos": 221,
+                        "endLine": 4,
+                        "endTokenPos": 103,
+                        "endFilePos": 223,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 106,
+                      "startFilePos": 226,
+                      "endLine": 4,
+                      "endTokenPos": 110,
+                      "endFilePos": 237
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 106,
+                        "startFilePos": 226,
+                        "endLine": 4,
+                        "endTokenPos": 106,
+                        "endFilePos": 230,
+                        "kind": 2,
+                        "rawValue": "\"sku\""
+                      },
+                      "value": "sku"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 110,
+                        "startFilePos": 235,
+                        "endLine": 4,
+                        "endTokenPos": 110,
+                        "endFilePos": 237,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 115,
+        "startFilePos": 242,
+        "endLine": 5,
+        "endTokenPos": 121,
+        "endFilePos": 254
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 115,
+          "startFilePos": 242,
+          "endLine": 5,
+          "endTokenPos": 120,
+          "endFilePos": 253
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 115,
+            "startFilePos": 242,
+            "endLine": 5,
+            "endTokenPos": 115,
+            "endFilePos": 248
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 119,
+            "startFilePos": 252,
+            "endLine": 5,
+            "endTokenPos": 120,
+            "endFilePos": 253,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 123,
+        "startFilePos": 256,
+        "endLine": 14,
+        "endTokenPos": 225,
+        "endFilePos": 495
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 126,
+          "startFilePos": 265,
+          "endLine": 6,
+          "endTokenPos": 126,
+          "endFilePos": 271
+        },
+        "name": "orders"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 130,
+          "startFilePos": 276,
+          "endLine": 6,
+          "endTokenPos": 130,
+          "endFilePos": 277
+        },
+        "name": "o"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 135,
+            "startFilePos": 284,
+            "endLine": 13,
+            "endTokenPos": 223,
+            "endFilePos": 493
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 138,
+              "startFilePos": 293,
+              "endLine": 7,
+              "endTokenPos": 138,
+              "endFilePos": 302
+            },
+            "name": "customers"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 142,
+              "startFilePos": 307,
+              "endLine": 7,
+              "endTokenPos": 142,
+              "endFilePos": 308
+            },
+            "name": "c"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Foreach",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 147,
+                "startFilePos": 317,
+                "endLine": 12,
+                "endTokenPos": 221,
+                "endFilePos": 489
+              },
+              "expr": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 150,
+                  "startFilePos": 326,
+                  "endLine": 8,
+                  "endTokenPos": 150,
+                  "endFilePos": 331
+                },
+                "name": "items"
+              },
+              "keyVar": null,
+              "byRef": false,
+              "valueVar": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 154,
+                  "startFilePos": 336,
+                  "endLine": 8,
+                  "endTokenPos": 154,
+                  "endFilePos": 337
+                },
+                "name": "i"
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_If",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 159,
+                    "startFilePos": 348,
+                    "endLine": 11,
+                    "endTokenPos": 219,
+                    "endFilePos": 483
+                  },
+                  "cond": {
+                    "nodeType": "Expr_BinaryOp_BooleanAnd",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 162,
+                      "startFilePos": 352,
+                      "endLine": 9,
+                      "endTokenPos": 186,
+                      "endFilePos": 408
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Equal",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 162,
+                        "startFilePos": 352,
+                        "endLine": 9,
+                        "endTokenPos": 172,
+                        "endFilePos": 379
+                      },
+                      "left": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 162,
+                          "startFilePos": 352,
+                          "endLine": 9,
+                          "endTokenPos": 165,
+                          "endFilePos": 367
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 162,
+                            "startFilePos": 352,
+                            "endLine": 9,
+                            "endTokenPos": 162,
+                            "endFilePos": 353
+                          },
+                          "name": "o"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 164,
+                            "startFilePos": 355,
+                            "endLine": 9,
+                            "endTokenPos": 164,
+                            "endFilePos": 366,
+                            "kind": 2,
+                            "rawValue": "\"customerId\""
+                          },
+                          "value": "customerId"
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 169,
+                          "startFilePos": 372,
+                          "endLine": 9,
+                          "endTokenPos": 172,
+                          "endFilePos": 379
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 169,
+                            "startFilePos": 372,
+                            "endLine": 9,
+                            "endTokenPos": 169,
+                            "endFilePos": 373
+                          },
+                          "name": "c"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 171,
+                            "startFilePos": 375,
+                            "endLine": 9,
+                            "endTokenPos": 171,
+                            "endFilePos": 378,
+                            "kind": 2,
+                            "rawValue": "\"id\""
+                          },
+                          "value": "id"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Expr_BinaryOp_Equal",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 176,
+                        "startFilePos": 384,
+                        "endLine": 9,
+                        "endTokenPos": 186,
+                        "endFilePos": 408
+                      },
+                      "left": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 176,
+                          "startFilePos": 384,
+                          "endLine": 9,
+                          "endTokenPos": 179,
+                          "endFilePos": 391
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 176,
+                            "startFilePos": 384,
+                            "endLine": 9,
+                            "endTokenPos": 176,
+                            "endFilePos": 385
+                          },
+                          "name": "o"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 178,
+                            "startFilePos": 387,
+                            "endLine": 9,
+                            "endTokenPos": 178,
+                            "endFilePos": 390,
+                            "kind": 2,
+                            "rawValue": "\"id\""
+                          },
+                          "value": "id"
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 183,
+                          "startFilePos": 396,
+                          "endLine": 9,
+                          "endTokenPos": 186,
+                          "endFilePos": 408
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 183,
+                            "startFilePos": 396,
+                            "endLine": 9,
+                            "endTokenPos": 183,
+                            "endFilePos": 397
+                          },
+                          "name": "i"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 185,
+                            "startFilePos": 399,
+                            "endLine": 9,
+                            "endTokenPos": 185,
+                            "endFilePos": 407,
+                            "kind": 2,
+                            "rawValue": "\"orderId\""
+                          },
+                          "value": "orderId"
+                        }
+                      }
+                    }
+                  },
+                  "stmts": [
+                    {
+                      "nodeType": "Stmt_Expression",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 191,
+                        "startFilePos": 421,
+                        "endLine": 10,
+                        "endTokenPos": 217,
+                        "endFilePos": 475
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Assign",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 191,
+                          "startFilePos": 421,
+                          "endLine": 10,
+                          "endTokenPos": 216,
+                          "endFilePos": 474
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 191,
+                            "startFilePos": 421,
+                            "endLine": 10,
+                            "endTokenPos": 193,
+                            "endFilePos": 429
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 191,
+                              "startFilePos": 421,
+                              "endLine": 10,
+                              "endTokenPos": 191,
+                              "endFilePos": 427
+                            },
+                            "name": "result"
+                          },
+                          "dim": null
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 197,
+                            "startFilePos": 433,
+                            "endLine": 10,
+                            "endTokenPos": 216,
+                            "endFilePos": 474,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 198,
+                                "startFilePos": 434,
+                                "endLine": 10,
+                                "endTokenPos": 205,
+                                "endFilePos": 453
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 198,
+                                  "startFilePos": 434,
+                                  "endLine": 10,
+                                  "endTokenPos": 198,
+                                  "endFilePos": 439,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 202,
+                                  "startFilePos": 444,
+                                  "endLine": 10,
+                                  "endTokenPos": 205,
+                                  "endFilePos": 453
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 202,
+                                    "startFilePos": 444,
+                                    "endLine": 10,
+                                    "endTokenPos": 202,
+                                    "endFilePos": 445
+                                  },
+                                  "name": "c"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 204,
+                                    "startFilePos": 447,
+                                    "endLine": 10,
+                                    "endTokenPos": 204,
+                                    "endFilePos": 452,
+                                    "kind": 2,
+                                    "rawValue": "\"name\""
+                                  },
+                                  "value": "name"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 208,
+                                "startFilePos": 456,
+                                "endLine": 10,
+                                "endTokenPos": 215,
+                                "endFilePos": 473
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 208,
+                                  "startFilePos": 456,
+                                  "endLine": 10,
+                                  "endTokenPos": 208,
+                                  "endFilePos": 460,
+                                  "kind": 2,
+                                  "rawValue": "\"sku\""
+                                },
+                                "value": "sku"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 10,
+                                  "startTokenPos": 212,
+                                  "startFilePos": 465,
+                                  "endLine": 10,
+                                  "endTokenPos": 215,
+                                  "endFilePos": 473
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 212,
+                                    "startFilePos": 465,
+                                    "endLine": 10,
+                                    "endTokenPos": 212,
+                                    "endFilePos": 466
+                                  },
+                                  "name": "i"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 10,
+                                    "startTokenPos": 214,
+                                    "startFilePos": 468,
+                                    "endLine": 10,
+                                    "endTokenPos": 214,
+                                    "endFilePos": 472,
+                                    "kind": 2,
+                                    "rawValue": "\"sku\""
+                                  },
+                                  "value": "sku"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "elseifs": [],
+                  "else": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 16,
+        "startTokenPos": 227,
+        "startFilePos": 498,
+        "endLine": 16,
+        "endTokenPos": 233,
+        "endFilePos": 532
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 229,
+            "startFilePos": 503,
+            "endLine": 16,
+            "endTokenPos": 229,
+            "endFilePos": 522,
+            "kind": 2,
+            "rawValue": "\"--- Multi Join ---\""
+          },
+          "value": "--- Multi Join ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 232,
+            "startFilePos": 525,
+            "endLine": 16,
+            "endTokenPos": 232,
+            "endFilePos": 531
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 232,
+              "startFilePos": 525,
+              "endLine": 16,
+              "endTokenPos": 232,
+              "endFilePos": 531
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 17,
+        "startTokenPos": 235,
+        "startFilePos": 534,
+        "endLine": 19,
+        "endTokenPos": 327,
+        "endFilePos": 740
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 17,
+          "startTokenPos": 238,
+          "startFilePos": 543,
+          "endLine": 17,
+          "endTokenPos": 238,
+          "endFilePos": 549
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 17,
+          "startTokenPos": 242,
+          "startFilePos": 554,
+          "endLine": 17,
+          "endTokenPos": 242,
+          "endFilePos": 555
+        },
+        "name": "r"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 247,
+            "startFilePos": 562,
+            "endLine": 18,
+            "endTokenPos": 325,
+            "endFilePos": 738
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 249,
+                "startFilePos": 567,
+                "endLine": 18,
+                "endTokenPos": 321,
+                "endFilePos": 728
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 249,
+                  "startFilePos": 567,
+                  "endLine": 18,
+                  "endTokenPos": 289,
+                  "endFilePos": 661
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 249,
+                    "startFilePos": 567,
+                    "endLine": 18,
+                    "endTokenPos": 285,
+                    "endFilePos": 655
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 249,
+                      "startFilePos": 567,
+                      "endLine": 18,
+                      "endTokenPos": 281,
+                      "endFilePos": 639
+                    },
+                    "left": {
+                      "nodeType": "Expr_Ternary",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 250,
+                        "startFilePos": 568,
+                        "endLine": 18,
+                        "endTokenPos": 276,
+                        "endFilePos": 632
+                      },
+                      "cond": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 250,
+                          "startFilePos": 568,
+                          "endLine": 18,
+                          "endTokenPos": 256,
+                          "endFilePos": 587
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 250,
+                            "startFilePos": 568,
+                            "endLine": 18,
+                            "endTokenPos": 250,
+                            "endFilePos": 575
+                          },
+                          "name": "is_float"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 18,
+                              "startTokenPos": 252,
+                              "startFilePos": 577,
+                              "endLine": 18,
+                              "endTokenPos": 255,
+                              "endFilePos": 586
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 18,
+                                "startTokenPos": 252,
+                                "startFilePos": 577,
+                                "endLine": 18,
+                                "endTokenPos": 255,
+                                "endFilePos": 586
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 18,
+                                  "startTokenPos": 252,
+                                  "startFilePos": 577,
+                                  "endLine": 18,
+                                  "endTokenPos": 252,
+                                  "endFilePos": 578
+                                },
+                                "name": "r"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 18,
+                                  "startTokenPos": 254,
+                                  "startFilePos": 580,
+                                  "endLine": 18,
+                                  "endTokenPos": 254,
+                                  "endFilePos": 585,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "if": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 260,
+                          "startFilePos": 591,
+                          "endLine": 18,
+                          "endTokenPos": 269,
+                          "endFilePos": 619
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 260,
+                            "startFilePos": 591,
+                            "endLine": 18,
+                            "endTokenPos": 260,
+                            "endFilePos": 601
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 18,
+                              "startTokenPos": 262,
+                              "startFilePos": 603,
+                              "endLine": 18,
+                              "endTokenPos": 265,
+                              "endFilePos": 612
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 18,
+                                "startTokenPos": 262,
+                                "startFilePos": 603,
+                                "endLine": 18,
+                                "endTokenPos": 265,
+                                "endFilePos": 612
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 18,
+                                  "startTokenPos": 262,
+                                  "startFilePos": 603,
+                                  "endLine": 18,
+                                  "endTokenPos": 262,
+                                  "endFilePos": 604
+                                },
+                                "name": "r"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 18,
+                                  "startTokenPos": 264,
+                                  "startFilePos": 606,
+                                  "endLine": 18,
+                                  "endTokenPos": 264,
+                                  "endFilePos": 611,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 18,
+                              "startTokenPos": 268,
+                              "startFilePos": 615,
+                              "endLine": 18,
+                              "endTokenPos": 268,
+                              "endFilePos": 618
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 18,
+                                "startTokenPos": 268,
+                                "startFilePos": 615,
+                                "endLine": 18,
+                                "endTokenPos": 268,
+                                "endFilePos": 618,
+                                "rawValue": "1344",
+                                "kind": 10
+                              },
+                              "value": 1344
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "else": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 273,
+                          "startFilePos": 623,
+                          "endLine": 18,
+                          "endTokenPos": 276,
+                          "endFilePos": 632
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 273,
+                            "startFilePos": 623,
+                            "endLine": 18,
+                            "endTokenPos": 273,
+                            "endFilePos": 624
+                          },
+                          "name": "r"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 275,
+                            "startFilePos": 626,
+                            "endLine": 18,
+                            "endTokenPos": 275,
+                            "endFilePos": 631,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 281,
+                        "startFilePos": 637,
+                        "endLine": 18,
+                        "endTokenPos": 281,
+                        "endFilePos": 639,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 285,
+                      "startFilePos": 643,
+                      "endLine": 18,
+                      "endTokenPos": 285,
+                      "endFilePos": 655,
+                      "kind": 2,
+                      "rawValue": "\"bought item\""
+                    },
+                    "value": "bought item"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 289,
+                    "startFilePos": 659,
+                    "endLine": 18,
+                    "endTokenPos": 289,
+                    "endFilePos": 661,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 294,
+                  "startFilePos": 666,
+                  "endLine": 18,
+                  "endTokenPos": 320,
+                  "endFilePos": 727
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 294,
+                    "startFilePos": 666,
+                    "endLine": 18,
+                    "endTokenPos": 300,
+                    "endFilePos": 684
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 294,
+                      "startFilePos": 666,
+                      "endLine": 18,
+                      "endTokenPos": 294,
+                      "endFilePos": 673
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 296,
+                        "startFilePos": 675,
+                        "endLine": 18,
+                        "endTokenPos": 299,
+                        "endFilePos": 683
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 296,
+                          "startFilePos": 675,
+                          "endLine": 18,
+                          "endTokenPos": 299,
+                          "endFilePos": 683
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 296,
+                            "startFilePos": 675,
+                            "endLine": 18,
+                            "endTokenPos": 296,
+                            "endFilePos": 676
+                          },
+                          "name": "r"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 298,
+                            "startFilePos": 678,
+                            "endLine": 18,
+                            "endTokenPos": 298,
+                            "endFilePos": 682,
+                            "kind": 2,
+                            "rawValue": "\"sku\""
+                          },
+                          "value": "sku"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 304,
+                    "startFilePos": 688,
+                    "endLine": 18,
+                    "endTokenPos": 313,
+                    "endFilePos": 715
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 304,
+                      "startFilePos": 688,
+                      "endLine": 18,
+                      "endTokenPos": 304,
+                      "endFilePos": 698
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 306,
+                        "startFilePos": 700,
+                        "endLine": 18,
+                        "endTokenPos": 309,
+                        "endFilePos": 708
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 306,
+                          "startFilePos": 700,
+                          "endLine": 18,
+                          "endTokenPos": 309,
+                          "endFilePos": 708
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 306,
+                            "startFilePos": 700,
+                            "endLine": 18,
+                            "endTokenPos": 306,
+                            "endFilePos": 701
+                          },
+                          "name": "r"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 18,
+                            "startTokenPos": 308,
+                            "startFilePos": 703,
+                            "endLine": 18,
+                            "endTokenPos": 308,
+                            "endFilePos": 707,
+                            "kind": 2,
+                            "rawValue": "\"sku\""
+                          },
+                          "value": "sku"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 312,
+                        "startFilePos": 711,
+                        "endLine": 18,
+                        "endTokenPos": 312,
+                        "endFilePos": 714
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 312,
+                          "startFilePos": 711,
+                          "endLine": 18,
+                          "endTokenPos": 312,
+                          "endFilePos": 714,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 317,
+                    "startFilePos": 719,
+                    "endLine": 18,
+                    "endTokenPos": 320,
+                    "endFilePos": 727
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 317,
+                      "startFilePos": 719,
+                      "endLine": 18,
+                      "endTokenPos": 317,
+                      "endFilePos": 720
+                    },
+                    "name": "r"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 319,
+                      "startFilePos": 722,
+                      "endLine": 18,
+                      "endTokenPos": 319,
+                      "endFilePos": 726,
+                      "kind": 2,
+                      "rawValue": "\"sku\""
+                    },
+                    "value": "sku"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 324,
+                "startFilePos": 731,
+                "endLine": 18,
+                "endTokenPos": 324,
+                "endFilePos": 737
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 324,
+                  "startFilePos": 731,
+                  "endLine": 18,
+                  "endTokenPos": 324,
+                  "endFilePos": 737
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/json_builtin.php.json
+++ b/tests/json-ast/x/php/json_builtin.php.json
@@ -1,0 +1,344 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 19,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 18,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 18,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 14,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 24,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 29,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 21,
+        "startFilePos": 33,
+        "endLine": 3,
+        "endTokenPos": 42,
+        "endFilePos": 94
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 23,
+            "startFilePos": 38,
+            "endLine": 3,
+            "endTokenPos": 38,
+            "endFilePos": 84
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 23,
+              "startFilePos": 38,
+              "endLine": 3,
+              "endTokenPos": 23,
+              "endFilePos": 48
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 25,
+                "startFilePos": 50,
+                "endLine": 3,
+                "endTokenPos": 25,
+                "endFilePos": 55
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 25,
+                  "startFilePos": 50,
+                  "endLine": 3,
+                  "endTokenPos": 25,
+                  "endFilePos": 55,
+                  "kind": 2,
+                  "rawValue": "\"    \""
+                },
+                "value": "    "
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 28,
+                "startFilePos": 58,
+                "endLine": 3,
+                "endTokenPos": 28,
+                "endFilePos": 61
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 28,
+                  "startFilePos": 58,
+                  "endLine": 3,
+                  "endTokenPos": 28,
+                  "endFilePos": 61,
+                  "kind": 2,
+                  "rawValue": "\"  \""
+                },
+                "value": "  "
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 31,
+                "startFilePos": 64,
+                "endLine": 3,
+                "endTokenPos": 37,
+                "endFilePos": 83
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 31,
+                  "startFilePos": 64,
+                  "endLine": 3,
+                  "endTokenPos": 37,
+                  "endFilePos": 83
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 31,
+                    "startFilePos": 64,
+                    "endLine": 3,
+                    "endTokenPos": 31,
+                    "endFilePos": 74
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 33,
+                      "startFilePos": 76,
+                      "endLine": 3,
+                      "endTokenPos": 33,
+                      "endFilePos": 77
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 33,
+                        "startFilePos": 76,
+                        "endLine": 3,
+                        "endTokenPos": 33,
+                        "endFilePos": 77
+                      },
+                      "name": "m"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 80,
+                      "endLine": 3,
+                      "endTokenPos": 36,
+                      "endFilePos": 82
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 36,
+                        "startFilePos": 80,
+                        "endLine": 3,
+                        "endTokenPos": 36,
+                        "endFilePos": 82,
+                        "rawValue": "128",
+                        "kind": 10
+                      },
+                      "value": 128
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 41,
+            "startFilePos": 87,
+            "endLine": 3,
+            "endTokenPos": 41,
+            "endFilePos": 93
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 41,
+              "startFilePos": 87,
+              "endLine": 3,
+              "endTokenPos": 41,
+              "endFilePos": 93
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/left_join.php.json
+++ b/tests/json-ast/x/php/left_join.php.json
@@ -1,0 +1,2701 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 37,
+        "endFilePos": 81
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 36,
+          "endFilePos": 80
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 36,
+            "endFilePos": 80,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 39,
+        "startFilePos": 83,
+        "endLine": 3,
+        "endTokenPos": 89,
+        "endFilePos": 192
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 39,
+          "startFilePos": 83,
+          "endLine": 3,
+          "endTokenPos": 88,
+          "endFilePos": 191
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 39,
+            "startFilePos": 83,
+            "endLine": 3,
+            "endTokenPos": 39,
+            "endFilePos": 89
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 43,
+            "startFilePos": 93,
+            "endLine": 3,
+            "endTokenPos": 88,
+            "endFilePos": 191,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 44,
+                "startFilePos": 94,
+                "endLine": 3,
+                "endTokenPos": 64,
+                "endFilePos": 141
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 94,
+                  "endLine": 3,
+                  "endTokenPos": 64,
+                  "endFilePos": 141,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 45,
+                      "startFilePos": 95,
+                      "endLine": 3,
+                      "endTokenPos": 49,
+                      "endFilePos": 105
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 45,
+                        "startFilePos": 95,
+                        "endLine": 3,
+                        "endTokenPos": 45,
+                        "endFilePos": 98,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 49,
+                        "startFilePos": 103,
+                        "endLine": 3,
+                        "endTokenPos": 49,
+                        "endFilePos": 105,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 52,
+                      "startFilePos": 108,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 124
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 52,
+                        "startFilePos": 108,
+                        "endLine": 3,
+                        "endTokenPos": 52,
+                        "endFilePos": 119,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 56,
+                        "startFilePos": 124,
+                        "endLine": 3,
+                        "endTokenPos": 56,
+                        "endFilePos": 124,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 59,
+                      "startFilePos": 127,
+                      "endLine": 3,
+                      "endTokenPos": 63,
+                      "endFilePos": 140
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 59,
+                        "startFilePos": 127,
+                        "endLine": 3,
+                        "endTokenPos": 59,
+                        "endFilePos": 133,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 63,
+                        "startFilePos": 138,
+                        "endLine": 3,
+                        "endTokenPos": 63,
+                        "endFilePos": 140,
+                        "rawValue": "250",
+                        "kind": 10
+                      },
+                      "value": 250
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 67,
+                "startFilePos": 144,
+                "endLine": 3,
+                "endTokenPos": 87,
+                "endFilePos": 190
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 67,
+                  "startFilePos": 144,
+                  "endLine": 3,
+                  "endTokenPos": 87,
+                  "endFilePos": 190,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 145,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 155
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 145,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 148,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 153,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 155,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 75,
+                      "startFilePos": 158,
+                      "endLine": 3,
+                      "endTokenPos": 79,
+                      "endFilePos": 174
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 75,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 75,
+                        "endFilePos": 169,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 79,
+                        "startFilePos": 174,
+                        "endLine": 3,
+                        "endTokenPos": 79,
+                        "endFilePos": 174,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 82,
+                      "startFilePos": 177,
+                      "endLine": 3,
+                      "endTokenPos": 86,
+                      "endFilePos": 189
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 82,
+                        "startFilePos": 177,
+                        "endLine": 3,
+                        "endTokenPos": 82,
+                        "endFilePos": 183,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 86,
+                        "startFilePos": 188,
+                        "endLine": 3,
+                        "endTokenPos": 86,
+                        "endFilePos": 189,
+                        "rawValue": "80",
+                        "kind": 10
+                      },
+                      "value": 80
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 91,
+        "startFilePos": 194,
+        "endLine": 19,
+        "endTokenPos": 280,
+        "endFilePos": 665
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 91,
+          "startFilePos": 194,
+          "endLine": 19,
+          "endTokenPos": 279,
+          "endFilePos": 664
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 91,
+            "startFilePos": 194,
+            "endLine": 4,
+            "endTokenPos": 91,
+            "endFilePos": 200
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 95,
+            "startFilePos": 204,
+            "endLine": 19,
+            "endTokenPos": 279,
+            "endFilePos": 664
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 96,
+              "startFilePos": 205,
+              "endLine": 19,
+              "endTokenPos": 276,
+              "endFilePos": 661
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 103,
+                  "startFilePos": 221,
+                  "endLine": 4,
+                  "endTokenPos": 103,
+                  "endFilePos": 230
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 103,
+                    "startFilePos": 221,
+                    "endLine": 4,
+                    "endTokenPos": 103,
+                    "endFilePos": 230
+                  },
+                  "name": "customers"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 106,
+                  "startFilePos": 233,
+                  "endLine": 4,
+                  "endTokenPos": 106,
+                  "endFilePos": 239
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 106,
+                    "startFilePos": 233,
+                    "endLine": 4,
+                    "endTokenPos": 106,
+                    "endFilePos": 239
+                  },
+                  "name": "orders"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 111,
+                  "startFilePos": 246,
+                  "endLine": 5,
+                  "endTokenPos": 117,
+                  "endFilePos": 258
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 111,
+                    "startFilePos": 246,
+                    "endLine": 5,
+                    "endTokenPos": 116,
+                    "endFilePos": 257
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 111,
+                      "startFilePos": 246,
+                      "endLine": 5,
+                      "endTokenPos": 111,
+                      "endFilePos": 252
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 115,
+                      "startFilePos": 256,
+                      "endLine": 5,
+                      "endTokenPos": 116,
+                      "endFilePos": 257,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 119,
+                  "startFilePos": 262,
+                  "endLine": 17,
+                  "endTokenPos": 269,
+                  "endFilePos": 641
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 122,
+                    "startFilePos": 271,
+                    "endLine": 6,
+                    "endTokenPos": 122,
+                    "endFilePos": 277
+                  },
+                  "name": "orders"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 126,
+                    "startFilePos": 282,
+                    "endLine": 6,
+                    "endTokenPos": 126,
+                    "endFilePos": 283
+                  },
+                  "name": "o"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 131,
+                      "startFilePos": 292,
+                      "endLine": 7,
+                      "endTokenPos": 136,
+                      "endFilePos": 308
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 131,
+                        "startFilePos": 292,
+                        "endLine": 7,
+                        "endTokenPos": 135,
+                        "endFilePos": 307
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 131,
+                          "startFilePos": 292,
+                          "endLine": 7,
+                          "endTokenPos": 131,
+                          "endFilePos": 299
+                        },
+                        "name": "matched"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ConstFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 135,
+                          "startFilePos": 303,
+                          "endLine": 7,
+                          "endTokenPos": 135,
+                          "endFilePos": 307
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 135,
+                            "startFilePos": 303,
+                            "endLine": 7,
+                            "endTokenPos": 135,
+                            "endFilePos": 307
+                          },
+                          "name": "false"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 138,
+                      "startFilePos": 314,
+                      "endLine": 12,
+                      "endTokenPos": 214,
+                      "endFilePos": 508
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 141,
+                        "startFilePos": 323,
+                        "endLine": 8,
+                        "endTokenPos": 141,
+                        "endFilePos": 332
+                      },
+                      "name": "customers"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 145,
+                        "startFilePos": 337,
+                        "endLine": 8,
+                        "endTokenPos": 145,
+                        "endFilePos": 338
+                      },
+                      "name": "c"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 150,
+                          "startFilePos": 349,
+                          "endLine": 9,
+                          "endTokenPos": 170,
+                          "endFilePos": 394
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 153,
+                            "startFilePos": 353,
+                            "endLine": 9,
+                            "endTokenPos": 166,
+                            "endFilePos": 383
+                          },
+                          "expr": {
+                            "nodeType": "Expr_BinaryOp_Equal",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 155,
+                              "startFilePos": 355,
+                              "endLine": 9,
+                              "endTokenPos": 165,
+                              "endFilePos": 382
+                            },
+                            "left": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 155,
+                                "startFilePos": 355,
+                                "endLine": 9,
+                                "endTokenPos": 158,
+                                "endFilePos": 370
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 155,
+                                  "startFilePos": 355,
+                                  "endLine": 9,
+                                  "endTokenPos": 155,
+                                  "endFilePos": 356
+                                },
+                                "name": "o"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 157,
+                                  "startFilePos": 358,
+                                  "endLine": 9,
+                                  "endTokenPos": 157,
+                                  "endFilePos": 369,
+                                  "kind": 2,
+                                  "rawValue": "\"customerId\""
+                                },
+                                "value": "customerId"
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 162,
+                                "startFilePos": 375,
+                                "endLine": 9,
+                                "endTokenPos": 165,
+                                "endFilePos": 382
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 162,
+                                  "startFilePos": 375,
+                                  "endLine": 9,
+                                  "endTokenPos": 162,
+                                  "endFilePos": 376
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 164,
+                                  "startFilePos": 378,
+                                  "endLine": 9,
+                                  "endTokenPos": 164,
+                                  "endFilePos": 381,
+                                  "kind": 2,
+                                  "rawValue": "\"id\""
+                                },
+                                "value": "id"
+                              }
+                            }
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Continue",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 169,
+                              "startFilePos": 386,
+                              "endLine": 9,
+                              "endTokenPos": 170,
+                              "endFilePos": 394
+                            },
+                            "num": null
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 172,
+                          "startFilePos": 402,
+                          "endLine": 10,
+                          "endTokenPos": 177,
+                          "endFilePos": 417
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 172,
+                            "startFilePos": 402,
+                            "endLine": 10,
+                            "endTokenPos": 176,
+                            "endFilePos": 416
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 172,
+                              "startFilePos": 402,
+                              "endLine": 10,
+                              "endTokenPos": 172,
+                              "endFilePos": 409
+                            },
+                            "name": "matched"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 176,
+                              "startFilePos": 413,
+                              "endLine": 10,
+                              "endTokenPos": 176,
+                              "endFilePos": 416
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 176,
+                                "startFilePos": 413,
+                                "endLine": 10,
+                                "endTokenPos": 176,
+                                "endFilePos": 416
+                              },
+                              "name": "true"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 179,
+                          "startFilePos": 425,
+                          "endLine": 11,
+                          "endTokenPos": 212,
+                          "endFilePos": 502
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 179,
+                            "startFilePos": 425,
+                            "endLine": 11,
+                            "endTokenPos": 211,
+                            "endFilePos": 501
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 179,
+                              "startFilePos": 425,
+                              "endLine": 11,
+                              "endTokenPos": 181,
+                              "endFilePos": 433
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 179,
+                                "startFilePos": 425,
+                                "endLine": 11,
+                                "endTokenPos": 179,
+                                "endFilePos": 431
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 185,
+                              "startFilePos": 437,
+                              "endLine": 11,
+                              "endTokenPos": 211,
+                              "endFilePos": 501,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 186,
+                                  "startFilePos": 438,
+                                  "endLine": 11,
+                                  "endTokenPos": 193,
+                                  "endFilePos": 458
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 186,
+                                    "startFilePos": 438,
+                                    "endLine": 11,
+                                    "endTokenPos": 186,
+                                    "endFilePos": 446,
+                                    "kind": 2,
+                                    "rawValue": "\"orderId\""
+                                  },
+                                  "value": "orderId"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 190,
+                                    "startFilePos": 451,
+                                    "endLine": 11,
+                                    "endTokenPos": 193,
+                                    "endFilePos": 458
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 190,
+                                      "startFilePos": 451,
+                                      "endLine": 11,
+                                      "endTokenPos": 190,
+                                      "endFilePos": 452
+                                    },
+                                    "name": "o"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 192,
+                                      "startFilePos": 454,
+                                      "endLine": 11,
+                                      "endTokenPos": 192,
+                                      "endFilePos": 457,
+                                      "kind": 2,
+                                      "rawValue": "\"id\""
+                                    },
+                                    "value": "id"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 196,
+                                  "startFilePos": 461,
+                                  "endLine": 11,
+                                  "endTokenPos": 200,
+                                  "endFilePos": 476
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 196,
+                                    "startFilePos": 461,
+                                    "endLine": 11,
+                                    "endTokenPos": 196,
+                                    "endFilePos": 470,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 200,
+                                    "startFilePos": 475,
+                                    "endLine": 11,
+                                    "endTokenPos": 200,
+                                    "endFilePos": 476
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 203,
+                                  "startFilePos": 479,
+                                  "endLine": 11,
+                                  "endTokenPos": 210,
+                                  "endFilePos": 500
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 203,
+                                    "startFilePos": 479,
+                                    "endLine": 11,
+                                    "endTokenPos": 203,
+                                    "endFilePos": 485,
+                                    "kind": 2,
+                                    "rawValue": "\"total\""
+                                  },
+                                  "value": "total"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 207,
+                                    "startFilePos": 490,
+                                    "endLine": 11,
+                                    "endTokenPos": 210,
+                                    "endFilePos": 500
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 207,
+                                      "startFilePos": 490,
+                                      "endLine": 11,
+                                      "endTokenPos": 207,
+                                      "endFilePos": 491
+                                    },
+                                    "name": "o"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 209,
+                                      "startFilePos": 493,
+                                      "endLine": 11,
+                                      "endTokenPos": 209,
+                                      "endFilePos": 499,
+                                      "kind": 2,
+                                      "rawValue": "\"total\""
+                                    },
+                                    "value": "total"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 216,
+                      "startFilePos": 514,
+                      "endLine": 16,
+                      "endTokenPos": 267,
+                      "endFilePos": 637
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 219,
+                        "startFilePos": 518,
+                        "endLine": 13,
+                        "endTokenPos": 220,
+                        "endFilePos": 526
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 220,
+                          "startFilePos": 519,
+                          "endLine": 13,
+                          "endTokenPos": 220,
+                          "endFilePos": 526
+                        },
+                        "name": "matched"
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 14,
+                          "startTokenPos": 225,
+                          "startFilePos": 537,
+                          "endLine": 14,
+                          "endTokenPos": 230,
+                          "endFilePos": 546
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 14,
+                            "startTokenPos": 225,
+                            "startFilePos": 537,
+                            "endLine": 14,
+                            "endTokenPos": 229,
+                            "endFilePos": 545
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 225,
+                              "startFilePos": 537,
+                              "endLine": 14,
+                              "endTokenPos": 225,
+                              "endFilePos": 538
+                            },
+                            "name": "c"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 229,
+                              "startFilePos": 542,
+                              "endLine": 14,
+                              "endTokenPos": 229,
+                              "endFilePos": 545
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 14,
+                                "startTokenPos": 229,
+                                "startFilePos": 542,
+                                "endLine": 14,
+                                "endTokenPos": 229,
+                                "endFilePos": 545
+                              },
+                              "name": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 232,
+                          "startFilePos": 554,
+                          "endLine": 15,
+                          "endTokenPos": 265,
+                          "endFilePos": 631
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 232,
+                            "startFilePos": 554,
+                            "endLine": 15,
+                            "endTokenPos": 264,
+                            "endFilePos": 630
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 232,
+                              "startFilePos": 554,
+                              "endLine": 15,
+                              "endTokenPos": 234,
+                              "endFilePos": 562
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 232,
+                                "startFilePos": 554,
+                                "endLine": 15,
+                                "endTokenPos": 232,
+                                "endFilePos": 560
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 238,
+                              "startFilePos": 566,
+                              "endLine": 15,
+                              "endTokenPos": 264,
+                              "endFilePos": 630,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 239,
+                                  "startFilePos": 567,
+                                  "endLine": 15,
+                                  "endTokenPos": 246,
+                                  "endFilePos": 587
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 239,
+                                    "startFilePos": 567,
+                                    "endLine": 15,
+                                    "endTokenPos": 239,
+                                    "endFilePos": 575,
+                                    "kind": 2,
+                                    "rawValue": "\"orderId\""
+                                  },
+                                  "value": "orderId"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 243,
+                                    "startFilePos": 580,
+                                    "endLine": 15,
+                                    "endTokenPos": 246,
+                                    "endFilePos": 587
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 243,
+                                      "startFilePos": 580,
+                                      "endLine": 15,
+                                      "endTokenPos": 243,
+                                      "endFilePos": 581
+                                    },
+                                    "name": "o"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 245,
+                                      "startFilePos": 583,
+                                      "endLine": 15,
+                                      "endTokenPos": 245,
+                                      "endFilePos": 586,
+                                      "kind": 2,
+                                      "rawValue": "\"id\""
+                                    },
+                                    "value": "id"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 249,
+                                  "startFilePos": 590,
+                                  "endLine": 15,
+                                  "endTokenPos": 253,
+                                  "endFilePos": 605
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 249,
+                                    "startFilePos": 590,
+                                    "endLine": 15,
+                                    "endTokenPos": 249,
+                                    "endFilePos": 599,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 253,
+                                    "startFilePos": 604,
+                                    "endLine": 15,
+                                    "endTokenPos": 253,
+                                    "endFilePos": 605
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 256,
+                                  "startFilePos": 608,
+                                  "endLine": 15,
+                                  "endTokenPos": 263,
+                                  "endFilePos": 629
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 256,
+                                    "startFilePos": 608,
+                                    "endLine": 15,
+                                    "endTokenPos": 256,
+                                    "endFilePos": 614,
+                                    "kind": 2,
+                                    "rawValue": "\"total\""
+                                  },
+                                  "value": "total"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 260,
+                                    "startFilePos": 619,
+                                    "endLine": 15,
+                                    "endTokenPos": 263,
+                                    "endFilePos": 629
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 260,
+                                      "startFilePos": 619,
+                                      "endLine": 15,
+                                      "endTokenPos": 260,
+                                      "endFilePos": 620
+                                    },
+                                    "name": "o"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 262,
+                                      "startFilePos": 622,
+                                      "endLine": 15,
+                                      "endTokenPos": 262,
+                                      "endFilePos": 628,
+                                      "kind": 2,
+                                      "rawValue": "\"total\""
+                                    },
+                                    "value": "total"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 271,
+                  "startFilePos": 645,
+                  "endLine": 18,
+                  "endTokenPos": 274,
+                  "endFilePos": 659
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 273,
+                    "startFilePos": 652,
+                    "endLine": 18,
+                    "endTokenPos": 273,
+                    "endFilePos": 658
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 20,
+        "startTokenPos": 282,
+        "startFilePos": 667,
+        "endLine": 20,
+        "endTokenPos": 288,
+        "endFilePos": 700
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 20,
+            "startTokenPos": 284,
+            "startFilePos": 672,
+            "endLine": 20,
+            "endTokenPos": 284,
+            "endFilePos": 690,
+            "kind": 2,
+            "rawValue": "\"--- Left Join ---\""
+          },
+          "value": "--- Left Join ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 20,
+            "startTokenPos": 287,
+            "startFilePos": 693,
+            "endLine": 20,
+            "endTokenPos": 287,
+            "endFilePos": 699
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 20,
+              "startTokenPos": 287,
+              "startFilePos": 693,
+              "endLine": 20,
+              "endTokenPos": 287,
+              "endFilePos": 699
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 21,
+        "startTokenPos": 290,
+        "startFilePos": 702,
+        "endLine": 23,
+        "endTokenPos": 434,
+        "endFilePos": 1080
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 21,
+          "startTokenPos": 293,
+          "startFilePos": 711,
+          "endLine": 21,
+          "endTokenPos": 293,
+          "endFilePos": 717
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 21,
+          "startTokenPos": 297,
+          "startFilePos": 722,
+          "endLine": 21,
+          "endTokenPos": 297,
+          "endFilePos": 727
+        },
+        "name": "entry"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 22,
+            "startTokenPos": 302,
+            "startFilePos": 734,
+            "endLine": 22,
+            "endTokenPos": 432,
+            "endFilePos": 1078
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 22,
+                "startTokenPos": 304,
+                "startFilePos": 739,
+                "endLine": 22,
+                "endTokenPos": 428,
+                "endFilePos": 1068
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 22,
+                  "startTokenPos": 304,
+                  "startFilePos": 739,
+                  "endLine": 22,
+                  "endTokenPos": 396,
+                  "endFilePos": 983
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 22,
+                    "startTokenPos": 304,
+                    "startFilePos": 739,
+                    "endLine": 22,
+                    "endTokenPos": 392,
+                    "endFilePos": 977
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 22,
+                      "startTokenPos": 304,
+                      "startFilePos": 739,
+                      "endLine": 22,
+                      "endTokenPos": 388,
+                      "endFilePos": 967
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 22,
+                        "startTokenPos": 304,
+                        "startFilePos": 739,
+                        "endLine": 22,
+                        "endTokenPos": 384,
+                        "endFilePos": 961
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 304,
+                          "startFilePos": 739,
+                          "endLine": 22,
+                          "endTokenPos": 352,
+                          "endFilePos": 867
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 304,
+                            "startFilePos": 739,
+                            "endLine": 22,
+                            "endTokenPos": 348,
+                            "endFilePos": 861
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 304,
+                              "startFilePos": 739,
+                              "endLine": 22,
+                              "endTokenPos": 344,
+                              "endFilePos": 848
+                            },
+                            "left": {
+                              "nodeType": "Expr_BinaryOp_Concat",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 304,
+                                "startFilePos": 739,
+                                "endLine": 22,
+                                "endTokenPos": 340,
+                                "endFilePos": 842
+                              },
+                              "left": {
+                                "nodeType": "Expr_BinaryOp_Concat",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 304,
+                                  "startFilePos": 739,
+                                  "endLine": 22,
+                                  "endTokenPos": 308,
+                                  "endFilePos": 751
+                                },
+                                "left": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 304,
+                                    "startFilePos": 739,
+                                    "endLine": 22,
+                                    "endTokenPos": 304,
+                                    "endFilePos": 745,
+                                    "kind": 2,
+                                    "rawValue": "\"Order\""
+                                  },
+                                  "value": "Order"
+                                },
+                                "right": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 308,
+                                    "startFilePos": 749,
+                                    "endLine": 22,
+                                    "endTokenPos": 308,
+                                    "endFilePos": 751,
+                                    "kind": 2,
+                                    "rawValue": "\" \""
+                                  },
+                                  "value": " "
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_Ternary",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 313,
+                                  "startFilePos": 756,
+                                  "endLine": 22,
+                                  "endTokenPos": 339,
+                                  "endFilePos": 841
+                                },
+                                "cond": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 313,
+                                    "startFilePos": 756,
+                                    "endLine": 22,
+                                    "endTokenPos": 319,
+                                    "endFilePos": 782
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 22,
+                                      "startTokenPos": 313,
+                                      "startFilePos": 756,
+                                      "endLine": 22,
+                                      "endTokenPos": 313,
+                                      "endFilePos": 763
+                                    },
+                                    "name": "is_float"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 22,
+                                        "startTokenPos": 315,
+                                        "startFilePos": 765,
+                                        "endLine": 22,
+                                        "endTokenPos": 318,
+                                        "endFilePos": 781
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 22,
+                                          "startTokenPos": 315,
+                                          "startFilePos": 765,
+                                          "endLine": 22,
+                                          "endTokenPos": 318,
+                                          "endFilePos": 781
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 22,
+                                            "startTokenPos": 315,
+                                            "startFilePos": 765,
+                                            "endLine": 22,
+                                            "endTokenPos": 315,
+                                            "endFilePos": 770
+                                          },
+                                          "name": "entry"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 22,
+                                            "startTokenPos": 317,
+                                            "startFilePos": 772,
+                                            "endLine": 22,
+                                            "endTokenPos": 317,
+                                            "endFilePos": 780,
+                                            "kind": 2,
+                                            "rawValue": "\"orderId\""
+                                          },
+                                          "value": "orderId"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "if": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 323,
+                                    "startFilePos": 786,
+                                    "endLine": 22,
+                                    "endTokenPos": 332,
+                                    "endFilePos": 821
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 22,
+                                      "startTokenPos": 323,
+                                      "startFilePos": 786,
+                                      "endLine": 22,
+                                      "endTokenPos": 323,
+                                      "endFilePos": 796
+                                    },
+                                    "name": "json_encode"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 22,
+                                        "startTokenPos": 325,
+                                        "startFilePos": 798,
+                                        "endLine": 22,
+                                        "endTokenPos": 328,
+                                        "endFilePos": 814
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 22,
+                                          "startTokenPos": 325,
+                                          "startFilePos": 798,
+                                          "endLine": 22,
+                                          "endTokenPos": 328,
+                                          "endFilePos": 814
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 22,
+                                            "startTokenPos": 325,
+                                            "startFilePos": 798,
+                                            "endLine": 22,
+                                            "endTokenPos": 325,
+                                            "endFilePos": 803
+                                          },
+                                          "name": "entry"
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 22,
+                                            "startTokenPos": 327,
+                                            "startFilePos": 805,
+                                            "endLine": 22,
+                                            "endTokenPos": 327,
+                                            "endFilePos": 813,
+                                            "kind": 2,
+                                            "rawValue": "\"orderId\""
+                                          },
+                                          "value": "orderId"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 22,
+                                        "startTokenPos": 331,
+                                        "startFilePos": 817,
+                                        "endLine": 22,
+                                        "endTokenPos": 331,
+                                        "endFilePos": 820
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_Int",
+                                        "attributes": {
+                                          "startLine": 22,
+                                          "startTokenPos": 331,
+                                          "startFilePos": 817,
+                                          "endLine": 22,
+                                          "endTokenPos": 331,
+                                          "endFilePos": 820,
+                                          "rawValue": "1344",
+                                          "kind": 10
+                                        },
+                                        "value": 1344
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "else": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 336,
+                                    "startFilePos": 825,
+                                    "endLine": 22,
+                                    "endTokenPos": 339,
+                                    "endFilePos": 841
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 22,
+                                      "startTokenPos": 336,
+                                      "startFilePos": 825,
+                                      "endLine": 22,
+                                      "endTokenPos": 336,
+                                      "endFilePos": 830
+                                    },
+                                    "name": "entry"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 22,
+                                      "startTokenPos": 338,
+                                      "startFilePos": 832,
+                                      "endLine": 22,
+                                      "endTokenPos": 338,
+                                      "endFilePos": 840,
+                                      "kind": 2,
+                                      "rawValue": "\"orderId\""
+                                    },
+                                    "value": "orderId"
+                                  }
+                                }
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 344,
+                                "startFilePos": 846,
+                                "endLine": 22,
+                                "endTokenPos": 344,
+                                "endFilePos": 848,
+                                "kind": 2,
+                                "rawValue": "\" \""
+                              },
+                              "value": " "
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 348,
+                              "startFilePos": 852,
+                              "endLine": 22,
+                              "endTokenPos": 348,
+                              "endFilePos": 861,
+                              "kind": 2,
+                              "rawValue": "\"customer\""
+                            },
+                            "value": "customer"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 352,
+                            "startFilePos": 865,
+                            "endLine": 22,
+                            "endTokenPos": 352,
+                            "endFilePos": 867,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_Ternary",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 357,
+                          "startFilePos": 872,
+                          "endLine": 22,
+                          "endTokenPos": 383,
+                          "endFilePos": 960
+                        },
+                        "cond": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 357,
+                            "startFilePos": 872,
+                            "endLine": 22,
+                            "endTokenPos": 363,
+                            "endFilePos": 899
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 357,
+                              "startFilePos": 872,
+                              "endLine": 22,
+                              "endTokenPos": 357,
+                              "endFilePos": 879
+                            },
+                            "name": "is_float"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 359,
+                                "startFilePos": 881,
+                                "endLine": 22,
+                                "endTokenPos": 362,
+                                "endFilePos": 898
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 359,
+                                  "startFilePos": 881,
+                                  "endLine": 22,
+                                  "endTokenPos": 362,
+                                  "endFilePos": 898
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 359,
+                                    "startFilePos": 881,
+                                    "endLine": 22,
+                                    "endTokenPos": 359,
+                                    "endFilePos": 886
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 361,
+                                    "startFilePos": 888,
+                                    "endLine": 22,
+                                    "endTokenPos": 361,
+                                    "endFilePos": 897,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "if": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 367,
+                            "startFilePos": 903,
+                            "endLine": 22,
+                            "endTokenPos": 376,
+                            "endFilePos": 939
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 367,
+                              "startFilePos": 903,
+                              "endLine": 22,
+                              "endTokenPos": 367,
+                              "endFilePos": 913
+                            },
+                            "name": "json_encode"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 369,
+                                "startFilePos": 915,
+                                "endLine": 22,
+                                "endTokenPos": 372,
+                                "endFilePos": 932
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 369,
+                                  "startFilePos": 915,
+                                  "endLine": 22,
+                                  "endTokenPos": 372,
+                                  "endFilePos": 932
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 369,
+                                    "startFilePos": 915,
+                                    "endLine": 22,
+                                    "endTokenPos": 369,
+                                    "endFilePos": 920
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 22,
+                                    "startTokenPos": 371,
+                                    "startFilePos": 922,
+                                    "endLine": 22,
+                                    "endTokenPos": 371,
+                                    "endFilePos": 931,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 375,
+                                "startFilePos": 935,
+                                "endLine": 22,
+                                "endTokenPos": 375,
+                                "endFilePos": 938
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 22,
+                                  "startTokenPos": 375,
+                                  "startFilePos": 935,
+                                  "endLine": 22,
+                                  "endTokenPos": 375,
+                                  "endFilePos": 938,
+                                  "rawValue": "1344",
+                                  "kind": 10
+                                },
+                                "value": 1344
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "else": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 380,
+                            "startFilePos": 943,
+                            "endLine": 22,
+                            "endTokenPos": 383,
+                            "endFilePos": 960
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 380,
+                              "startFilePos": 943,
+                              "endLine": 22,
+                              "endTokenPos": 380,
+                              "endFilePos": 948
+                            },
+                            "name": "entry"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 382,
+                              "startFilePos": 950,
+                              "endLine": 22,
+                              "endTokenPos": 382,
+                              "endFilePos": 959,
+                              "kind": 2,
+                              "rawValue": "\"customer\""
+                            },
+                            "value": "customer"
+                          }
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 22,
+                        "startTokenPos": 388,
+                        "startFilePos": 965,
+                        "endLine": 22,
+                        "endTokenPos": 388,
+                        "endFilePos": 967,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 22,
+                      "startTokenPos": 392,
+                      "startFilePos": 971,
+                      "endLine": 22,
+                      "endTokenPos": 392,
+                      "endFilePos": 977,
+                      "kind": 2,
+                      "rawValue": "\"total\""
+                    },
+                    "value": "total"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 22,
+                    "startTokenPos": 396,
+                    "startFilePos": 981,
+                    "endLine": 22,
+                    "endTokenPos": 396,
+                    "endFilePos": 983,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 22,
+                  "startTokenPos": 401,
+                  "startFilePos": 988,
+                  "endLine": 22,
+                  "endTokenPos": 427,
+                  "endFilePos": 1067
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 22,
+                    "startTokenPos": 401,
+                    "startFilePos": 988,
+                    "endLine": 22,
+                    "endTokenPos": 407,
+                    "endFilePos": 1012
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 22,
+                      "startTokenPos": 401,
+                      "startFilePos": 988,
+                      "endLine": 22,
+                      "endTokenPos": 401,
+                      "endFilePos": 995
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 22,
+                        "startTokenPos": 403,
+                        "startFilePos": 997,
+                        "endLine": 22,
+                        "endTokenPos": 406,
+                        "endFilePos": 1011
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 403,
+                          "startFilePos": 997,
+                          "endLine": 22,
+                          "endTokenPos": 406,
+                          "endFilePos": 1011
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 403,
+                            "startFilePos": 997,
+                            "endLine": 22,
+                            "endTokenPos": 403,
+                            "endFilePos": 1002
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 405,
+                            "startFilePos": 1004,
+                            "endLine": 22,
+                            "endTokenPos": 405,
+                            "endFilePos": 1010,
+                            "kind": 2,
+                            "rawValue": "\"total\""
+                          },
+                          "value": "total"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 22,
+                    "startTokenPos": 411,
+                    "startFilePos": 1016,
+                    "endLine": 22,
+                    "endTokenPos": 420,
+                    "endFilePos": 1049
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 22,
+                      "startTokenPos": 411,
+                      "startFilePos": 1016,
+                      "endLine": 22,
+                      "endTokenPos": 411,
+                      "endFilePos": 1026
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 22,
+                        "startTokenPos": 413,
+                        "startFilePos": 1028,
+                        "endLine": 22,
+                        "endTokenPos": 416,
+                        "endFilePos": 1042
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 413,
+                          "startFilePos": 1028,
+                          "endLine": 22,
+                          "endTokenPos": 416,
+                          "endFilePos": 1042
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 413,
+                            "startFilePos": 1028,
+                            "endLine": 22,
+                            "endTokenPos": 413,
+                            "endFilePos": 1033
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 415,
+                            "startFilePos": 1035,
+                            "endLine": 22,
+                            "endTokenPos": 415,
+                            "endFilePos": 1041,
+                            "kind": 2,
+                            "rawValue": "\"total\""
+                          },
+                          "value": "total"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 22,
+                        "startTokenPos": 419,
+                        "startFilePos": 1045,
+                        "endLine": 22,
+                        "endTokenPos": 419,
+                        "endFilePos": 1048
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 419,
+                          "startFilePos": 1045,
+                          "endLine": 22,
+                          "endTokenPos": 419,
+                          "endFilePos": 1048,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 22,
+                    "startTokenPos": 424,
+                    "startFilePos": 1053,
+                    "endLine": 22,
+                    "endTokenPos": 427,
+                    "endFilePos": 1067
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 22,
+                      "startTokenPos": 424,
+                      "startFilePos": 1053,
+                      "endLine": 22,
+                      "endTokenPos": 424,
+                      "endFilePos": 1058
+                    },
+                    "name": "entry"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 22,
+                      "startTokenPos": 426,
+                      "startFilePos": 1060,
+                      "endLine": 22,
+                      "endTokenPos": 426,
+                      "endFilePos": 1066,
+                      "kind": 2,
+                      "rawValue": "\"total\""
+                    },
+                    "value": "total"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 22,
+                "startTokenPos": 431,
+                "startFilePos": 1071,
+                "endLine": 22,
+                "endTokenPos": 431,
+                "endFilePos": 1077
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 22,
+                  "startTokenPos": 431,
+                  "startFilePos": 1071,
+                  "endLine": 22,
+                  "endTokenPos": 431,
+                  "endFilePos": 1077
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/left_join_multi.php.json
+++ b/tests/json-ast/x/php/left_join_multi.php.json
@@ -1,0 +1,2729 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 37,
+        "endFilePos": 81
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 36,
+          "endFilePos": 80
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 36,
+            "endFilePos": 80,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 39,
+        "startFilePos": 83,
+        "endLine": 3,
+        "endTokenPos": 75,
+        "endFilePos": 161
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 39,
+          "startFilePos": 83,
+          "endLine": 3,
+          "endTokenPos": 74,
+          "endFilePos": 160
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 39,
+            "startFilePos": 83,
+            "endLine": 3,
+            "endTokenPos": 39,
+            "endFilePos": 89
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 43,
+            "startFilePos": 93,
+            "endLine": 3,
+            "endTokenPos": 74,
+            "endFilePos": 160,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 44,
+                "startFilePos": 94,
+                "endLine": 3,
+                "endTokenPos": 57,
+                "endFilePos": 125
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 94,
+                  "endLine": 3,
+                  "endTokenPos": 57,
+                  "endFilePos": 125,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 45,
+                      "startFilePos": 95,
+                      "endLine": 3,
+                      "endTokenPos": 49,
+                      "endFilePos": 105
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 45,
+                        "startFilePos": 95,
+                        "endLine": 3,
+                        "endTokenPos": 45,
+                        "endFilePos": 98,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 49,
+                        "startFilePos": 103,
+                        "endLine": 3,
+                        "endTokenPos": 49,
+                        "endFilePos": 105,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 52,
+                      "startFilePos": 108,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 124
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 52,
+                        "startFilePos": 108,
+                        "endLine": 3,
+                        "endTokenPos": 52,
+                        "endFilePos": 119,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 56,
+                        "startFilePos": 124,
+                        "endLine": 3,
+                        "endTokenPos": 56,
+                        "endFilePos": 124,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 60,
+                "startFilePos": 128,
+                "endLine": 3,
+                "endTokenPos": 73,
+                "endFilePos": 159
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 73,
+                  "endFilePos": 159,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 61,
+                      "startFilePos": 129,
+                      "endLine": 3,
+                      "endTokenPos": 65,
+                      "endFilePos": 139
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 61,
+                        "startFilePos": 129,
+                        "endLine": 3,
+                        "endTokenPos": 61,
+                        "endFilePos": 132,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 65,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 65,
+                        "endFilePos": 139,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 68,
+                      "startFilePos": 142,
+                      "endLine": 3,
+                      "endTokenPos": 72,
+                      "endFilePos": 158
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 68,
+                        "startFilePos": 142,
+                        "endLine": 3,
+                        "endTokenPos": 68,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 72,
+                        "startFilePos": 158,
+                        "endLine": 3,
+                        "endTokenPos": 72,
+                        "endFilePos": 158,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 77,
+        "startFilePos": 163,
+        "endLine": 4,
+        "endTokenPos": 97,
+        "endFilePos": 206
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 77,
+          "startFilePos": 163,
+          "endLine": 4,
+          "endTokenPos": 96,
+          "endFilePos": 205
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 77,
+            "startFilePos": 163,
+            "endLine": 4,
+            "endTokenPos": 77,
+            "endFilePos": 168
+          },
+          "name": "items"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 81,
+            "startFilePos": 172,
+            "endLine": 4,
+            "endTokenPos": 96,
+            "endFilePos": 205,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 82,
+                "startFilePos": 173,
+                "endLine": 4,
+                "endTokenPos": 95,
+                "endFilePos": 204
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 82,
+                  "startFilePos": 173,
+                  "endLine": 4,
+                  "endTokenPos": 95,
+                  "endFilePos": 204,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 83,
+                      "startFilePos": 174,
+                      "endLine": 4,
+                      "endTokenPos": 87,
+                      "endFilePos": 189
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 83,
+                        "startFilePos": 174,
+                        "endLine": 4,
+                        "endTokenPos": 83,
+                        "endFilePos": 182,
+                        "kind": 2,
+                        "rawValue": "\"orderId\""
+                      },
+                      "value": "orderId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 87,
+                        "startFilePos": 187,
+                        "endLine": 4,
+                        "endTokenPos": 87,
+                        "endFilePos": 189,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 90,
+                      "startFilePos": 192,
+                      "endLine": 4,
+                      "endTokenPos": 94,
+                      "endFilePos": 203
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 90,
+                        "startFilePos": 192,
+                        "endLine": 4,
+                        "endTokenPos": 90,
+                        "endFilePos": 196,
+                        "kind": 2,
+                        "rawValue": "\"sku\""
+                      },
+                      "value": "sku"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 94,
+                        "startFilePos": 201,
+                        "endLine": 4,
+                        "endTokenPos": 94,
+                        "endFilePos": 203,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 99,
+        "startFilePos": 208,
+        "endLine": 5,
+        "endTokenPos": 105,
+        "endFilePos": 220
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 99,
+          "startFilePos": 208,
+          "endLine": 5,
+          "endTokenPos": 104,
+          "endFilePos": 219
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 99,
+            "startFilePos": 208,
+            "endLine": 5,
+            "endTokenPos": 99,
+            "endFilePos": 214
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 103,
+            "startFilePos": 218,
+            "endLine": 5,
+            "endTokenPos": 104,
+            "endFilePos": 219,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 107,
+        "startFilePos": 222,
+        "endLine": 23,
+        "endTokenPos": 311,
+        "endFilePos": 719
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 110,
+          "startFilePos": 231,
+          "endLine": 6,
+          "endTokenPos": 110,
+          "endFilePos": 237
+        },
+        "name": "orders"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 114,
+          "startFilePos": 242,
+          "endLine": 6,
+          "endTokenPos": 114,
+          "endFilePos": 243
+        },
+        "name": "o"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Foreach",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 119,
+            "startFilePos": 250,
+            "endLine": 22,
+            "endTokenPos": 309,
+            "endFilePos": 717
+          },
+          "expr": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 122,
+              "startFilePos": 259,
+              "endLine": 7,
+              "endTokenPos": 122,
+              "endFilePos": 268
+            },
+            "name": "customers"
+          },
+          "keyVar": null,
+          "byRef": false,
+          "valueVar": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 126,
+              "startFilePos": 273,
+              "endLine": 7,
+              "endTokenPos": 126,
+              "endFilePos": 274
+            },
+            "name": "c"
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 131,
+                "startFilePos": 283,
+                "endLine": 8,
+                "endTokenPos": 136,
+                "endFilePos": 299
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 131,
+                  "startFilePos": 283,
+                  "endLine": 8,
+                  "endTokenPos": 135,
+                  "endFilePos": 298
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 131,
+                    "startFilePos": 283,
+                    "endLine": 8,
+                    "endTokenPos": 131,
+                    "endFilePos": 290
+                  },
+                  "name": "matched"
+                },
+                "expr": {
+                  "nodeType": "Expr_ConstFetch",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 135,
+                    "startFilePos": 294,
+                    "endLine": 8,
+                    "endTokenPos": 135,
+                    "endFilePos": 298
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 135,
+                      "startFilePos": 294,
+                      "endLine": 8,
+                      "endTokenPos": 135,
+                      "endFilePos": 298
+                    },
+                    "name": "false"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Stmt_Foreach",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 138,
+                "startFilePos": 305,
+                "endLine": 15,
+                "endTokenPos": 234,
+                "endFilePos": 538
+              },
+              "expr": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 141,
+                  "startFilePos": 314,
+                  "endLine": 9,
+                  "endTokenPos": 141,
+                  "endFilePos": 319
+                },
+                "name": "items"
+              },
+              "keyVar": null,
+              "byRef": false,
+              "valueVar": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 145,
+                  "startFilePos": 324,
+                  "endLine": 9,
+                  "endTokenPos": 145,
+                  "endFilePos": 325
+                },
+                "name": "i"
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_If",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 150,
+                    "startFilePos": 336,
+                    "endLine": 10,
+                    "endTokenPos": 170,
+                    "endFilePos": 378
+                  },
+                  "cond": {
+                    "nodeType": "Expr_BooleanNot",
+                    "attributes": {
+                      "startLine": 10,
+                      "startTokenPos": 153,
+                      "startFilePos": 340,
+                      "endLine": 10,
+                      "endTokenPos": 166,
+                      "endFilePos": 367
+                    },
+                    "expr": {
+                      "nodeType": "Expr_BinaryOp_Equal",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 155,
+                        "startFilePos": 342,
+                        "endLine": 10,
+                        "endTokenPos": 165,
+                        "endFilePos": 366
+                      },
+                      "left": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 155,
+                          "startFilePos": 342,
+                          "endLine": 10,
+                          "endTokenPos": 158,
+                          "endFilePos": 349
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 155,
+                            "startFilePos": 342,
+                            "endLine": 10,
+                            "endTokenPos": 155,
+                            "endFilePos": 343
+                          },
+                          "name": "o"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 157,
+                            "startFilePos": 345,
+                            "endLine": 10,
+                            "endTokenPos": 157,
+                            "endFilePos": 348,
+                            "kind": 2,
+                            "rawValue": "\"id\""
+                          },
+                          "value": "id"
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 162,
+                          "startFilePos": 354,
+                          "endLine": 10,
+                          "endTokenPos": 165,
+                          "endFilePos": 366
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 162,
+                            "startFilePos": 354,
+                            "endLine": 10,
+                            "endTokenPos": 162,
+                            "endFilePos": 355
+                          },
+                          "name": "i"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 164,
+                            "startFilePos": 357,
+                            "endLine": 10,
+                            "endTokenPos": 164,
+                            "endFilePos": 365,
+                            "kind": 2,
+                            "rawValue": "\"orderId\""
+                          },
+                          "value": "orderId"
+                        }
+                      }
+                    }
+                  },
+                  "stmts": [
+                    {
+                      "nodeType": "Stmt_Continue",
+                      "attributes": {
+                        "startLine": 10,
+                        "startTokenPos": 169,
+                        "startFilePos": 370,
+                        "endLine": 10,
+                        "endTokenPos": 170,
+                        "endFilePos": 378
+                      },
+                      "num": null
+                    }
+                  ],
+                  "elseifs": [],
+                  "else": null
+                },
+                {
+                  "nodeType": "Stmt_Expression",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 172,
+                    "startFilePos": 386,
+                    "endLine": 11,
+                    "endTokenPos": 177,
+                    "endFilePos": 401
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Assign",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 172,
+                      "startFilePos": 386,
+                      "endLine": 11,
+                      "endTokenPos": 176,
+                      "endFilePos": 400
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 172,
+                        "startFilePos": 386,
+                        "endLine": 11,
+                        "endTokenPos": 172,
+                        "endFilePos": 393
+                      },
+                      "name": "matched"
+                    },
+                    "expr": {
+                      "nodeType": "Expr_ConstFetch",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 176,
+                        "startFilePos": 397,
+                        "endLine": 11,
+                        "endTokenPos": 176,
+                        "endFilePos": 400
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 176,
+                          "startFilePos": 397,
+                          "endLine": 11,
+                          "endTokenPos": 176,
+                          "endFilePos": 400
+                        },
+                        "name": "true"
+                      }
+                    }
+                  }
+                },
+                {
+                  "nodeType": "Stmt_If",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 179,
+                    "startFilePos": 409,
+                    "endLine": 14,
+                    "endTokenPos": 232,
+                    "endFilePos": 532
+                  },
+                  "cond": {
+                    "nodeType": "Expr_BinaryOp_Equal",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 182,
+                      "startFilePos": 413,
+                      "endLine": 12,
+                      "endTokenPos": 192,
+                      "endFilePos": 440
+                    },
+                    "left": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 182,
+                        "startFilePos": 413,
+                        "endLine": 12,
+                        "endTokenPos": 185,
+                        "endFilePos": 428
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 182,
+                          "startFilePos": 413,
+                          "endLine": 12,
+                          "endTokenPos": 182,
+                          "endFilePos": 414
+                        },
+                        "name": "o"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 184,
+                          "startFilePos": 416,
+                          "endLine": 12,
+                          "endTokenPos": 184,
+                          "endFilePos": 427,
+                          "kind": 2,
+                          "rawValue": "\"customerId\""
+                        },
+                        "value": "customerId"
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 189,
+                        "startFilePos": 433,
+                        "endLine": 12,
+                        "endTokenPos": 192,
+                        "endFilePos": 440
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 189,
+                          "startFilePos": 433,
+                          "endLine": 12,
+                          "endTokenPos": 189,
+                          "endFilePos": 434
+                        },
+                        "name": "c"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 191,
+                          "startFilePos": 436,
+                          "endLine": 12,
+                          "endTokenPos": 191,
+                          "endFilePos": 439,
+                          "kind": 2,
+                          "rawValue": "\"id\""
+                        },
+                        "value": "id"
+                      }
+                    }
+                  },
+                  "stmts": [
+                    {
+                      "nodeType": "Stmt_Expression",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 197,
+                        "startFilePos": 453,
+                        "endLine": 13,
+                        "endTokenPos": 230,
+                        "endFilePos": 524
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Assign",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 197,
+                          "startFilePos": 453,
+                          "endLine": 13,
+                          "endTokenPos": 229,
+                          "endFilePos": 523
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 197,
+                            "startFilePos": 453,
+                            "endLine": 13,
+                            "endTokenPos": 199,
+                            "endFilePos": 461
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 13,
+                              "startTokenPos": 197,
+                              "startFilePos": 453,
+                              "endLine": 13,
+                              "endTokenPos": 197,
+                              "endFilePos": 459
+                            },
+                            "name": "result"
+                          },
+                          "dim": null
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 13,
+                            "startTokenPos": 203,
+                            "startFilePos": 465,
+                            "endLine": 13,
+                            "endTokenPos": 229,
+                            "endFilePos": 523,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 204,
+                                "startFilePos": 466,
+                                "endLine": 13,
+                                "endTokenPos": 211,
+                                "endFilePos": 486
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 204,
+                                  "startFilePos": 466,
+                                  "endLine": 13,
+                                  "endTokenPos": 204,
+                                  "endFilePos": 474,
+                                  "kind": 2,
+                                  "rawValue": "\"orderId\""
+                                },
+                                "value": "orderId"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 208,
+                                  "startFilePos": 479,
+                                  "endLine": 13,
+                                  "endTokenPos": 211,
+                                  "endFilePos": 486
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 208,
+                                    "startFilePos": 479,
+                                    "endLine": 13,
+                                    "endTokenPos": 208,
+                                    "endFilePos": 480
+                                  },
+                                  "name": "o"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 210,
+                                    "startFilePos": 482,
+                                    "endLine": 13,
+                                    "endTokenPos": 210,
+                                    "endFilePos": 485,
+                                    "kind": 2,
+                                    "rawValue": "\"id\""
+                                  },
+                                  "value": "id"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 214,
+                                "startFilePos": 489,
+                                "endLine": 13,
+                                "endTokenPos": 221,
+                                "endFilePos": 508
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 214,
+                                  "startFilePos": 489,
+                                  "endLine": 13,
+                                  "endTokenPos": 214,
+                                  "endFilePos": 494,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 218,
+                                  "startFilePos": 499,
+                                  "endLine": 13,
+                                  "endTokenPos": 221,
+                                  "endFilePos": 508
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 218,
+                                    "startFilePos": 499,
+                                    "endLine": 13,
+                                    "endTokenPos": 218,
+                                    "endFilePos": 500
+                                  },
+                                  "name": "c"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 13,
+                                    "startTokenPos": 220,
+                                    "startFilePos": 502,
+                                    "endLine": 13,
+                                    "endTokenPos": 220,
+                                    "endFilePos": 507,
+                                    "kind": 2,
+                                    "rawValue": "\"name\""
+                                  },
+                                  "value": "name"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 13,
+                                "startTokenPos": 224,
+                                "startFilePos": 511,
+                                "endLine": 13,
+                                "endTokenPos": 228,
+                                "endFilePos": 522
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 224,
+                                  "startFilePos": 511,
+                                  "endLine": 13,
+                                  "endTokenPos": 224,
+                                  "endFilePos": 516,
+                                  "kind": 2,
+                                  "rawValue": "\"item\""
+                                },
+                                "value": "item"
+                              },
+                              "value": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 13,
+                                  "startTokenPos": 228,
+                                  "startFilePos": 521,
+                                  "endLine": 13,
+                                  "endTokenPos": 228,
+                                  "endFilePos": 522
+                                },
+                                "name": "i"
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "elseifs": [],
+                  "else": null
+                }
+              ]
+            },
+            {
+              "nodeType": "Stmt_If",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 236,
+                "startFilePos": 544,
+                "endLine": 21,
+                "endTokenPos": 307,
+                "endFilePos": 713
+              },
+              "cond": {
+                "nodeType": "Expr_BooleanNot",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 239,
+                  "startFilePos": 548,
+                  "endLine": 16,
+                  "endTokenPos": 240,
+                  "endFilePos": 556
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 240,
+                    "startFilePos": 549,
+                    "endLine": 16,
+                    "endTokenPos": 240,
+                    "endFilePos": 556
+                  },
+                  "name": "matched"
+                }
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_Expression",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 245,
+                    "startFilePos": 567,
+                    "endLine": 17,
+                    "endTokenPos": 250,
+                    "endFilePos": 576
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Assign",
+                    "attributes": {
+                      "startLine": 17,
+                      "startTokenPos": 245,
+                      "startFilePos": 567,
+                      "endLine": 17,
+                      "endTokenPos": 249,
+                      "endFilePos": 575
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 17,
+                        "startTokenPos": 245,
+                        "startFilePos": 567,
+                        "endLine": 17,
+                        "endTokenPos": 245,
+                        "endFilePos": 568
+                      },
+                      "name": "i"
+                    },
+                    "expr": {
+                      "nodeType": "Expr_ConstFetch",
+                      "attributes": {
+                        "startLine": 17,
+                        "startTokenPos": 249,
+                        "startFilePos": 572,
+                        "endLine": 17,
+                        "endTokenPos": 249,
+                        "endFilePos": 575
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 17,
+                          "startTokenPos": 249,
+                          "startFilePos": 572,
+                          "endLine": 17,
+                          "endTokenPos": 249,
+                          "endFilePos": 575
+                        },
+                        "name": "null"
+                      }
+                    }
+                  }
+                },
+                {
+                  "nodeType": "Stmt_If",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 252,
+                    "startFilePos": 584,
+                    "endLine": 20,
+                    "endTokenPos": 305,
+                    "endFilePos": 707
+                  },
+                  "cond": {
+                    "nodeType": "Expr_BinaryOp_Equal",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 255,
+                      "startFilePos": 588,
+                      "endLine": 18,
+                      "endTokenPos": 265,
+                      "endFilePos": 615
+                    },
+                    "left": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 255,
+                        "startFilePos": 588,
+                        "endLine": 18,
+                        "endTokenPos": 258,
+                        "endFilePos": 603
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 255,
+                          "startFilePos": 588,
+                          "endLine": 18,
+                          "endTokenPos": 255,
+                          "endFilePos": 589
+                        },
+                        "name": "o"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 257,
+                          "startFilePos": 591,
+                          "endLine": 18,
+                          "endTokenPos": 257,
+                          "endFilePos": 602,
+                          "kind": 2,
+                          "rawValue": "\"customerId\""
+                        },
+                        "value": "customerId"
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 18,
+                        "startTokenPos": 262,
+                        "startFilePos": 608,
+                        "endLine": 18,
+                        "endTokenPos": 265,
+                        "endFilePos": 615
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 262,
+                          "startFilePos": 608,
+                          "endLine": 18,
+                          "endTokenPos": 262,
+                          "endFilePos": 609
+                        },
+                        "name": "c"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 18,
+                          "startTokenPos": 264,
+                          "startFilePos": 611,
+                          "endLine": 18,
+                          "endTokenPos": 264,
+                          "endFilePos": 614,
+                          "kind": 2,
+                          "rawValue": "\"id\""
+                        },
+                        "value": "id"
+                      }
+                    }
+                  },
+                  "stmts": [
+                    {
+                      "nodeType": "Stmt_Expression",
+                      "attributes": {
+                        "startLine": 19,
+                        "startTokenPos": 270,
+                        "startFilePos": 628,
+                        "endLine": 19,
+                        "endTokenPos": 303,
+                        "endFilePos": 699
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Assign",
+                        "attributes": {
+                          "startLine": 19,
+                          "startTokenPos": 270,
+                          "startFilePos": 628,
+                          "endLine": 19,
+                          "endTokenPos": 302,
+                          "endFilePos": 698
+                        },
+                        "var": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 19,
+                            "startTokenPos": 270,
+                            "startFilePos": 628,
+                            "endLine": 19,
+                            "endTokenPos": 272,
+                            "endFilePos": 636
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 19,
+                              "startTokenPos": 270,
+                              "startFilePos": 628,
+                              "endLine": 19,
+                              "endTokenPos": 270,
+                              "endFilePos": 634
+                            },
+                            "name": "result"
+                          },
+                          "dim": null
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Array",
+                          "attributes": {
+                            "startLine": 19,
+                            "startTokenPos": 276,
+                            "startFilePos": 640,
+                            "endLine": 19,
+                            "endTokenPos": 302,
+                            "endFilePos": 698,
+                            "kind": 2
+                          },
+                          "items": [
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 19,
+                                "startTokenPos": 277,
+                                "startFilePos": 641,
+                                "endLine": 19,
+                                "endTokenPos": 284,
+                                "endFilePos": 661
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 19,
+                                  "startTokenPos": 277,
+                                  "startFilePos": 641,
+                                  "endLine": 19,
+                                  "endTokenPos": 277,
+                                  "endFilePos": 649,
+                                  "kind": 2,
+                                  "rawValue": "\"orderId\""
+                                },
+                                "value": "orderId"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 19,
+                                  "startTokenPos": 281,
+                                  "startFilePos": 654,
+                                  "endLine": 19,
+                                  "endTokenPos": 284,
+                                  "endFilePos": 661
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 19,
+                                    "startTokenPos": 281,
+                                    "startFilePos": 654,
+                                    "endLine": 19,
+                                    "endTokenPos": 281,
+                                    "endFilePos": 655
+                                  },
+                                  "name": "o"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 19,
+                                    "startTokenPos": 283,
+                                    "startFilePos": 657,
+                                    "endLine": 19,
+                                    "endTokenPos": 283,
+                                    "endFilePos": 660,
+                                    "kind": 2,
+                                    "rawValue": "\"id\""
+                                  },
+                                  "value": "id"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 19,
+                                "startTokenPos": 287,
+                                "startFilePos": 664,
+                                "endLine": 19,
+                                "endTokenPos": 294,
+                                "endFilePos": 683
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 19,
+                                  "startTokenPos": 287,
+                                  "startFilePos": 664,
+                                  "endLine": 19,
+                                  "endTokenPos": 287,
+                                  "endFilePos": 669,
+                                  "kind": 2,
+                                  "rawValue": "\"name\""
+                                },
+                                "value": "name"
+                              },
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 19,
+                                  "startTokenPos": 291,
+                                  "startFilePos": 674,
+                                  "endLine": 19,
+                                  "endTokenPos": 294,
+                                  "endFilePos": 683
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 19,
+                                    "startTokenPos": 291,
+                                    "startFilePos": 674,
+                                    "endLine": 19,
+                                    "endTokenPos": 291,
+                                    "endFilePos": 675
+                                  },
+                                  "name": "c"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 19,
+                                    "startTokenPos": 293,
+                                    "startFilePos": 677,
+                                    "endLine": 19,
+                                    "endTokenPos": 293,
+                                    "endFilePos": 682,
+                                    "kind": 2,
+                                    "rawValue": "\"name\""
+                                  },
+                                  "value": "name"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "ArrayItem",
+                              "attributes": {
+                                "startLine": 19,
+                                "startTokenPos": 297,
+                                "startFilePos": 686,
+                                "endLine": 19,
+                                "endTokenPos": 301,
+                                "endFilePos": 697
+                              },
+                              "key": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 19,
+                                  "startTokenPos": 297,
+                                  "startFilePos": 686,
+                                  "endLine": 19,
+                                  "endTokenPos": 297,
+                                  "endFilePos": 691,
+                                  "kind": 2,
+                                  "rawValue": "\"item\""
+                                },
+                                "value": "item"
+                              },
+                              "value": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 19,
+                                  "startTokenPos": 301,
+                                  "startFilePos": 696,
+                                  "endLine": 19,
+                                  "endTokenPos": 301,
+                                  "endFilePos": 697
+                                },
+                                "name": "i"
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "elseifs": [],
+                  "else": null
+                }
+              ],
+              "elseifs": [],
+              "else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 25,
+        "startTokenPos": 313,
+        "startFilePos": 722,
+        "endLine": 25,
+        "endTokenPos": 319,
+        "endFilePos": 761
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 25,
+            "startTokenPos": 315,
+            "startFilePos": 727,
+            "endLine": 25,
+            "endTokenPos": 315,
+            "endFilePos": 751,
+            "kind": 2,
+            "rawValue": "\"--- Left Join Multi ---\""
+          },
+          "value": "--- Left Join Multi ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 25,
+            "startTokenPos": 318,
+            "startFilePos": 754,
+            "endLine": 25,
+            "endTokenPos": 318,
+            "endFilePos": 760
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 25,
+              "startTokenPos": 318,
+              "startFilePos": 754,
+              "endLine": 25,
+              "endTokenPos": 318,
+              "endFilePos": 760
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 26,
+        "startTokenPos": 321,
+        "startFilePos": 763,
+        "endLine": 28,
+        "endTokenPos": 441,
+        "endFilePos": 1035
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 26,
+          "startTokenPos": 324,
+          "startFilePos": 772,
+          "endLine": 26,
+          "endTokenPos": 324,
+          "endFilePos": 778
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 26,
+          "startTokenPos": 328,
+          "startFilePos": 783,
+          "endLine": 26,
+          "endTokenPos": 328,
+          "endFilePos": 784
+        },
+        "name": "r"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 27,
+            "startTokenPos": 333,
+            "startFilePos": 791,
+            "endLine": 27,
+            "endTokenPos": 439,
+            "endFilePos": 1033
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 27,
+                "startTokenPos": 335,
+                "startFilePos": 796,
+                "endLine": 27,
+                "endTokenPos": 435,
+                "endFilePos": 1023
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 335,
+                  "startFilePos": 796,
+                  "endLine": 27,
+                  "endTokenPos": 403,
+                  "endFilePos": 953
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 335,
+                    "startFilePos": 796,
+                    "endLine": 27,
+                    "endTokenPos": 399,
+                    "endFilePos": 947
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 335,
+                      "startFilePos": 796,
+                      "endLine": 27,
+                      "endTokenPos": 367,
+                      "endFilePos": 877
+                    },
+                    "left": {
+                      "nodeType": "Expr_Ternary",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 336,
+                        "startFilePos": 797,
+                        "endLine": 27,
+                        "endTokenPos": 362,
+                        "endFilePos": 870
+                      },
+                      "cond": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 336,
+                          "startFilePos": 797,
+                          "endLine": 27,
+                          "endTokenPos": 342,
+                          "endFilePos": 819
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 336,
+                            "startFilePos": 797,
+                            "endLine": 27,
+                            "endTokenPos": 336,
+                            "endFilePos": 804
+                          },
+                          "name": "is_float"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 338,
+                              "startFilePos": 806,
+                              "endLine": 27,
+                              "endTokenPos": 341,
+                              "endFilePos": 818
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 338,
+                                "startFilePos": 806,
+                                "endLine": 27,
+                                "endTokenPos": 341,
+                                "endFilePos": 818
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 27,
+                                  "startTokenPos": 338,
+                                  "startFilePos": 806,
+                                  "endLine": 27,
+                                  "endTokenPos": 338,
+                                  "endFilePos": 807
+                                },
+                                "name": "r"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 27,
+                                  "startTokenPos": 340,
+                                  "startFilePos": 809,
+                                  "endLine": 27,
+                                  "endTokenPos": 340,
+                                  "endFilePos": 817,
+                                  "kind": 2,
+                                  "rawValue": "\"orderId\""
+                                },
+                                "value": "orderId"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "if": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 346,
+                          "startFilePos": 823,
+                          "endLine": 27,
+                          "endTokenPos": 355,
+                          "endFilePos": 854
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 346,
+                            "startFilePos": 823,
+                            "endLine": 27,
+                            "endTokenPos": 346,
+                            "endFilePos": 833
+                          },
+                          "name": "json_encode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 348,
+                              "startFilePos": 835,
+                              "endLine": 27,
+                              "endTokenPos": 351,
+                              "endFilePos": 847
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 348,
+                                "startFilePos": 835,
+                                "endLine": 27,
+                                "endTokenPos": 351,
+                                "endFilePos": 847
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 27,
+                                  "startTokenPos": 348,
+                                  "startFilePos": 835,
+                                  "endLine": 27,
+                                  "endTokenPos": 348,
+                                  "endFilePos": 836
+                                },
+                                "name": "r"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 27,
+                                  "startTokenPos": 350,
+                                  "startFilePos": 838,
+                                  "endLine": 27,
+                                  "endTokenPos": 350,
+                                  "endFilePos": 846,
+                                  "kind": 2,
+                                  "rawValue": "\"orderId\""
+                                },
+                                "value": "orderId"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 354,
+                              "startFilePos": 850,
+                              "endLine": 27,
+                              "endTokenPos": 354,
+                              "endFilePos": 853
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 354,
+                                "startFilePos": 850,
+                                "endLine": 27,
+                                "endTokenPos": 354,
+                                "endFilePos": 853,
+                                "rawValue": "1344",
+                                "kind": 10
+                              },
+                              "value": 1344
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "else": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 359,
+                          "startFilePos": 858,
+                          "endLine": 27,
+                          "endTokenPos": 362,
+                          "endFilePos": 870
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 359,
+                            "startFilePos": 858,
+                            "endLine": 27,
+                            "endTokenPos": 359,
+                            "endFilePos": 859
+                          },
+                          "name": "r"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 361,
+                            "startFilePos": 861,
+                            "endLine": 27,
+                            "endTokenPos": 361,
+                            "endFilePos": 869,
+                            "kind": 2,
+                            "rawValue": "\"orderId\""
+                          },
+                          "value": "orderId"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 367,
+                        "startFilePos": 875,
+                        "endLine": 27,
+                        "endTokenPos": 367,
+                        "endFilePos": 877,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Expr_Ternary",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 372,
+                      "startFilePos": 882,
+                      "endLine": 27,
+                      "endTokenPos": 398,
+                      "endFilePos": 946
+                    },
+                    "cond": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 372,
+                        "startFilePos": 882,
+                        "endLine": 27,
+                        "endTokenPos": 378,
+                        "endFilePos": 901
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 372,
+                          "startFilePos": 882,
+                          "endLine": 27,
+                          "endTokenPos": 372,
+                          "endFilePos": 889
+                        },
+                        "name": "is_float"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 374,
+                            "startFilePos": 891,
+                            "endLine": 27,
+                            "endTokenPos": 377,
+                            "endFilePos": 900
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 374,
+                              "startFilePos": 891,
+                              "endLine": 27,
+                              "endTokenPos": 377,
+                              "endFilePos": 900
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 374,
+                                "startFilePos": 891,
+                                "endLine": 27,
+                                "endTokenPos": 374,
+                                "endFilePos": 892
+                              },
+                              "name": "r"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 376,
+                                "startFilePos": 894,
+                                "endLine": 27,
+                                "endTokenPos": 376,
+                                "endFilePos": 899,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "if": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 382,
+                        "startFilePos": 905,
+                        "endLine": 27,
+                        "endTokenPos": 391,
+                        "endFilePos": 933
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 382,
+                          "startFilePos": 905,
+                          "endLine": 27,
+                          "endTokenPos": 382,
+                          "endFilePos": 915
+                        },
+                        "name": "json_encode"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 384,
+                            "startFilePos": 917,
+                            "endLine": 27,
+                            "endTokenPos": 387,
+                            "endFilePos": 926
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 384,
+                              "startFilePos": 917,
+                              "endLine": 27,
+                              "endTokenPos": 387,
+                              "endFilePos": 926
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 384,
+                                "startFilePos": 917,
+                                "endLine": 27,
+                                "endTokenPos": 384,
+                                "endFilePos": 918
+                              },
+                              "name": "r"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 386,
+                                "startFilePos": 920,
+                                "endLine": 27,
+                                "endTokenPos": 386,
+                                "endFilePos": 925,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 390,
+                            "startFilePos": 929,
+                            "endLine": 27,
+                            "endTokenPos": 390,
+                            "endFilePos": 932
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 390,
+                              "startFilePos": 929,
+                              "endLine": 27,
+                              "endTokenPos": 390,
+                              "endFilePos": 932,
+                              "rawValue": "1344",
+                              "kind": 10
+                            },
+                            "value": 1344
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "else": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 395,
+                        "startFilePos": 937,
+                        "endLine": 27,
+                        "endTokenPos": 398,
+                        "endFilePos": 946
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 395,
+                          "startFilePos": 937,
+                          "endLine": 27,
+                          "endTokenPos": 395,
+                          "endFilePos": 938
+                        },
+                        "name": "r"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 397,
+                          "startFilePos": 940,
+                          "endLine": 27,
+                          "endTokenPos": 397,
+                          "endFilePos": 945,
+                          "kind": 2,
+                          "rawValue": "\"name\""
+                        },
+                        "value": "name"
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 403,
+                    "startFilePos": 951,
+                    "endLine": 27,
+                    "endTokenPos": 403,
+                    "endFilePos": 953,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 408,
+                  "startFilePos": 958,
+                  "endLine": 27,
+                  "endTokenPos": 434,
+                  "endFilePos": 1022
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 408,
+                    "startFilePos": 958,
+                    "endLine": 27,
+                    "endTokenPos": 414,
+                    "endFilePos": 977
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 408,
+                      "startFilePos": 958,
+                      "endLine": 27,
+                      "endTokenPos": 408,
+                      "endFilePos": 965
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 410,
+                        "startFilePos": 967,
+                        "endLine": 27,
+                        "endTokenPos": 413,
+                        "endFilePos": 976
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 410,
+                          "startFilePos": 967,
+                          "endLine": 27,
+                          "endTokenPos": 413,
+                          "endFilePos": 976
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 410,
+                            "startFilePos": 967,
+                            "endLine": 27,
+                            "endTokenPos": 410,
+                            "endFilePos": 968
+                          },
+                          "name": "r"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 412,
+                            "startFilePos": 970,
+                            "endLine": 27,
+                            "endTokenPos": 412,
+                            "endFilePos": 975,
+                            "kind": 2,
+                            "rawValue": "\"item\""
+                          },
+                          "value": "item"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 418,
+                    "startFilePos": 981,
+                    "endLine": 27,
+                    "endTokenPos": 427,
+                    "endFilePos": 1009
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 418,
+                      "startFilePos": 981,
+                      "endLine": 27,
+                      "endTokenPos": 418,
+                      "endFilePos": 991
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 420,
+                        "startFilePos": 993,
+                        "endLine": 27,
+                        "endTokenPos": 423,
+                        "endFilePos": 1002
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 420,
+                          "startFilePos": 993,
+                          "endLine": 27,
+                          "endTokenPos": 423,
+                          "endFilePos": 1002
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 420,
+                            "startFilePos": 993,
+                            "endLine": 27,
+                            "endTokenPos": 420,
+                            "endFilePos": 994
+                          },
+                          "name": "r"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 422,
+                            "startFilePos": 996,
+                            "endLine": 27,
+                            "endTokenPos": 422,
+                            "endFilePos": 1001,
+                            "kind": 2,
+                            "rawValue": "\"item\""
+                          },
+                          "value": "item"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 27,
+                        "startTokenPos": 426,
+                        "startFilePos": 1005,
+                        "endLine": 27,
+                        "endTokenPos": 426,
+                        "endFilePos": 1008
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 426,
+                          "startFilePos": 1005,
+                          "endLine": 27,
+                          "endTokenPos": 426,
+                          "endFilePos": 1008,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 431,
+                    "startFilePos": 1013,
+                    "endLine": 27,
+                    "endTokenPos": 434,
+                    "endFilePos": 1022
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 431,
+                      "startFilePos": 1013,
+                      "endLine": 27,
+                      "endTokenPos": 431,
+                      "endFilePos": 1014
+                    },
+                    "name": "r"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 433,
+                      "startFilePos": 1016,
+                      "endLine": 27,
+                      "endTokenPos": 433,
+                      "endFilePos": 1021,
+                      "kind": 2,
+                      "rawValue": "\"item\""
+                    },
+                    "value": "item"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 27,
+                "startTokenPos": 438,
+                "startFilePos": 1026,
+                "endLine": 27,
+                "endTokenPos": 438,
+                "endFilePos": 1032
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 438,
+                  "startFilePos": 1026,
+                  "endLine": 27,
+                  "endTokenPos": 438,
+                  "endFilePos": 1032
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/len_builtin.php.json
+++ b/tests/json-ast/x/php/len_builtin.php.json
@@ -1,0 +1,568 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 59,
+        "endFilePos": 105
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 54,
+            "endFilePos": 94
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 18,
+              "endFilePos": 37
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 36
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 17,
+                    "endFilePos": 36
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 25
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 27,
+                        "endLine": 2,
+                        "endTokenPos": 16,
+                        "endFilePos": 35
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 27,
+                          "endLine": 2,
+                          "endTokenPos": 16,
+                          "endFilePos": 35,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 9,
+                              "startFilePos": 28,
+                              "endLine": 2,
+                              "endTokenPos": 9,
+                              "endFilePos": 28
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 9,
+                                "startFilePos": 28,
+                                "endLine": 2,
+                                "endTokenPos": 9,
+                                "endFilePos": 28,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 12,
+                              "startFilePos": 31,
+                              "endLine": 2,
+                              "endTokenPos": 12,
+                              "endFilePos": 31
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 12,
+                                "startFilePos": 31,
+                                "endLine": 2,
+                                "endTokenPos": 12,
+                                "endFilePos": 31,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 15,
+                              "startFilePos": 34,
+                              "endLine": 2,
+                              "endTokenPos": 15,
+                              "endFilePos": 34
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 15,
+                                "startFilePos": 34,
+                                "endLine": 2,
+                                "endTokenPos": 15,
+                                "endFilePos": 34,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 22,
+              "startFilePos": 41,
+              "endLine": 2,
+              "endTokenPos": 39,
+              "endFilePos": 75
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 41,
+                "endLine": 2,
+                "endTokenPos": 22,
+                "endFilePos": 51
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 53,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 68
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 24,
+                    "startFilePos": 53,
+                    "endLine": 2,
+                    "endTokenPos": 35,
+                    "endFilePos": 68
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 24,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 24,
+                      "endFilePos": 57
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 26,
+                        "startFilePos": 59,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 67
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 26,
+                          "startFilePos": 59,
+                          "endLine": 2,
+                          "endTokenPos": 34,
+                          "endFilePos": 67,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 27,
+                              "startFilePos": 60,
+                              "endLine": 2,
+                              "endTokenPos": 27,
+                              "endFilePos": 60
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 27,
+                                "startFilePos": 60,
+                                "endLine": 2,
+                                "endTokenPos": 27,
+                                "endFilePos": 60,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 30,
+                              "startFilePos": 63,
+                              "endLine": 2,
+                              "endTokenPos": 30,
+                              "endFilePos": 63
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 30,
+                                "startFilePos": 63,
+                                "endLine": 2,
+                                "endTokenPos": 30,
+                                "endFilePos": 63,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 33,
+                              "startFilePos": 66,
+                              "endLine": 2,
+                              "endTokenPos": 33,
+                              "endFilePos": 66
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 33,
+                                "startFilePos": 66,
+                                "endLine": 2,
+                                "endTokenPos": 33,
+                                "endFilePos": 66,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 71,
+                  "endLine": 2,
+                  "endTokenPos": 38,
+                  "endFilePos": 74
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 38,
+                    "startFilePos": 71,
+                    "endLine": 2,
+                    "endTokenPos": 38,
+                    "endFilePos": 74,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 43,
+              "startFilePos": 79,
+              "endLine": 2,
+              "endTokenPos": 54,
+              "endFilePos": 94
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 43,
+                "startFilePos": 79,
+                "endLine": 2,
+                "endTokenPos": 43,
+                "endFilePos": 83
+              },
+              "name": "count"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 45,
+                  "startFilePos": 85,
+                  "endLine": 2,
+                  "endTokenPos": 53,
+                  "endFilePos": 93
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 45,
+                    "startFilePos": 85,
+                    "endLine": 2,
+                    "endTokenPos": 53,
+                    "endFilePos": 93,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 86,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 86
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 46,
+                          "startFilePos": 86,
+                          "endLine": 2,
+                          "endTokenPos": 46,
+                          "endFilePos": 86,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 49,
+                        "startFilePos": 89,
+                        "endLine": 2,
+                        "endTokenPos": 49,
+                        "endFilePos": 89
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 49,
+                          "startFilePos": 89,
+                          "endLine": 2,
+                          "endTokenPos": 49,
+                          "endFilePos": 89,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 52,
+                        "startFilePos": 92,
+                        "endLine": 2,
+                        "endTokenPos": 52,
+                        "endFilePos": 92
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 52,
+                          "startFilePos": 92,
+                          "endLine": 2,
+                          "endTokenPos": 52,
+                          "endFilePos": 92,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 58,
+            "startFilePos": 98,
+            "endLine": 2,
+            "endTokenPos": 58,
+            "endFilePos": 104
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 58,
+              "startFilePos": 98,
+              "endLine": 2,
+              "endTokenPos": 58,
+              "endFilePos": 104
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/len_map.php.json
+++ b/tests/json-ast/x/php/len_map.php.json
@@ -1,0 +1,562 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 74,
+        "endFilePos": 138
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 69,
+            "endFilePos": 127
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 23,
+              "endFilePos": 48
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 22,
+                  "endFilePos": 47
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 22,
+                    "endFilePos": 47
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 25
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 27,
+                        "endLine": 2,
+                        "endTokenPos": 21,
+                        "endFilePos": 46
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 27,
+                          "endLine": 2,
+                          "endTokenPos": 21,
+                          "endFilePos": 46,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 9,
+                              "startFilePos": 28,
+                              "endLine": 2,
+                              "endTokenPos": 13,
+                              "endFilePos": 35
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 9,
+                                "startFilePos": 28,
+                                "endLine": 2,
+                                "endTokenPos": 9,
+                                "endFilePos": 30,
+                                "kind": 2,
+                                "rawValue": "\"a\""
+                              },
+                              "value": "a"
+                            },
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 13,
+                                "startFilePos": 35,
+                                "endLine": 2,
+                                "endTokenPos": 13,
+                                "endFilePos": 35,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 16,
+                              "startFilePos": 38,
+                              "endLine": 2,
+                              "endTokenPos": 20,
+                              "endFilePos": 45
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 16,
+                                "startFilePos": 38,
+                                "endLine": 2,
+                                "endTokenPos": 16,
+                                "endFilePos": 40,
+                                "kind": 2,
+                                "rawValue": "\"b\""
+                              },
+                              "value": "b"
+                            },
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 20,
+                                "startFilePos": 45,
+                                "endLine": 2,
+                                "endTokenPos": 20,
+                                "endFilePos": 45,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 27,
+              "startFilePos": 52,
+              "endLine": 2,
+              "endTokenPos": 49,
+              "endFilePos": 97
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 27,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 27,
+                "endFilePos": 62
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 64,
+                  "endLine": 2,
+                  "endTokenPos": 45,
+                  "endFilePos": 90
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 29,
+                    "startFilePos": 64,
+                    "endLine": 2,
+                    "endTokenPos": 45,
+                    "endFilePos": 90
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 29,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 29,
+                      "endFilePos": 68
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 31,
+                        "startFilePos": 70,
+                        "endLine": 2,
+                        "endTokenPos": 44,
+                        "endFilePos": 89
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 31,
+                          "startFilePos": 70,
+                          "endLine": 2,
+                          "endTokenPos": 44,
+                          "endFilePos": 89,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 32,
+                              "startFilePos": 71,
+                              "endLine": 2,
+                              "endTokenPos": 36,
+                              "endFilePos": 78
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 32,
+                                "startFilePos": 71,
+                                "endLine": 2,
+                                "endTokenPos": 32,
+                                "endFilePos": 73,
+                                "kind": 2,
+                                "rawValue": "\"a\""
+                              },
+                              "value": "a"
+                            },
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 36,
+                                "startFilePos": 78,
+                                "endLine": 2,
+                                "endTokenPos": 36,
+                                "endFilePos": 78,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 39,
+                              "startFilePos": 81,
+                              "endLine": 2,
+                              "endTokenPos": 43,
+                              "endFilePos": 88
+                            },
+                            "key": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 39,
+                                "startFilePos": 81,
+                                "endLine": 2,
+                                "endTokenPos": 39,
+                                "endFilePos": 83,
+                                "kind": 2,
+                                "rawValue": "\"b\""
+                              },
+                              "value": "b"
+                            },
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 43,
+                                "startFilePos": 88,
+                                "endLine": 2,
+                                "endTokenPos": 43,
+                                "endFilePos": 88,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 48,
+                  "startFilePos": 93,
+                  "endLine": 2,
+                  "endTokenPos": 48,
+                  "endFilePos": 96
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 48,
+                    "startFilePos": 93,
+                    "endLine": 2,
+                    "endTokenPos": 48,
+                    "endFilePos": 96,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 53,
+              "startFilePos": 101,
+              "endLine": 2,
+              "endTokenPos": 69,
+              "endFilePos": 127
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 53,
+                "startFilePos": 101,
+                "endLine": 2,
+                "endTokenPos": 53,
+                "endFilePos": 105
+              },
+              "name": "count"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 55,
+                  "startFilePos": 107,
+                  "endLine": 2,
+                  "endTokenPos": 68,
+                  "endFilePos": 126
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 55,
+                    "startFilePos": 107,
+                    "endLine": 2,
+                    "endTokenPos": 68,
+                    "endFilePos": 126,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 56,
+                        "startFilePos": 108,
+                        "endLine": 2,
+                        "endTokenPos": 60,
+                        "endFilePos": 115
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 56,
+                          "startFilePos": 108,
+                          "endLine": 2,
+                          "endTokenPos": 56,
+                          "endFilePos": 110,
+                          "kind": 2,
+                          "rawValue": "\"a\""
+                        },
+                        "value": "a"
+                      },
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 60,
+                          "startFilePos": 115,
+                          "endLine": 2,
+                          "endTokenPos": 60,
+                          "endFilePos": 115,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 63,
+                        "startFilePos": 118,
+                        "endLine": 2,
+                        "endTokenPos": 67,
+                        "endFilePos": 125
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 63,
+                          "startFilePos": 118,
+                          "endLine": 2,
+                          "endTokenPos": 63,
+                          "endFilePos": 120,
+                          "kind": 2,
+                          "rawValue": "\"b\""
+                        },
+                        "value": "b"
+                      },
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 67,
+                          "startFilePos": 125,
+                          "endLine": 2,
+                          "endTokenPos": 67,
+                          "endFilePos": 125,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 73,
+            "startFilePos": 131,
+            "endLine": 2,
+            "endTokenPos": 73,
+            "endFilePos": 137
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 73,
+              "startFilePos": 131,
+              "endLine": 2,
+              "endTokenPos": 73,
+              "endFilePos": 137
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/len_string.php.json
+++ b/tests/json-ast/x/php/len_string.php.json
@@ -1,0 +1,316 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 35,
+        "endFilePos": 102
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 30,
+            "endFilePos": 91
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 10,
+              "endFilePos": 36
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 35
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 9,
+                    "endFilePos": 35
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 26
+                    },
+                    "name": "strlen"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 8,
+                        "endFilePos": 34
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 28,
+                          "endLine": 2,
+                          "endTokenPos": 8,
+                          "endFilePos": 34,
+                          "kind": 2,
+                          "rawValue": "\"mochi\""
+                        },
+                        "value": "mochi"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 14,
+              "startFilePos": 40,
+              "endLine": 2,
+              "endTokenPos": 23,
+              "endFilePos": 73
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 14,
+                "startFilePos": 40,
+                "endLine": 2,
+                "endTokenPos": 14,
+                "endFilePos": 50
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 16,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 66
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 16,
+                    "startFilePos": 52,
+                    "endLine": 2,
+                    "endTokenPos": 19,
+                    "endFilePos": 66
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 52,
+                      "endLine": 2,
+                      "endTokenPos": 16,
+                      "endFilePos": 57
+                    },
+                    "name": "strlen"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 59,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 65
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 18,
+                          "startFilePos": 59,
+                          "endLine": 2,
+                          "endTokenPos": 18,
+                          "endFilePos": 65,
+                          "kind": 2,
+                          "rawValue": "\"mochi\""
+                        },
+                        "value": "mochi"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 69,
+                  "endLine": 2,
+                  "endTokenPos": 22,
+                  "endFilePos": 72
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 22,
+                    "startFilePos": 69,
+                    "endLine": 2,
+                    "endTokenPos": 22,
+                    "endFilePos": 72,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 27,
+              "startFilePos": 77,
+              "endLine": 2,
+              "endTokenPos": 30,
+              "endFilePos": 91
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 27,
+                "startFilePos": 77,
+                "endLine": 2,
+                "endTokenPos": 27,
+                "endFilePos": 82
+              },
+              "name": "strlen"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 84,
+                  "endLine": 2,
+                  "endTokenPos": 29,
+                  "endFilePos": 90
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 29,
+                    "startFilePos": 84,
+                    "endLine": 2,
+                    "endTokenPos": 29,
+                    "endFilePos": 90,
+                    "kind": 2,
+                    "rawValue": "\"mochi\""
+                  },
+                  "value": "mochi"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 34,
+            "startFilePos": 95,
+            "endLine": 2,
+            "endTokenPos": 34,
+            "endFilePos": 101
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 34,
+              "startFilePos": 95,
+              "endLine": 2,
+              "endTokenPos": 34,
+              "endFilePos": 101
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/let_and_print.php.json
+++ b/tests/json-ast/x/php/let_and_print.php.json
@@ -1,0 +1,358 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 13
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 12
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "a"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 12,
+            "rawValue": "10",
+            "kind": 10
+          },
+          "value": 10
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 15,
+        "endLine": 3,
+        "endTokenPos": 13,
+        "endFilePos": 22
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 15,
+          "endLine": 3,
+          "endTokenPos": 12,
+          "endFilePos": 21
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 15,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 16
+          },
+          "name": "b"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 20,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 21,
+            "rawValue": "20",
+            "kind": 10
+          },
+          "value": 20
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 15,
+        "startFilePos": 24,
+        "endLine": 4,
+        "endTokenPos": 52,
+        "endFilePos": 96
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 18,
+            "startFilePos": 30,
+            "endLine": 4,
+            "endTokenPos": 47,
+            "endFilePos": 85
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 18,
+              "startFilePos": 30,
+              "endLine": 4,
+              "endTokenPos": 25,
+              "endFilePos": 46
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 18,
+                "startFilePos": 30,
+                "endLine": 4,
+                "endTokenPos": 18,
+                "endFilePos": 37
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 20,
+                  "startFilePos": 39,
+                  "endLine": 4,
+                  "endTokenPos": 24,
+                  "endFilePos": 45
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 20,
+                    "startFilePos": 39,
+                    "endLine": 4,
+                    "endTokenPos": 24,
+                    "endFilePos": 45
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 20,
+                      "startFilePos": 39,
+                      "endLine": 4,
+                      "endTokenPos": 20,
+                      "endFilePos": 40
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 24,
+                      "startFilePos": 44,
+                      "endLine": 4,
+                      "endTokenPos": 24,
+                      "endFilePos": 45
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 29,
+              "startFilePos": 50,
+              "endLine": 4,
+              "endTokenPos": 39,
+              "endFilePos": 75
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 29,
+                "startFilePos": 50,
+                "endLine": 4,
+                "endTokenPos": 29,
+                "endFilePos": 60
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 31,
+                  "startFilePos": 62,
+                  "endLine": 4,
+                  "endTokenPos": 35,
+                  "endFilePos": 68
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 31,
+                    "startFilePos": 62,
+                    "endLine": 4,
+                    "endTokenPos": 35,
+                    "endFilePos": 68
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 31,
+                      "startFilePos": 62,
+                      "endLine": 4,
+                      "endTokenPos": 31,
+                      "endFilePos": 63
+                    },
+                    "name": "a"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 35,
+                      "startFilePos": 67,
+                      "endLine": 4,
+                      "endTokenPos": 35,
+                      "endFilePos": 68
+                    },
+                    "name": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 38,
+                  "startFilePos": 71,
+                  "endLine": 4,
+                  "endTokenPos": 38,
+                  "endFilePos": 74
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 38,
+                    "startFilePos": 71,
+                    "endLine": 4,
+                    "endTokenPos": 38,
+                    "endFilePos": 74,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 43,
+              "startFilePos": 79,
+              "endLine": 4,
+              "endTokenPos": 47,
+              "endFilePos": 85
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 43,
+                "startFilePos": 79,
+                "endLine": 4,
+                "endTokenPos": 43,
+                "endFilePos": 80
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 47,
+                "startFilePos": 84,
+                "endLine": 4,
+                "endTokenPos": 47,
+                "endFilePos": 85
+              },
+              "name": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 51,
+            "startFilePos": 89,
+            "endLine": 4,
+            "endTokenPos": 51,
+            "endFilePos": 95
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 51,
+              "startFilePos": 89,
+              "endLine": 4,
+              "endTokenPos": 51,
+              "endFilePos": 95
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/list_assign.php.json
+++ b/tests/json-ast/x/php/list_assign.php.json
@@ -1,0 +1,445 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 11,
+        "endFilePos": 20
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 10,
+          "endFilePos": 19
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "nums"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 10,
+            "endFilePos": 19,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 13,
+        "startFilePos": 22,
+        "endLine": 3,
+        "endTokenPos": 21,
+        "endFilePos": 34
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 13,
+          "startFilePos": 22,
+          "endLine": 3,
+          "endTokenPos": 20,
+          "endFilePos": 33
+        },
+        "var": {
+          "nodeType": "Expr_ArrayDimFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 22,
+            "endLine": 3,
+            "endTokenPos": 16,
+            "endFilePos": 29
+          },
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 13,
+              "startFilePos": 22,
+              "endLine": 3,
+              "endTokenPos": 13,
+              "endFilePos": 26
+            },
+            "name": "nums"
+          },
+          "dim": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 15,
+              "startFilePos": 28,
+              "endLine": 3,
+              "endTokenPos": 15,
+              "endFilePos": 28,
+              "rawValue": "1",
+              "kind": 10
+            },
+            "value": 1
+          }
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 20,
+            "startFilePos": 33,
+            "endLine": 3,
+            "endTokenPos": 20,
+            "endFilePos": 33,
+            "rawValue": "3",
+            "kind": 10
+          },
+          "value": 3
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 23,
+        "startFilePos": 36,
+        "endLine": 4,
+        "endTokenPos": 57,
+        "endFilePos": 111
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 26,
+            "startFilePos": 42,
+            "endLine": 4,
+            "endTokenPos": 52,
+            "endFilePos": 100
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 26,
+              "startFilePos": 42,
+              "endLine": 4,
+              "endTokenPos": 32,
+              "endFilePos": 59
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 26,
+                "startFilePos": 42,
+                "endLine": 4,
+                "endTokenPos": 26,
+                "endFilePos": 49
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 28,
+                  "startFilePos": 51,
+                  "endLine": 4,
+                  "endTokenPos": 31,
+                  "endFilePos": 58
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 28,
+                    "startFilePos": 51,
+                    "endLine": 4,
+                    "endTokenPos": 31,
+                    "endFilePos": 58
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 28,
+                      "startFilePos": 51,
+                      "endLine": 4,
+                      "endTokenPos": 28,
+                      "endFilePos": 55
+                    },
+                    "name": "nums"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 30,
+                      "startFilePos": 57,
+                      "endLine": 4,
+                      "endTokenPos": 30,
+                      "endFilePos": 57,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 36,
+              "startFilePos": 63,
+              "endLine": 4,
+              "endTokenPos": 45,
+              "endFilePos": 89
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 36,
+                "startFilePos": 63,
+                "endLine": 4,
+                "endTokenPos": 36,
+                "endFilePos": 73
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 38,
+                  "startFilePos": 75,
+                  "endLine": 4,
+                  "endTokenPos": 41,
+                  "endFilePos": 82
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 38,
+                    "startFilePos": 75,
+                    "endLine": 4,
+                    "endTokenPos": 41,
+                    "endFilePos": 82
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 38,
+                      "startFilePos": 75,
+                      "endLine": 4,
+                      "endTokenPos": 38,
+                      "endFilePos": 79
+                    },
+                    "name": "nums"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 40,
+                      "startFilePos": 81,
+                      "endLine": 4,
+                      "endTokenPos": 40,
+                      "endFilePos": 81,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 44,
+                  "startFilePos": 85,
+                  "endLine": 4,
+                  "endTokenPos": 44,
+                  "endFilePos": 88
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 44,
+                    "startFilePos": 85,
+                    "endLine": 4,
+                    "endTokenPos": 44,
+                    "endFilePos": 88,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 49,
+              "startFilePos": 93,
+              "endLine": 4,
+              "endTokenPos": 52,
+              "endFilePos": 100
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 49,
+                "startFilePos": 93,
+                "endLine": 4,
+                "endTokenPos": 49,
+                "endFilePos": 97
+              },
+              "name": "nums"
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 51,
+                "startFilePos": 99,
+                "endLine": 4,
+                "endTokenPos": 51,
+                "endFilePos": 99,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 56,
+            "startFilePos": 104,
+            "endLine": 4,
+            "endTokenPos": 56,
+            "endFilePos": 110
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 56,
+              "startFilePos": 104,
+              "endLine": 4,
+              "endTokenPos": 56,
+              "endFilePos": 110
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/list_index.php.json
+++ b/tests/json-ast/x/php/list_index.php.json
@@ -1,0 +1,400 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 24
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 23
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 8
+          },
+          "name": "xs"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 23,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 13,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 14
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 13,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 14,
+                  "rawValue": "10",
+                  "kind": 10
+                },
+                "value": 10
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "20",
+                  "kind": 10
+                },
+                "value": 20
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 21,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 22
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 22,
+                  "rawValue": "30",
+                  "kind": 10
+                },
+                "value": 30
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 26,
+        "endLine": 3,
+        "endTokenPos": 50,
+        "endFilePos": 95
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 19,
+            "startFilePos": 32,
+            "endLine": 3,
+            "endTokenPos": 45,
+            "endFilePos": 84
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 19,
+              "startFilePos": 32,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 47
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 19,
+                "startFilePos": 32,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 39
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 21,
+                  "startFilePos": 41,
+                  "endLine": 3,
+                  "endTokenPos": 24,
+                  "endFilePos": 46
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 21,
+                    "startFilePos": 41,
+                    "endLine": 3,
+                    "endTokenPos": 24,
+                    "endFilePos": 46
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 21,
+                      "startFilePos": 41,
+                      "endLine": 3,
+                      "endTokenPos": 21,
+                      "endFilePos": 43
+                    },
+                    "name": "xs"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 23,
+                      "startFilePos": 45,
+                      "endLine": 3,
+                      "endTokenPos": 23,
+                      "endFilePos": 45,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 29,
+              "startFilePos": 51,
+              "endLine": 3,
+              "endTokenPos": 38,
+              "endFilePos": 75
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 29,
+                "startFilePos": 51,
+                "endLine": 3,
+                "endTokenPos": 29,
+                "endFilePos": 61
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 31,
+                  "startFilePos": 63,
+                  "endLine": 3,
+                  "endTokenPos": 34,
+                  "endFilePos": 68
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 31,
+                    "startFilePos": 63,
+                    "endLine": 3,
+                    "endTokenPos": 34,
+                    "endFilePos": 68
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 31,
+                      "startFilePos": 63,
+                      "endLine": 3,
+                      "endTokenPos": 31,
+                      "endFilePos": 65
+                    },
+                    "name": "xs"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 33,
+                      "startFilePos": 67,
+                      "endLine": 3,
+                      "endTokenPos": 33,
+                      "endFilePos": 67,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 37,
+                  "startFilePos": 71,
+                  "endLine": 3,
+                  "endTokenPos": 37,
+                  "endFilePos": 74
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 37,
+                    "startFilePos": 71,
+                    "endLine": 3,
+                    "endTokenPos": 37,
+                    "endFilePos": 74,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 42,
+              "startFilePos": 79,
+              "endLine": 3,
+              "endTokenPos": 45,
+              "endFilePos": 84
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 42,
+                "startFilePos": 79,
+                "endLine": 3,
+                "endTokenPos": 42,
+                "endFilePos": 81
+              },
+              "name": "xs"
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 44,
+                "startFilePos": 83,
+                "endLine": 3,
+                "endTokenPos": 44,
+                "endFilePos": 83,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 49,
+            "startFilePos": 88,
+            "endLine": 3,
+            "endTokenPos": 49,
+            "endFilePos": 94
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 49,
+              "startFilePos": 88,
+              "endLine": 3,
+              "endTokenPos": 49,
+              "endFilePos": 94
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/list_nested_assign.php.json
+++ b/tests/json-ast/x/php/list_nested_assign.php.json
@@ -1,0 +1,657 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 21,
+        "endFilePos": 32
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 20,
+          "endFilePos": 31
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "matrix"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 20,
+            "endFilePos": 31,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 11,
+                "endFilePos": 22
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 11,
+                  "endFilePos": 22,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 7,
+                      "endFilePos": 18
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 18,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 10,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 10,
+                      "endFilePos": 21
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 10,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 10,
+                        "endFilePos": 21,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 14,
+                "startFilePos": 25,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 30
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 14,
+                  "startFilePos": 25,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 30,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 15,
+                      "startFilePos": 26,
+                      "endLine": 2,
+                      "endTokenPos": 15,
+                      "endFilePos": 26
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 15,
+                        "startFilePos": 26,
+                        "endLine": 2,
+                        "endTokenPos": 15,
+                        "endFilePos": 26,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 18,
+                      "startFilePos": 29,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 29
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 29,
+                        "rawValue": "4",
+                        "kind": 10
+                      },
+                      "value": 4
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 23,
+        "startFilePos": 34,
+        "endLine": 3,
+        "endTokenPos": 34,
+        "endFilePos": 51
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 23,
+          "startFilePos": 34,
+          "endLine": 3,
+          "endTokenPos": 33,
+          "endFilePos": 50
+        },
+        "var": {
+          "nodeType": "Expr_ArrayDimFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 23,
+            "startFilePos": 34,
+            "endLine": 3,
+            "endTokenPos": 29,
+            "endFilePos": 46
+          },
+          "var": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 23,
+              "startFilePos": 34,
+              "endLine": 3,
+              "endTokenPos": 26,
+              "endFilePos": 43
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 23,
+                "startFilePos": 34,
+                "endLine": 3,
+                "endTokenPos": 23,
+                "endFilePos": 40
+              },
+              "name": "matrix"
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 25,
+                "startFilePos": 42,
+                "endLine": 3,
+                "endTokenPos": 25,
+                "endFilePos": 42,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          },
+          "dim": {
+            "nodeType": "Scalar_Int",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 28,
+              "startFilePos": 45,
+              "endLine": 3,
+              "endTokenPos": 28,
+              "endFilePos": 45,
+              "rawValue": "0",
+              "kind": 10
+            },
+            "value": 0
+          }
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 33,
+            "startFilePos": 50,
+            "endLine": 3,
+            "endTokenPos": 33,
+            "endFilePos": 50,
+            "rawValue": "5",
+            "kind": 10
+          },
+          "value": 5
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 36,
+        "startFilePos": 53,
+        "endLine": 4,
+        "endTokenPos": 79,
+        "endFilePos": 143
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 39,
+            "startFilePos": 59,
+            "endLine": 4,
+            "endTokenPos": 74,
+            "endFilePos": 132
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 39,
+              "startFilePos": 59,
+              "endLine": 4,
+              "endTokenPos": 48,
+              "endFilePos": 81
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 39,
+                "startFilePos": 59,
+                "endLine": 4,
+                "endTokenPos": 39,
+                "endFilePos": 66
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 41,
+                  "startFilePos": 68,
+                  "endLine": 4,
+                  "endTokenPos": 47,
+                  "endFilePos": 80
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 41,
+                    "startFilePos": 68,
+                    "endLine": 4,
+                    "endTokenPos": 47,
+                    "endFilePos": 80
+                  },
+                  "var": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 41,
+                      "startFilePos": 68,
+                      "endLine": 4,
+                      "endTokenPos": 44,
+                      "endFilePos": 77
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 41,
+                        "startFilePos": 68,
+                        "endLine": 4,
+                        "endTokenPos": 41,
+                        "endFilePos": 74
+                      },
+                      "name": "matrix"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 43,
+                        "startFilePos": 76,
+                        "endLine": 4,
+                        "endTokenPos": 43,
+                        "endFilePos": 76,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    }
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 46,
+                      "startFilePos": 79,
+                      "endLine": 4,
+                      "endTokenPos": 46,
+                      "endFilePos": 79,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 52,
+              "startFilePos": 85,
+              "endLine": 4,
+              "endTokenPos": 64,
+              "endFilePos": 116
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 52,
+                "startFilePos": 85,
+                "endLine": 4,
+                "endTokenPos": 52,
+                "endFilePos": 95
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 54,
+                  "startFilePos": 97,
+                  "endLine": 4,
+                  "endTokenPos": 60,
+                  "endFilePos": 109
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 54,
+                    "startFilePos": 97,
+                    "endLine": 4,
+                    "endTokenPos": 60,
+                    "endFilePos": 109
+                  },
+                  "var": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 54,
+                      "startFilePos": 97,
+                      "endLine": 4,
+                      "endTokenPos": 57,
+                      "endFilePos": 106
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 54,
+                        "startFilePos": 97,
+                        "endLine": 4,
+                        "endTokenPos": 54,
+                        "endFilePos": 103
+                      },
+                      "name": "matrix"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 56,
+                        "startFilePos": 105,
+                        "endLine": 4,
+                        "endTokenPos": 56,
+                        "endFilePos": 105,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    }
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 59,
+                      "startFilePos": 108,
+                      "endLine": 4,
+                      "endTokenPos": 59,
+                      "endFilePos": 108,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 63,
+                  "startFilePos": 112,
+                  "endLine": 4,
+                  "endTokenPos": 63,
+                  "endFilePos": 115
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 63,
+                    "startFilePos": 112,
+                    "endLine": 4,
+                    "endTokenPos": 63,
+                    "endFilePos": 115,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 68,
+              "startFilePos": 120,
+              "endLine": 4,
+              "endTokenPos": 74,
+              "endFilePos": 132
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 68,
+                "startFilePos": 120,
+                "endLine": 4,
+                "endTokenPos": 71,
+                "endFilePos": 129
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 68,
+                  "startFilePos": 120,
+                  "endLine": 4,
+                  "endTokenPos": 68,
+                  "endFilePos": 126
+                },
+                "name": "matrix"
+              },
+              "dim": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 70,
+                  "startFilePos": 128,
+                  "endLine": 4,
+                  "endTokenPos": 70,
+                  "endFilePos": 128,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              }
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 73,
+                "startFilePos": 131,
+                "endLine": 4,
+                "endTokenPos": 73,
+                "endFilePos": 131,
+                "rawValue": "0",
+                "kind": 10
+              },
+              "value": 0
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 78,
+            "startFilePos": 136,
+            "endLine": 4,
+            "endTokenPos": 78,
+            "endFilePos": 142
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 78,
+              "startFilePos": 136,
+              "endLine": 4,
+              "endTokenPos": 78,
+              "endFilePos": 142
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/list_set_ops.php.json
+++ b/tests/json-ast/x/php/list_set_ops.php.json
@@ -1,0 +1,3387 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 83,
+        "endFilePos": 240
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 3,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 79,
+            "endFilePos": 230
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 3,
+              "startFilePos": 11,
+              "endLine": 2,
+              "endTokenPos": 3,
+              "endFilePos": 21
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 5,
+                "startFilePos": 23,
+                "endLine": 2,
+                "endTokenPos": 5,
+                "endFilePos": 29
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 5,
+                  "startFilePos": 23,
+                  "endLine": 2,
+                  "endTokenPos": 5,
+                  "endFilePos": 29,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 8,
+                "startFilePos": 32,
+                "endLine": 2,
+                "endTokenPos": 8,
+                "endFilePos": 38
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 8,
+                  "startFilePos": 32,
+                  "endLine": 2,
+                  "endTokenPos": 8,
+                  "endFilePos": 38,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 11,
+                "startFilePos": 41,
+                "endLine": 2,
+                "endTokenPos": 78,
+                "endFilePos": 229
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 11,
+                  "startFilePos": 41,
+                  "endLine": 2,
+                  "endTokenPos": 78,
+                  "endFilePos": 229
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 11,
+                    "startFilePos": 41,
+                    "endLine": 2,
+                    "endTokenPos": 11,
+                    "endFilePos": 51
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 13,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 13,
+                      "endFilePos": 58
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 13,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 13,
+                        "endFilePos": 58,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 61,
+                      "endLine": 2,
+                      "endTokenPos": 16,
+                      "endFilePos": 66
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 16,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 16,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 19,
+                      "startFilePos": 69,
+                      "endLine": 2,
+                      "endTokenPos": 77,
+                      "endFilePos": 228
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 19,
+                        "startFilePos": 69,
+                        "endLine": 2,
+                        "endTokenPos": 77,
+                        "endFilePos": 228
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 19,
+                          "startFilePos": 69,
+                          "endLine": 2,
+                          "endTokenPos": 19,
+                          "endFilePos": 79
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 21,
+                            "startFilePos": 81,
+                            "endLine": 2,
+                            "endTokenPos": 21,
+                            "endFilePos": 84
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 21,
+                              "startFilePos": 81,
+                              "endLine": 2,
+                              "endTokenPos": 21,
+                              "endFilePos": 84,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 24,
+                            "startFilePos": 87,
+                            "endLine": 2,
+                            "endTokenPos": 24,
+                            "endFilePos": 89
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 24,
+                              "startFilePos": 87,
+                              "endLine": 2,
+                              "endTokenPos": 24,
+                              "endFilePos": 89,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 27,
+                            "startFilePos": 92,
+                            "endLine": 2,
+                            "endTokenPos": 76,
+                            "endFilePos": 227
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 27,
+                              "startFilePos": 92,
+                              "endLine": 2,
+                              "endTokenPos": 76,
+                              "endFilePos": 227
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 27,
+                                "startFilePos": 92,
+                                "endLine": 2,
+                                "endTokenPos": 27,
+                                "endFilePos": 102
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 29,
+                                  "startFilePos": 104,
+                                  "endLine": 2,
+                                  "endTokenPos": 29,
+                                  "endFilePos": 106
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 29,
+                                    "startFilePos": 104,
+                                    "endLine": 2,
+                                    "endTokenPos": 29,
+                                    "endFilePos": 106,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 32,
+                                  "startFilePos": 109,
+                                  "endLine": 2,
+                                  "endTokenPos": 32,
+                                  "endFilePos": 112
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 32,
+                                    "startFilePos": 109,
+                                    "endLine": 2,
+                                    "endTokenPos": 32,
+                                    "endFilePos": 112,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 35,
+                                  "startFilePos": 115,
+                                  "endLine": 2,
+                                  "endTokenPos": 75,
+                                  "endFilePos": 226
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 35,
+                                    "startFilePos": 115,
+                                    "endLine": 2,
+                                    "endTokenPos": 75,
+                                    "endFilePos": 226
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 35,
+                                      "startFilePos": 115,
+                                      "endLine": 2,
+                                      "endTokenPos": 35,
+                                      "endFilePos": 125
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 37,
+                                        "startFilePos": 127,
+                                        "endLine": 2,
+                                        "endTokenPos": 37,
+                                        "endFilePos": 129
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 37,
+                                          "startFilePos": 127,
+                                          "endLine": 2,
+                                          "endTokenPos": 37,
+                                          "endFilePos": 129,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 40,
+                                        "startFilePos": 132,
+                                        "endLine": 2,
+                                        "endTokenPos": 40,
+                                        "endFilePos": 135
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 40,
+                                          "startFilePos": 132,
+                                          "endLine": 2,
+                                          "endTokenPos": 40,
+                                          "endFilePos": 135,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 43,
+                                        "startFilePos": 138,
+                                        "endLine": 2,
+                                        "endTokenPos": 74,
+                                        "endFilePos": 225
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 43,
+                                          "startFilePos": 138,
+                                          "endLine": 2,
+                                          "endTokenPos": 74,
+                                          "endFilePos": 225
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 43,
+                                            "startFilePos": 138,
+                                            "endLine": 2,
+                                            "endTokenPos": 43,
+                                            "endFilePos": 148
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 45,
+                                              "startFilePos": 150,
+                                              "endLine": 2,
+                                              "endTokenPos": 70,
+                                              "endFilePos": 218
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 2,
+                                                "startTokenPos": 45,
+                                                "startFilePos": 150,
+                                                "endLine": 2,
+                                                "endTokenPos": 70,
+                                                "endFilePos": 218
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 2,
+                                                  "startTokenPos": 45,
+                                                  "startFilePos": 150,
+                                                  "endLine": 2,
+                                                  "endTokenPos": 45,
+                                                  "endFilePos": 161
+                                                },
+                                                "name": "array_values"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 2,
+                                                    "startTokenPos": 47,
+                                                    "startFilePos": 163,
+                                                    "endLine": 2,
+                                                    "endTokenPos": 69,
+                                                    "endFilePos": 217
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_FuncCall",
+                                                    "attributes": {
+                                                      "startLine": 2,
+                                                      "startTokenPos": 47,
+                                                      "startFilePos": 163,
+                                                      "endLine": 2,
+                                                      "endTokenPos": 69,
+                                                      "endFilePos": 217
+                                                    },
+                                                    "name": {
+                                                      "nodeType": "Name",
+                                                      "attributes": {
+                                                        "startLine": 2,
+                                                        "startTokenPos": 47,
+                                                        "startFilePos": 163,
+                                                        "endLine": 2,
+                                                        "endTokenPos": 47,
+                                                        "endFilePos": 174
+                                                      },
+                                                      "name": "array_unique"
+                                                    },
+                                                    "args": [
+                                                      {
+                                                        "nodeType": "Arg",
+                                                        "attributes": {
+                                                          "startLine": 2,
+                                                          "startTokenPos": 49,
+                                                          "startFilePos": 176,
+                                                          "endLine": 2,
+                                                          "endTokenPos": 65,
+                                                          "endFilePos": 202
+                                                        },
+                                                        "name": null,
+                                                        "value": {
+                                                          "nodeType": "Expr_FuncCall",
+                                                          "attributes": {
+                                                            "startLine": 2,
+                                                            "startTokenPos": 49,
+                                                            "startFilePos": 176,
+                                                            "endLine": 2,
+                                                            "endTokenPos": 65,
+                                                            "endFilePos": 202
+                                                          },
+                                                          "name": {
+                                                            "nodeType": "Name",
+                                                            "attributes": {
+                                                              "startLine": 2,
+                                                              "startTokenPos": 49,
+                                                              "startFilePos": 176,
+                                                              "endLine": 2,
+                                                              "endTokenPos": 49,
+                                                              "endFilePos": 186
+                                                            },
+                                                            "name": "array_merge"
+                                                          },
+                                                          "args": [
+                                                            {
+                                                              "nodeType": "Arg",
+                                                              "attributes": {
+                                                                "startLine": 2,
+                                                                "startTokenPos": 51,
+                                                                "startFilePos": 188,
+                                                                "endLine": 2,
+                                                                "endTokenPos": 56,
+                                                                "endFilePos": 193
+                                                              },
+                                                              "name": null,
+                                                              "value": {
+                                                                "nodeType": "Expr_Array",
+                                                                "attributes": {
+                                                                  "startLine": 2,
+                                                                  "startTokenPos": 51,
+                                                                  "startFilePos": 188,
+                                                                  "endLine": 2,
+                                                                  "endTokenPos": 56,
+                                                                  "endFilePos": 193,
+                                                                  "kind": 2
+                                                                },
+                                                                "items": [
+                                                                  {
+                                                                    "nodeType": "ArrayItem",
+                                                                    "attributes": {
+                                                                      "startLine": 2,
+                                                                      "startTokenPos": 52,
+                                                                      "startFilePos": 189,
+                                                                      "endLine": 2,
+                                                                      "endTokenPos": 52,
+                                                                      "endFilePos": 189
+                                                                    },
+                                                                    "key": null,
+                                                                    "value": {
+                                                                      "nodeType": "Scalar_Int",
+                                                                      "attributes": {
+                                                                        "startLine": 2,
+                                                                        "startTokenPos": 52,
+                                                                        "startFilePos": 189,
+                                                                        "endLine": 2,
+                                                                        "endTokenPos": 52,
+                                                                        "endFilePos": 189,
+                                                                        "rawValue": "1",
+                                                                        "kind": 10
+                                                                      },
+                                                                      "value": 1
+                                                                    },
+                                                                    "byRef": false,
+                                                                    "unpack": false
+                                                                  },
+                                                                  {
+                                                                    "nodeType": "ArrayItem",
+                                                                    "attributes": {
+                                                                      "startLine": 2,
+                                                                      "startTokenPos": 55,
+                                                                      "startFilePos": 192,
+                                                                      "endLine": 2,
+                                                                      "endTokenPos": 55,
+                                                                      "endFilePos": 192
+                                                                    },
+                                                                    "key": null,
+                                                                    "value": {
+                                                                      "nodeType": "Scalar_Int",
+                                                                      "attributes": {
+                                                                        "startLine": 2,
+                                                                        "startTokenPos": 55,
+                                                                        "startFilePos": 192,
+                                                                        "endLine": 2,
+                                                                        "endTokenPos": 55,
+                                                                        "endFilePos": 192,
+                                                                        "rawValue": "2",
+                                                                        "kind": 10
+                                                                      },
+                                                                      "value": 2
+                                                                    },
+                                                                    "byRef": false,
+                                                                    "unpack": false
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            },
+                                                            {
+                                                              "nodeType": "Arg",
+                                                              "attributes": {
+                                                                "startLine": 2,
+                                                                "startTokenPos": 59,
+                                                                "startFilePos": 196,
+                                                                "endLine": 2,
+                                                                "endTokenPos": 64,
+                                                                "endFilePos": 201
+                                                              },
+                                                              "name": null,
+                                                              "value": {
+                                                                "nodeType": "Expr_Array",
+                                                                "attributes": {
+                                                                  "startLine": 2,
+                                                                  "startTokenPos": 59,
+                                                                  "startFilePos": 196,
+                                                                  "endLine": 2,
+                                                                  "endTokenPos": 64,
+                                                                  "endFilePos": 201,
+                                                                  "kind": 2
+                                                                },
+                                                                "items": [
+                                                                  {
+                                                                    "nodeType": "ArrayItem",
+                                                                    "attributes": {
+                                                                      "startLine": 2,
+                                                                      "startTokenPos": 60,
+                                                                      "startFilePos": 197,
+                                                                      "endLine": 2,
+                                                                      "endTokenPos": 60,
+                                                                      "endFilePos": 197
+                                                                    },
+                                                                    "key": null,
+                                                                    "value": {
+                                                                      "nodeType": "Scalar_Int",
+                                                                      "attributes": {
+                                                                        "startLine": 2,
+                                                                        "startTokenPos": 60,
+                                                                        "startFilePos": 197,
+                                                                        "endLine": 2,
+                                                                        "endTokenPos": 60,
+                                                                        "endFilePos": 197,
+                                                                        "rawValue": "2",
+                                                                        "kind": 10
+                                                                      },
+                                                                      "value": 2
+                                                                    },
+                                                                    "byRef": false,
+                                                                    "unpack": false
+                                                                  },
+                                                                  {
+                                                                    "nodeType": "ArrayItem",
+                                                                    "attributes": {
+                                                                      "startLine": 2,
+                                                                      "startTokenPos": 63,
+                                                                      "startFilePos": 200,
+                                                                      "endLine": 2,
+                                                                      "endTokenPos": 63,
+                                                                      "endFilePos": 200
+                                                                    },
+                                                                    "key": null,
+                                                                    "value": {
+                                                                      "nodeType": "Scalar_Int",
+                                                                      "attributes": {
+                                                                        "startLine": 2,
+                                                                        "startTokenPos": 63,
+                                                                        "startFilePos": 200,
+                                                                        "endLine": 2,
+                                                                        "endTokenPos": 63,
+                                                                        "endFilePos": 200,
+                                                                        "rawValue": "3",
+                                                                        "kind": 10
+                                                                      },
+                                                                      "value": 3
+                                                                    },
+                                                                    "byRef": false,
+                                                                    "unpack": false
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            }
+                                                          ]
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "Arg",
+                                                        "attributes": {
+                                                          "startLine": 2,
+                                                          "startTokenPos": 68,
+                                                          "startFilePos": 205,
+                                                          "endLine": 2,
+                                                          "endTokenPos": 68,
+                                                          "endFilePos": 216
+                                                        },
+                                                        "name": null,
+                                                        "value": {
+                                                          "nodeType": "Expr_ConstFetch",
+                                                          "attributes": {
+                                                            "startLine": 2,
+                                                            "startTokenPos": 68,
+                                                            "startFilePos": 205,
+                                                            "endLine": 2,
+                                                            "endTokenPos": 68,
+                                                            "endFilePos": 216
+                                                          },
+                                                          "name": {
+                                                            "nodeType": "Name",
+                                                            "attributes": {
+                                                              "startLine": 2,
+                                                              "startTokenPos": 68,
+                                                              "startFilePos": 205,
+                                                              "endLine": 2,
+                                                              "endTokenPos": 68,
+                                                              "endFilePos": 216
+                                                            },
+                                                            "name": "SORT_REGULAR"
+                                                          }
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      }
+                                                    ]
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 73,
+                                              "startFilePos": 221,
+                                              "endLine": 2,
+                                              "endTokenPos": 73,
+                                              "endFilePos": 224
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 2,
+                                                "startTokenPos": 73,
+                                                "startFilePos": 221,
+                                                "endLine": 2,
+                                                "endTokenPos": 73,
+                                                "endFilePos": 224,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 82,
+            "startFilePos": 233,
+            "endLine": 2,
+            "endTokenPos": 82,
+            "endFilePos": 239
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 82,
+              "startFilePos": 233,
+              "endLine": 2,
+              "endTokenPos": 82,
+              "endFilePos": 239
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 85,
+        "startFilePos": 242,
+        "endLine": 3,
+        "endTokenPos": 161,
+        "endFilePos": 447
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 87,
+            "startFilePos": 247,
+            "endLine": 3,
+            "endTokenPos": 157,
+            "endFilePos": 437
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 87,
+              "startFilePos": 247,
+              "endLine": 3,
+              "endTokenPos": 87,
+              "endFilePos": 257
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 89,
+                "startFilePos": 259,
+                "endLine": 3,
+                "endTokenPos": 89,
+                "endFilePos": 265
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 89,
+                  "startFilePos": 259,
+                  "endLine": 3,
+                  "endTokenPos": 89,
+                  "endFilePos": 265,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 92,
+                "startFilePos": 268,
+                "endLine": 3,
+                "endTokenPos": 92,
+                "endFilePos": 274
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 92,
+                  "startFilePos": 268,
+                  "endLine": 3,
+                  "endTokenPos": 92,
+                  "endFilePos": 274,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 95,
+                "startFilePos": 277,
+                "endLine": 3,
+                "endTokenPos": 156,
+                "endFilePos": 436
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 95,
+                  "startFilePos": 277,
+                  "endLine": 3,
+                  "endTokenPos": 156,
+                  "endFilePos": 436
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 95,
+                    "startFilePos": 277,
+                    "endLine": 3,
+                    "endTokenPos": 95,
+                    "endFilePos": 287
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 97,
+                      "startFilePos": 289,
+                      "endLine": 3,
+                      "endTokenPos": 97,
+                      "endFilePos": 294
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 97,
+                        "startFilePos": 289,
+                        "endLine": 3,
+                        "endTokenPos": 97,
+                        "endFilePos": 294,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 100,
+                      "startFilePos": 297,
+                      "endLine": 3,
+                      "endTokenPos": 100,
+                      "endFilePos": 302
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 100,
+                        "startFilePos": 297,
+                        "endLine": 3,
+                        "endTokenPos": 100,
+                        "endFilePos": 302,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 103,
+                      "startFilePos": 305,
+                      "endLine": 3,
+                      "endTokenPos": 155,
+                      "endFilePos": 435
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 103,
+                        "startFilePos": 305,
+                        "endLine": 3,
+                        "endTokenPos": 155,
+                        "endFilePos": 435
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 103,
+                          "startFilePos": 305,
+                          "endLine": 3,
+                          "endTokenPos": 103,
+                          "endFilePos": 315
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 105,
+                            "startFilePos": 317,
+                            "endLine": 3,
+                            "endTokenPos": 105,
+                            "endFilePos": 320
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 105,
+                              "startFilePos": 317,
+                              "endLine": 3,
+                              "endTokenPos": 105,
+                              "endFilePos": 320,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 108,
+                            "startFilePos": 323,
+                            "endLine": 3,
+                            "endTokenPos": 108,
+                            "endFilePos": 325
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 108,
+                              "startFilePos": 323,
+                              "endLine": 3,
+                              "endTokenPos": 108,
+                              "endFilePos": 325,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 111,
+                            "startFilePos": 328,
+                            "endLine": 3,
+                            "endTokenPos": 154,
+                            "endFilePos": 434
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 111,
+                              "startFilePos": 328,
+                              "endLine": 3,
+                              "endTokenPos": 154,
+                              "endFilePos": 434
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 3,
+                                "startTokenPos": 111,
+                                "startFilePos": 328,
+                                "endLine": 3,
+                                "endTokenPos": 111,
+                                "endFilePos": 338
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 113,
+                                  "startFilePos": 340,
+                                  "endLine": 3,
+                                  "endTokenPos": 113,
+                                  "endFilePos": 342
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 113,
+                                    "startFilePos": 340,
+                                    "endLine": 3,
+                                    "endTokenPos": 113,
+                                    "endFilePos": 342,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 116,
+                                  "startFilePos": 345,
+                                  "endLine": 3,
+                                  "endTokenPos": 116,
+                                  "endFilePos": 348
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 116,
+                                    "startFilePos": 345,
+                                    "endLine": 3,
+                                    "endTokenPos": 116,
+                                    "endFilePos": 348,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 119,
+                                  "startFilePos": 351,
+                                  "endLine": 3,
+                                  "endTokenPos": 153,
+                                  "endFilePos": 433
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 119,
+                                    "startFilePos": 351,
+                                    "endLine": 3,
+                                    "endTokenPos": 153,
+                                    "endFilePos": 433
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 3,
+                                      "startTokenPos": 119,
+                                      "startFilePos": 351,
+                                      "endLine": 3,
+                                      "endTokenPos": 119,
+                                      "endFilePos": 361
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 121,
+                                        "startFilePos": 363,
+                                        "endLine": 3,
+                                        "endTokenPos": 121,
+                                        "endFilePos": 365
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 121,
+                                          "startFilePos": 363,
+                                          "endLine": 3,
+                                          "endTokenPos": 121,
+                                          "endFilePos": 365,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 124,
+                                        "startFilePos": 368,
+                                        "endLine": 3,
+                                        "endTokenPos": 124,
+                                        "endFilePos": 371
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 124,
+                                          "startFilePos": 368,
+                                          "endLine": 3,
+                                          "endTokenPos": 124,
+                                          "endFilePos": 371,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 127,
+                                        "startFilePos": 374,
+                                        "endLine": 3,
+                                        "endTokenPos": 152,
+                                        "endFilePos": 432
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 127,
+                                          "startFilePos": 374,
+                                          "endLine": 3,
+                                          "endTokenPos": 152,
+                                          "endFilePos": 432
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 3,
+                                            "startTokenPos": 127,
+                                            "startFilePos": 374,
+                                            "endLine": 3,
+                                            "endTokenPos": 127,
+                                            "endFilePos": 384
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 129,
+                                              "startFilePos": 386,
+                                              "endLine": 3,
+                                              "endTokenPos": 148,
+                                              "endFilePos": 425
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 129,
+                                                "startFilePos": 386,
+                                                "endLine": 3,
+                                                "endTokenPos": 148,
+                                                "endFilePos": 425
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 3,
+                                                  "startTokenPos": 129,
+                                                  "startFilePos": 386,
+                                                  "endLine": 3,
+                                                  "endTokenPos": 129,
+                                                  "endFilePos": 397
+                                                },
+                                                "name": "array_values"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 131,
+                                                    "startFilePos": 399,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 147,
+                                                    "endFilePos": 424
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_FuncCall",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 131,
+                                                      "startFilePos": 399,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 147,
+                                                      "endFilePos": 424
+                                                    },
+                                                    "name": {
+                                                      "nodeType": "Name",
+                                                      "attributes": {
+                                                        "startLine": 3,
+                                                        "startTokenPos": 131,
+                                                        "startFilePos": 399,
+                                                        "endLine": 3,
+                                                        "endTokenPos": 131,
+                                                        "endFilePos": 408
+                                                      },
+                                                      "name": "array_diff"
+                                                    },
+                                                    "args": [
+                                                      {
+                                                        "nodeType": "Arg",
+                                                        "attributes": {
+                                                          "startLine": 3,
+                                                          "startTokenPos": 133,
+                                                          "startFilePos": 410,
+                                                          "endLine": 3,
+                                                          "endTokenPos": 141,
+                                                          "endFilePos": 418
+                                                        },
+                                                        "name": null,
+                                                        "value": {
+                                                          "nodeType": "Expr_Array",
+                                                          "attributes": {
+                                                            "startLine": 3,
+                                                            "startTokenPos": 133,
+                                                            "startFilePos": 410,
+                                                            "endLine": 3,
+                                                            "endTokenPos": 141,
+                                                            "endFilePos": 418,
+                                                            "kind": 2
+                                                          },
+                                                          "items": [
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 3,
+                                                                "startTokenPos": 134,
+                                                                "startFilePos": 411,
+                                                                "endLine": 3,
+                                                                "endTokenPos": 134,
+                                                                "endFilePos": 411
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 3,
+                                                                  "startTokenPos": 134,
+                                                                  "startFilePos": 411,
+                                                                  "endLine": 3,
+                                                                  "endTokenPos": 134,
+                                                                  "endFilePos": 411,
+                                                                  "rawValue": "1",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 1
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            },
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 3,
+                                                                "startTokenPos": 137,
+                                                                "startFilePos": 414,
+                                                                "endLine": 3,
+                                                                "endTokenPos": 137,
+                                                                "endFilePos": 414
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 3,
+                                                                  "startTokenPos": 137,
+                                                                  "startFilePos": 414,
+                                                                  "endLine": 3,
+                                                                  "endTokenPos": 137,
+                                                                  "endFilePos": 414,
+                                                                  "rawValue": "2",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 2
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            },
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 3,
+                                                                "startTokenPos": 140,
+                                                                "startFilePos": 417,
+                                                                "endLine": 3,
+                                                                "endTokenPos": 140,
+                                                                "endFilePos": 417
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 3,
+                                                                  "startTokenPos": 140,
+                                                                  "startFilePos": 417,
+                                                                  "endLine": 3,
+                                                                  "endTokenPos": 140,
+                                                                  "endFilePos": 417,
+                                                                  "rawValue": "3",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 3
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            }
+                                                          ]
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "Arg",
+                                                        "attributes": {
+                                                          "startLine": 3,
+                                                          "startTokenPos": 144,
+                                                          "startFilePos": 421,
+                                                          "endLine": 3,
+                                                          "endTokenPos": 146,
+                                                          "endFilePos": 423
+                                                        },
+                                                        "name": null,
+                                                        "value": {
+                                                          "nodeType": "Expr_Array",
+                                                          "attributes": {
+                                                            "startLine": 3,
+                                                            "startTokenPos": 144,
+                                                            "startFilePos": 421,
+                                                            "endLine": 3,
+                                                            "endTokenPos": 146,
+                                                            "endFilePos": 423,
+                                                            "kind": 2
+                                                          },
+                                                          "items": [
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 3,
+                                                                "startTokenPos": 145,
+                                                                "startFilePos": 422,
+                                                                "endLine": 3,
+                                                                "endTokenPos": 145,
+                                                                "endFilePos": 422
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 3,
+                                                                  "startTokenPos": 145,
+                                                                  "startFilePos": 422,
+                                                                  "endLine": 3,
+                                                                  "endTokenPos": 145,
+                                                                  "endFilePos": 422,
+                                                                  "rawValue": "2",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 2
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            }
+                                                          ]
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      }
+                                                    ]
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 151,
+                                              "startFilePos": 428,
+                                              "endLine": 3,
+                                              "endTokenPos": 151,
+                                              "endFilePos": 431
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 151,
+                                                "startFilePos": 428,
+                                                "endLine": 3,
+                                                "endTokenPos": 151,
+                                                "endFilePos": 431,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 160,
+            "startFilePos": 440,
+            "endLine": 3,
+            "endTokenPos": 160,
+            "endFilePos": 446
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 160,
+              "startFilePos": 440,
+              "endLine": 3,
+              "endTokenPos": 160,
+              "endFilePos": 446
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 163,
+        "startFilePos": 449,
+        "endLine": 4,
+        "endTokenPos": 242,
+        "endFilePos": 662
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 165,
+            "startFilePos": 454,
+            "endLine": 4,
+            "endTokenPos": 238,
+            "endFilePos": 652
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 165,
+              "startFilePos": 454,
+              "endLine": 4,
+              "endTokenPos": 165,
+              "endFilePos": 464
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 167,
+                "startFilePos": 466,
+                "endLine": 4,
+                "endTokenPos": 167,
+                "endFilePos": 472
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 167,
+                  "startFilePos": 466,
+                  "endLine": 4,
+                  "endTokenPos": 167,
+                  "endFilePos": 472,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 170,
+                "startFilePos": 475,
+                "endLine": 4,
+                "endTokenPos": 170,
+                "endFilePos": 481
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 170,
+                  "startFilePos": 475,
+                  "endLine": 4,
+                  "endTokenPos": 170,
+                  "endFilePos": 481,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 173,
+                "startFilePos": 484,
+                "endLine": 4,
+                "endTokenPos": 237,
+                "endFilePos": 651
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 173,
+                  "startFilePos": 484,
+                  "endLine": 4,
+                  "endTokenPos": 237,
+                  "endFilePos": 651
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 173,
+                    "startFilePos": 484,
+                    "endLine": 4,
+                    "endTokenPos": 173,
+                    "endFilePos": 494
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 175,
+                      "startFilePos": 496,
+                      "endLine": 4,
+                      "endTokenPos": 175,
+                      "endFilePos": 501
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 175,
+                        "startFilePos": 496,
+                        "endLine": 4,
+                        "endTokenPos": 175,
+                        "endFilePos": 501,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 178,
+                      "startFilePos": 504,
+                      "endLine": 4,
+                      "endTokenPos": 178,
+                      "endFilePos": 509
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 178,
+                        "startFilePos": 504,
+                        "endLine": 4,
+                        "endTokenPos": 178,
+                        "endFilePos": 509,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 181,
+                      "startFilePos": 512,
+                      "endLine": 4,
+                      "endTokenPos": 236,
+                      "endFilePos": 650
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 181,
+                        "startFilePos": 512,
+                        "endLine": 4,
+                        "endTokenPos": 236,
+                        "endFilePos": 650
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 181,
+                          "startFilePos": 512,
+                          "endLine": 4,
+                          "endTokenPos": 181,
+                          "endFilePos": 522
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 183,
+                            "startFilePos": 524,
+                            "endLine": 4,
+                            "endTokenPos": 183,
+                            "endFilePos": 527
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 183,
+                              "startFilePos": 524,
+                              "endLine": 4,
+                              "endTokenPos": 183,
+                              "endFilePos": 527,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 186,
+                            "startFilePos": 530,
+                            "endLine": 4,
+                            "endTokenPos": 186,
+                            "endFilePos": 532
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 186,
+                              "startFilePos": 530,
+                              "endLine": 4,
+                              "endTokenPos": 186,
+                              "endFilePos": 532,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 189,
+                            "startFilePos": 535,
+                            "endLine": 4,
+                            "endTokenPos": 235,
+                            "endFilePos": 649
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 189,
+                              "startFilePos": 535,
+                              "endLine": 4,
+                              "endTokenPos": 235,
+                              "endFilePos": 649
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 4,
+                                "startTokenPos": 189,
+                                "startFilePos": 535,
+                                "endLine": 4,
+                                "endTokenPos": 189,
+                                "endFilePos": 545
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 4,
+                                  "startTokenPos": 191,
+                                  "startFilePos": 547,
+                                  "endLine": 4,
+                                  "endTokenPos": 191,
+                                  "endFilePos": 549
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 4,
+                                    "startTokenPos": 191,
+                                    "startFilePos": 547,
+                                    "endLine": 4,
+                                    "endTokenPos": 191,
+                                    "endFilePos": 549,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 4,
+                                  "startTokenPos": 194,
+                                  "startFilePos": 552,
+                                  "endLine": 4,
+                                  "endTokenPos": 194,
+                                  "endFilePos": 555
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 4,
+                                    "startTokenPos": 194,
+                                    "startFilePos": 552,
+                                    "endLine": 4,
+                                    "endTokenPos": 194,
+                                    "endFilePos": 555,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 4,
+                                  "startTokenPos": 197,
+                                  "startFilePos": 558,
+                                  "endLine": 4,
+                                  "endTokenPos": 234,
+                                  "endFilePos": 648
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 4,
+                                    "startTokenPos": 197,
+                                    "startFilePos": 558,
+                                    "endLine": 4,
+                                    "endTokenPos": 234,
+                                    "endFilePos": 648
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 4,
+                                      "startTokenPos": 197,
+                                      "startFilePos": 558,
+                                      "endLine": 4,
+                                      "endTokenPos": 197,
+                                      "endFilePos": 568
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 4,
+                                        "startTokenPos": 199,
+                                        "startFilePos": 570,
+                                        "endLine": 4,
+                                        "endTokenPos": 199,
+                                        "endFilePos": 572
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 4,
+                                          "startTokenPos": 199,
+                                          "startFilePos": 570,
+                                          "endLine": 4,
+                                          "endTokenPos": 199,
+                                          "endFilePos": 572,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 4,
+                                        "startTokenPos": 202,
+                                        "startFilePos": 575,
+                                        "endLine": 4,
+                                        "endTokenPos": 202,
+                                        "endFilePos": 578
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 4,
+                                          "startTokenPos": 202,
+                                          "startFilePos": 575,
+                                          "endLine": 4,
+                                          "endTokenPos": 202,
+                                          "endFilePos": 578,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 4,
+                                        "startTokenPos": 205,
+                                        "startFilePos": 581,
+                                        "endLine": 4,
+                                        "endTokenPos": 233,
+                                        "endFilePos": 647
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 4,
+                                          "startTokenPos": 205,
+                                          "startFilePos": 581,
+                                          "endLine": 4,
+                                          "endTokenPos": 233,
+                                          "endFilePos": 647
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 4,
+                                            "startTokenPos": 205,
+                                            "startFilePos": 581,
+                                            "endLine": 4,
+                                            "endTokenPos": 205,
+                                            "endFilePos": 591
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 4,
+                                              "startTokenPos": 207,
+                                              "startFilePos": 593,
+                                              "endLine": 4,
+                                              "endTokenPos": 229,
+                                              "endFilePos": 640
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 4,
+                                                "startTokenPos": 207,
+                                                "startFilePos": 593,
+                                                "endLine": 4,
+                                                "endTokenPos": 229,
+                                                "endFilePos": 640
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 4,
+                                                  "startTokenPos": 207,
+                                                  "startFilePos": 593,
+                                                  "endLine": 4,
+                                                  "endTokenPos": 207,
+                                                  "endFilePos": 604
+                                                },
+                                                "name": "array_values"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 4,
+                                                    "startTokenPos": 209,
+                                                    "startFilePos": 606,
+                                                    "endLine": 4,
+                                                    "endTokenPos": 228,
+                                                    "endFilePos": 639
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_FuncCall",
+                                                    "attributes": {
+                                                      "startLine": 4,
+                                                      "startTokenPos": 209,
+                                                      "startFilePos": 606,
+                                                      "endLine": 4,
+                                                      "endTokenPos": 228,
+                                                      "endFilePos": 639
+                                                    },
+                                                    "name": {
+                                                      "nodeType": "Name",
+                                                      "attributes": {
+                                                        "startLine": 4,
+                                                        "startTokenPos": 209,
+                                                        "startFilePos": 606,
+                                                        "endLine": 4,
+                                                        "endTokenPos": 209,
+                                                        "endFilePos": 620
+                                                      },
+                                                      "name": "array_intersect"
+                                                    },
+                                                    "args": [
+                                                      {
+                                                        "nodeType": "Arg",
+                                                        "attributes": {
+                                                          "startLine": 4,
+                                                          "startTokenPos": 211,
+                                                          "startFilePos": 622,
+                                                          "endLine": 4,
+                                                          "endTokenPos": 219,
+                                                          "endFilePos": 630
+                                                        },
+                                                        "name": null,
+                                                        "value": {
+                                                          "nodeType": "Expr_Array",
+                                                          "attributes": {
+                                                            "startLine": 4,
+                                                            "startTokenPos": 211,
+                                                            "startFilePos": 622,
+                                                            "endLine": 4,
+                                                            "endTokenPos": 219,
+                                                            "endFilePos": 630,
+                                                            "kind": 2
+                                                          },
+                                                          "items": [
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 4,
+                                                                "startTokenPos": 212,
+                                                                "startFilePos": 623,
+                                                                "endLine": 4,
+                                                                "endTokenPos": 212,
+                                                                "endFilePos": 623
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 4,
+                                                                  "startTokenPos": 212,
+                                                                  "startFilePos": 623,
+                                                                  "endLine": 4,
+                                                                  "endTokenPos": 212,
+                                                                  "endFilePos": 623,
+                                                                  "rawValue": "1",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 1
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            },
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 4,
+                                                                "startTokenPos": 215,
+                                                                "startFilePos": 626,
+                                                                "endLine": 4,
+                                                                "endTokenPos": 215,
+                                                                "endFilePos": 626
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 4,
+                                                                  "startTokenPos": 215,
+                                                                  "startFilePos": 626,
+                                                                  "endLine": 4,
+                                                                  "endTokenPos": 215,
+                                                                  "endFilePos": 626,
+                                                                  "rawValue": "2",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 2
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            },
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 4,
+                                                                "startTokenPos": 218,
+                                                                "startFilePos": 629,
+                                                                "endLine": 4,
+                                                                "endTokenPos": 218,
+                                                                "endFilePos": 629
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 4,
+                                                                  "startTokenPos": 218,
+                                                                  "startFilePos": 629,
+                                                                  "endLine": 4,
+                                                                  "endTokenPos": 218,
+                                                                  "endFilePos": 629,
+                                                                  "rawValue": "3",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 3
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            }
+                                                          ]
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "Arg",
+                                                        "attributes": {
+                                                          "startLine": 4,
+                                                          "startTokenPos": 222,
+                                                          "startFilePos": 633,
+                                                          "endLine": 4,
+                                                          "endTokenPos": 227,
+                                                          "endFilePos": 638
+                                                        },
+                                                        "name": null,
+                                                        "value": {
+                                                          "nodeType": "Expr_Array",
+                                                          "attributes": {
+                                                            "startLine": 4,
+                                                            "startTokenPos": 222,
+                                                            "startFilePos": 633,
+                                                            "endLine": 4,
+                                                            "endTokenPos": 227,
+                                                            "endFilePos": 638,
+                                                            "kind": 2
+                                                          },
+                                                          "items": [
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 4,
+                                                                "startTokenPos": 223,
+                                                                "startFilePos": 634,
+                                                                "endLine": 4,
+                                                                "endTokenPos": 223,
+                                                                "endFilePos": 634
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 4,
+                                                                  "startTokenPos": 223,
+                                                                  "startFilePos": 634,
+                                                                  "endLine": 4,
+                                                                  "endTokenPos": 223,
+                                                                  "endFilePos": 634,
+                                                                  "rawValue": "2",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 2
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            },
+                                                            {
+                                                              "nodeType": "ArrayItem",
+                                                              "attributes": {
+                                                                "startLine": 4,
+                                                                "startTokenPos": 226,
+                                                                "startFilePos": 637,
+                                                                "endLine": 4,
+                                                                "endTokenPos": 226,
+                                                                "endFilePos": 637
+                                                              },
+                                                              "key": null,
+                                                              "value": {
+                                                                "nodeType": "Scalar_Int",
+                                                                "attributes": {
+                                                                  "startLine": 4,
+                                                                  "startTokenPos": 226,
+                                                                  "startFilePos": 637,
+                                                                  "endLine": 4,
+                                                                  "endTokenPos": 226,
+                                                                  "endFilePos": 637,
+                                                                  "rawValue": "4",
+                                                                  "kind": 10
+                                                                },
+                                                                "value": 4
+                                                              },
+                                                              "byRef": false,
+                                                              "unpack": false
+                                                            }
+                                                          ]
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      }
+                                                    ]
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 4,
+                                              "startTokenPos": 232,
+                                              "startFilePos": 643,
+                                              "endLine": 4,
+                                              "endTokenPos": 232,
+                                              "endFilePos": 646
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 4,
+                                                "startTokenPos": 232,
+                                                "startFilePos": 643,
+                                                "endLine": 4,
+                                                "endTokenPos": 232,
+                                                "endFilePos": 646,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 241,
+            "startFilePos": 655,
+            "endLine": 4,
+            "endTokenPos": 241,
+            "endFilePos": 661
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 241,
+              "startFilePos": 655,
+              "endLine": 4,
+              "endTokenPos": 241,
+              "endFilePos": 661
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 244,
+        "startFilePos": 664,
+        "endLine": 5,
+        "endTokenPos": 326,
+        "endFilePos": 817
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 247,
+            "startFilePos": 670,
+            "endLine": 5,
+            "endTokenPos": 321,
+            "endFilePos": 806
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 247,
+              "startFilePos": 670,
+              "endLine": 5,
+              "endTokenPos": 269,
+              "endFilePos": 713
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 247,
+                "startFilePos": 670,
+                "endLine": 5,
+                "endTokenPos": 247,
+                "endFilePos": 677
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 249,
+                  "startFilePos": 679,
+                  "endLine": 5,
+                  "endTokenPos": 268,
+                  "endFilePos": 712
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 249,
+                    "startFilePos": 679,
+                    "endLine": 5,
+                    "endTokenPos": 268,
+                    "endFilePos": 712
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 249,
+                      "startFilePos": 679,
+                      "endLine": 5,
+                      "endTokenPos": 249,
+                      "endFilePos": 683
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 251,
+                        "startFilePos": 685,
+                        "endLine": 5,
+                        "endTokenPos": 267,
+                        "endFilePos": 711
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 251,
+                          "startFilePos": 685,
+                          "endLine": 5,
+                          "endTokenPos": 267,
+                          "endFilePos": 711
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 251,
+                            "startFilePos": 685,
+                            "endLine": 5,
+                            "endTokenPos": 251,
+                            "endFilePos": 695
+                          },
+                          "name": "array_merge"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 253,
+                              "startFilePos": 697,
+                              "endLine": 5,
+                              "endTokenPos": 258,
+                              "endFilePos": 702
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 253,
+                                "startFilePos": 697,
+                                "endLine": 5,
+                                "endTokenPos": 258,
+                                "endFilePos": 702,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 254,
+                                    "startFilePos": 698,
+                                    "endLine": 5,
+                                    "endTokenPos": 254,
+                                    "endFilePos": 698
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 254,
+                                      "startFilePos": 698,
+                                      "endLine": 5,
+                                      "endTokenPos": 254,
+                                      "endFilePos": 698,
+                                      "rawValue": "1",
+                                      "kind": 10
+                                    },
+                                    "value": 1
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 257,
+                                    "startFilePos": 701,
+                                    "endLine": 5,
+                                    "endTokenPos": 257,
+                                    "endFilePos": 701
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 257,
+                                      "startFilePos": 701,
+                                      "endLine": 5,
+                                      "endTokenPos": 257,
+                                      "endFilePos": 701,
+                                      "rawValue": "2",
+                                      "kind": 10
+                                    },
+                                    "value": 2
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 261,
+                              "startFilePos": 705,
+                              "endLine": 5,
+                              "endTokenPos": 266,
+                              "endFilePos": 710
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 261,
+                                "startFilePos": 705,
+                                "endLine": 5,
+                                "endTokenPos": 266,
+                                "endFilePos": 710,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 262,
+                                    "startFilePos": 706,
+                                    "endLine": 5,
+                                    "endTokenPos": 262,
+                                    "endFilePos": 706
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 262,
+                                      "startFilePos": 706,
+                                      "endLine": 5,
+                                      "endTokenPos": 262,
+                                      "endFilePos": 706,
+                                      "rawValue": "2",
+                                      "kind": 10
+                                    },
+                                    "value": 2
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 265,
+                                    "startFilePos": 709,
+                                    "endLine": 5,
+                                    "endTokenPos": 265,
+                                    "endFilePos": 709
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 265,
+                                      "startFilePos": 709,
+                                      "endLine": 5,
+                                      "endTokenPos": 265,
+                                      "endFilePos": 709,
+                                      "rawValue": "3",
+                                      "kind": 10
+                                    },
+                                    "value": 3
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 273,
+              "startFilePos": 717,
+              "endLine": 5,
+              "endTokenPos": 298,
+              "endFilePos": 769
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 273,
+                "startFilePos": 717,
+                "endLine": 5,
+                "endTokenPos": 273,
+                "endFilePos": 727
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 275,
+                  "startFilePos": 729,
+                  "endLine": 5,
+                  "endTokenPos": 294,
+                  "endFilePos": 762
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 275,
+                    "startFilePos": 729,
+                    "endLine": 5,
+                    "endTokenPos": 294,
+                    "endFilePos": 762
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 275,
+                      "startFilePos": 729,
+                      "endLine": 5,
+                      "endTokenPos": 275,
+                      "endFilePos": 733
+                    },
+                    "name": "count"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 277,
+                        "startFilePos": 735,
+                        "endLine": 5,
+                        "endTokenPos": 293,
+                        "endFilePos": 761
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 277,
+                          "startFilePos": 735,
+                          "endLine": 5,
+                          "endTokenPos": 293,
+                          "endFilePos": 761
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 277,
+                            "startFilePos": 735,
+                            "endLine": 5,
+                            "endTokenPos": 277,
+                            "endFilePos": 745
+                          },
+                          "name": "array_merge"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 279,
+                              "startFilePos": 747,
+                              "endLine": 5,
+                              "endTokenPos": 284,
+                              "endFilePos": 752
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 279,
+                                "startFilePos": 747,
+                                "endLine": 5,
+                                "endTokenPos": 284,
+                                "endFilePos": 752,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 280,
+                                    "startFilePos": 748,
+                                    "endLine": 5,
+                                    "endTokenPos": 280,
+                                    "endFilePos": 748
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 280,
+                                      "startFilePos": 748,
+                                      "endLine": 5,
+                                      "endTokenPos": 280,
+                                      "endFilePos": 748,
+                                      "rawValue": "1",
+                                      "kind": 10
+                                    },
+                                    "value": 1
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 283,
+                                    "startFilePos": 751,
+                                    "endLine": 5,
+                                    "endTokenPos": 283,
+                                    "endFilePos": 751
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 283,
+                                      "startFilePos": 751,
+                                      "endLine": 5,
+                                      "endTokenPos": 283,
+                                      "endFilePos": 751,
+                                      "rawValue": "2",
+                                      "kind": 10
+                                    },
+                                    "value": 2
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 287,
+                              "startFilePos": 755,
+                              "endLine": 5,
+                              "endTokenPos": 292,
+                              "endFilePos": 760
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Array",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 287,
+                                "startFilePos": 755,
+                                "endLine": 5,
+                                "endTokenPos": 292,
+                                "endFilePos": 760,
+                                "kind": 2
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 288,
+                                    "startFilePos": 756,
+                                    "endLine": 5,
+                                    "endTokenPos": 288,
+                                    "endFilePos": 756
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 288,
+                                      "startFilePos": 756,
+                                      "endLine": 5,
+                                      "endTokenPos": 288,
+                                      "endFilePos": 756,
+                                      "rawValue": "2",
+                                      "kind": 10
+                                    },
+                                    "value": 2
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 5,
+                                    "startTokenPos": 291,
+                                    "startFilePos": 759,
+                                    "endLine": 5,
+                                    "endTokenPos": 291,
+                                    "endFilePos": 759
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 5,
+                                      "startTokenPos": 291,
+                                      "startFilePos": 759,
+                                      "endLine": 5,
+                                      "endTokenPos": 291,
+                                      "endFilePos": 759,
+                                      "rawValue": "3",
+                                      "kind": 10
+                                    },
+                                    "value": 3
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 297,
+                  "startFilePos": 765,
+                  "endLine": 5,
+                  "endTokenPos": 297,
+                  "endFilePos": 768
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 297,
+                    "startFilePos": 765,
+                    "endLine": 5,
+                    "endTokenPos": 297,
+                    "endFilePos": 768,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 302,
+              "startFilePos": 773,
+              "endLine": 5,
+              "endTokenPos": 321,
+              "endFilePos": 806
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 302,
+                "startFilePos": 773,
+                "endLine": 5,
+                "endTokenPos": 302,
+                "endFilePos": 777
+              },
+              "name": "count"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 304,
+                  "startFilePos": 779,
+                  "endLine": 5,
+                  "endTokenPos": 320,
+                  "endFilePos": 805
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 304,
+                    "startFilePos": 779,
+                    "endLine": 5,
+                    "endTokenPos": 320,
+                    "endFilePos": 805
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 304,
+                      "startFilePos": 779,
+                      "endLine": 5,
+                      "endTokenPos": 304,
+                      "endFilePos": 789
+                    },
+                    "name": "array_merge"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 306,
+                        "startFilePos": 791,
+                        "endLine": 5,
+                        "endTokenPos": 311,
+                        "endFilePos": 796
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 306,
+                          "startFilePos": 791,
+                          "endLine": 5,
+                          "endTokenPos": 311,
+                          "endFilePos": 796,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 307,
+                              "startFilePos": 792,
+                              "endLine": 5,
+                              "endTokenPos": 307,
+                              "endFilePos": 792
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 307,
+                                "startFilePos": 792,
+                                "endLine": 5,
+                                "endTokenPos": 307,
+                                "endFilePos": 792,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 310,
+                              "startFilePos": 795,
+                              "endLine": 5,
+                              "endTokenPos": 310,
+                              "endFilePos": 795
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 310,
+                                "startFilePos": 795,
+                                "endLine": 5,
+                                "endTokenPos": 310,
+                                "endFilePos": 795,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 314,
+                        "startFilePos": 799,
+                        "endLine": 5,
+                        "endTokenPos": 319,
+                        "endFilePos": 804
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 314,
+                          "startFilePos": 799,
+                          "endLine": 5,
+                          "endTokenPos": 319,
+                          "endFilePos": 804,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 315,
+                              "startFilePos": 800,
+                              "endLine": 5,
+                              "endTokenPos": 315,
+                              "endFilePos": 800
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 315,
+                                "startFilePos": 800,
+                                "endLine": 5,
+                                "endTokenPos": 315,
+                                "endFilePos": 800,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 318,
+                              "startFilePos": 803,
+                              "endLine": 5,
+                              "endTokenPos": 318,
+                              "endFilePos": 803
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 5,
+                                "startTokenPos": 318,
+                                "startFilePos": 803,
+                                "endLine": 5,
+                                "endTokenPos": 318,
+                                "endFilePos": 803,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 325,
+            "startFilePos": 810,
+            "endLine": 5,
+            "endTokenPos": 325,
+            "endFilePos": 816
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 325,
+              "startFilePos": 810,
+              "endLine": 5,
+              "endTokenPos": 325,
+              "endFilePos": 816
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/load_jsonl.php.json
+++ b/tests/json-ast/x/php/load_jsonl.php.json
@@ -1,0 +1,1491 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 91,
+        "endFilePos": 277
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 90,
+          "endFilePos": 276
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 90,
+            "endFilePos": 276
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 6,
+              "startFilePos": 17,
+              "endLine": 2,
+              "endTokenPos": 87,
+              "endFilePos": 273
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 30,
+                  "endLine": 2,
+                  "endTokenPos": 18,
+                  "endFilePos": 40
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 12,
+                    "startFilePos": 30,
+                    "endLine": 2,
+                    "endTokenPos": 17,
+                    "endFilePos": 39
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 12,
+                      "startFilePos": 30,
+                      "endLine": 2,
+                      "endTokenPos": 12,
+                      "endFilePos": 34
+                    },
+                    "name": "rows"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 38,
+                      "endLine": 2,
+                      "endTokenPos": 17,
+                      "endFilePos": 39,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 20,
+                  "startFilePos": 42,
+                  "endLine": 2,
+                  "endTokenPos": 80,
+                  "endFilePos": 257
+                },
+                "expr": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 23,
+                    "startFilePos": 51,
+                    "endLine": 2,
+                    "endTokenPos": 33,
+                    "endFilePos": 158
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 51,
+                      "endLine": 2,
+                      "endTokenPos": 23,
+                      "endFilePos": 54
+                    },
+                    "name": "file"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 56,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 110
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 25,
+                          "startFilePos": 56,
+                          "endLine": 2,
+                          "endTokenPos": 25,
+                          "endFilePos": 110,
+                          "kind": 2,
+                          "rawValue": "\"\/workspace\/mochi\/tests\/interpreter\/valid\/people.jsonl\""
+                        },
+                        "value": "\/workspace\/mochi\/tests\/interpreter\/valid\/people.jsonl"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 28,
+                        "startFilePos": 113,
+                        "endLine": 2,
+                        "endTokenPos": 32,
+                        "endFilePos": 157
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_BitwiseOr",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 28,
+                          "startFilePos": 113,
+                          "endLine": 2,
+                          "endTokenPos": 32,
+                          "endFilePos": 157
+                        },
+                        "left": {
+                          "nodeType": "Expr_ConstFetch",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 28,
+                            "startFilePos": 113,
+                            "endLine": 2,
+                            "endTokenPos": 28,
+                            "endFilePos": 133
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 28,
+                              "startFilePos": 113,
+                              "endLine": 2,
+                              "endTokenPos": 28,
+                              "endFilePos": 133
+                            },
+                            "name": "FILE_IGNORE_NEW_LINES"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Expr_ConstFetch",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 32,
+                            "startFilePos": 137,
+                            "endLine": 2,
+                            "endTokenPos": 32,
+                            "endFilePos": 157
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 32,
+                              "startFilePos": 137,
+                              "endLine": 2,
+                              "endTokenPos": 32,
+                              "endFilePos": 157
+                            },
+                            "name": "FILE_SKIP_EMPTY_LINES"
+                          }
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 37,
+                    "startFilePos": 163,
+                    "endLine": 2,
+                    "endTokenPos": 37,
+                    "endFilePos": 167
+                  },
+                  "name": "line"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 42,
+                      "startFilePos": 172,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 191
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 42,
+                        "startFilePos": 172,
+                        "endLine": 2,
+                        "endTokenPos": 49,
+                        "endFilePos": 190
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 42,
+                          "startFilePos": 172,
+                          "endLine": 2,
+                          "endTokenPos": 42,
+                          "endFilePos": 176
+                        },
+                        "name": "line"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 46,
+                          "startFilePos": 180,
+                          "endLine": 2,
+                          "endTokenPos": 49,
+                          "endFilePos": 190
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 46,
+                            "startFilePos": 180,
+                            "endLine": 2,
+                            "endTokenPos": 46,
+                            "endFilePos": 183
+                          },
+                          "name": "trim"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 48,
+                              "startFilePos": 185,
+                              "endLine": 2,
+                              "endTokenPos": 48,
+                              "endFilePos": 189
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 48,
+                                "startFilePos": 185,
+                                "endLine": 2,
+                                "endTokenPos": 48,
+                                "endFilePos": 189
+                              },
+                              "name": "line"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 52,
+                      "startFilePos": 193,
+                      "endLine": 2,
+                      "endTokenPos": 63,
+                      "endFilePos": 219
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BinaryOp_Identical",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 197,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 208
+                      },
+                      "left": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 55,
+                          "startFilePos": 197,
+                          "endLine": 2,
+                          "endTokenPos": 55,
+                          "endFilePos": 201
+                        },
+                        "name": "line"
+                      },
+                      "right": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 59,
+                          "startFilePos": 207,
+                          "endLine": 2,
+                          "endTokenPos": 59,
+                          "endFilePos": 208,
+                          "kind": 1,
+                          "rawValue": "''"
+                        },
+                        "value": ""
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Continue",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 62,
+                          "startFilePos": 211,
+                          "endLine": 2,
+                          "endTokenPos": 63,
+                          "endFilePos": 219
+                        },
+                        "num": null
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  },
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 65,
+                      "startFilePos": 221,
+                      "endLine": 2,
+                      "endTokenPos": 78,
+                      "endFilePos": 255
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 65,
+                        "startFilePos": 221,
+                        "endLine": 2,
+                        "endTokenPos": 77,
+                        "endFilePos": 254
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 65,
+                          "startFilePos": 221,
+                          "endLine": 2,
+                          "endTokenPos": 67,
+                          "endFilePos": 227
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 65,
+                            "startFilePos": 221,
+                            "endLine": 2,
+                            "endTokenPos": 65,
+                            "endFilePos": 225
+                          },
+                          "name": "rows"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 71,
+                          "startFilePos": 231,
+                          "endLine": 2,
+                          "endTokenPos": 77,
+                          "endFilePos": 254
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 71,
+                            "startFilePos": 231,
+                            "endLine": 2,
+                            "endTokenPos": 71,
+                            "endFilePos": 241
+                          },
+                          "name": "json_decode"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 73,
+                              "startFilePos": 243,
+                              "endLine": 2,
+                              "endTokenPos": 73,
+                              "endFilePos": 247
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 73,
+                                "startFilePos": 243,
+                                "endLine": 2,
+                                "endTokenPos": 73,
+                                "endFilePos": 247
+                              },
+                              "name": "line"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 76,
+                              "startFilePos": 250,
+                              "endLine": 2,
+                              "endTokenPos": 76,
+                              "endFilePos": 253
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_ConstFetch",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 76,
+                                "startFilePos": 250,
+                                "endLine": 2,
+                                "endTokenPos": 76,
+                                "endFilePos": 253
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 76,
+                                  "startFilePos": 250,
+                                  "endLine": 2,
+                                  "endTokenPos": 76,
+                                  "endFilePos": 253
+                                },
+                                "name": "true"
+                              }
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 82,
+                  "startFilePos": 259,
+                  "endLine": 2,
+                  "endTokenPos": 85,
+                  "endFilePos": 271
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 84,
+                    "startFilePos": 266,
+                    "endLine": 2,
+                    "endTokenPos": 84,
+                    "endFilePos": 270
+                  },
+                  "name": "rows"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 93,
+        "startFilePos": 279,
+        "endLine": 3,
+        "endTokenPos": 99,
+        "endFilePos": 291
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 93,
+          "startFilePos": 279,
+          "endLine": 3,
+          "endTokenPos": 98,
+          "endFilePos": 290
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 93,
+            "startFilePos": 279,
+            "endLine": 3,
+            "endTokenPos": 93,
+            "endFilePos": 285
+          },
+          "name": "adults"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 97,
+            "startFilePos": 289,
+            "endLine": 3,
+            "endTokenPos": 98,
+            "endFilePos": 290,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 101,
+        "startFilePos": 293,
+        "endLine": 8,
+        "endTokenPos": 158,
+        "endFilePos": 412
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 104,
+          "startFilePos": 302,
+          "endLine": 4,
+          "endTokenPos": 104,
+          "endFilePos": 308
+        },
+        "name": "people"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 108,
+          "startFilePos": 313,
+          "endLine": 4,
+          "endTokenPos": 108,
+          "endFilePos": 314
+        },
+        "name": "p"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 113,
+            "startFilePos": 321,
+            "endLine": 7,
+            "endTokenPos": 156,
+            "endFilePos": 410
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 116,
+              "startFilePos": 325,
+              "endLine": 5,
+              "endTokenPos": 123,
+              "endFilePos": 339
+            },
+            "left": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 116,
+                "startFilePos": 325,
+                "endLine": 5,
+                "endTokenPos": 119,
+                "endFilePos": 333
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 116,
+                  "startFilePos": 325,
+                  "endLine": 5,
+                  "endTokenPos": 116,
+                  "endFilePos": 326
+                },
+                "name": "p"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 118,
+                  "startFilePos": 328,
+                  "endLine": 5,
+                  "endTokenPos": 118,
+                  "endFilePos": 332,
+                  "kind": 2,
+                  "rawValue": "\"age\""
+                },
+                "value": "age"
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 123,
+                "startFilePos": 338,
+                "endLine": 5,
+                "endTokenPos": 123,
+                "endFilePos": 339,
+                "rawValue": "18",
+                "kind": 10
+              },
+              "value": 18
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 128,
+                "startFilePos": 348,
+                "endLine": 6,
+                "endTokenPos": 154,
+                "endFilePos": 406
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 128,
+                  "startFilePos": 348,
+                  "endLine": 6,
+                  "endTokenPos": 153,
+                  "endFilePos": 405
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 128,
+                    "startFilePos": 348,
+                    "endLine": 6,
+                    "endTokenPos": 130,
+                    "endFilePos": 356
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 128,
+                      "startFilePos": 348,
+                      "endLine": 6,
+                      "endTokenPos": 128,
+                      "endFilePos": 354
+                    },
+                    "name": "adults"
+                  },
+                  "dim": null
+                },
+                "expr": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 134,
+                    "startFilePos": 360,
+                    "endLine": 6,
+                    "endTokenPos": 153,
+                    "endFilePos": 405,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 135,
+                        "startFilePos": 361,
+                        "endLine": 6,
+                        "endTokenPos": 142,
+                        "endFilePos": 380
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 135,
+                          "startFilePos": 361,
+                          "endLine": 6,
+                          "endTokenPos": 135,
+                          "endFilePos": 366,
+                          "kind": 2,
+                          "rawValue": "\"name\""
+                        },
+                        "value": "name"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 139,
+                          "startFilePos": 371,
+                          "endLine": 6,
+                          "endTokenPos": 142,
+                          "endFilePos": 380
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 139,
+                            "startFilePos": 371,
+                            "endLine": 6,
+                            "endTokenPos": 139,
+                            "endFilePos": 372
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 141,
+                            "startFilePos": 374,
+                            "endLine": 6,
+                            "endTokenPos": 141,
+                            "endFilePos": 379,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 145,
+                        "startFilePos": 383,
+                        "endLine": 6,
+                        "endTokenPos": 152,
+                        "endFilePos": 404
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 145,
+                          "startFilePos": 383,
+                          "endLine": 6,
+                          "endTokenPos": 145,
+                          "endFilePos": 389,
+                          "kind": 2,
+                          "rawValue": "\"email\""
+                        },
+                        "value": "email"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 149,
+                          "startFilePos": 394,
+                          "endLine": 6,
+                          "endTokenPos": 152,
+                          "endFilePos": 404
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 149,
+                            "startFilePos": 394,
+                            "endLine": 6,
+                            "endTokenPos": 149,
+                            "endFilePos": 395
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 151,
+                            "startFilePos": 397,
+                            "endLine": 6,
+                            "endTokenPos": 151,
+                            "endFilePos": 403,
+                            "kind": 2,
+                            "rawValue": "\"email\""
+                          },
+                          "value": "email"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 160,
+        "startFilePos": 415,
+        "endLine": 12,
+        "endTokenPos": 244,
+        "endFilePos": 605
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 10,
+          "startTokenPos": 163,
+          "startFilePos": 424,
+          "endLine": 10,
+          "endTokenPos": 163,
+          "endFilePos": 430
+        },
+        "name": "adults"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 10,
+          "startTokenPos": 167,
+          "startFilePos": 435,
+          "endLine": 10,
+          "endTokenPos": 167,
+          "endFilePos": 436
+        },
+        "name": "a"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 172,
+            "startFilePos": 443,
+            "endLine": 11,
+            "endTokenPos": 242,
+            "endFilePos": 603
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 174,
+                "startFilePos": 448,
+                "endLine": 11,
+                "endTokenPos": 238,
+                "endFilePos": 593
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 174,
+                  "startFilePos": 448,
+                  "endLine": 11,
+                  "endTokenPos": 206,
+                  "endFilePos": 520
+                },
+                "left": {
+                  "nodeType": "Expr_Ternary",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 175,
+                    "startFilePos": 449,
+                    "endLine": 11,
+                    "endTokenPos": 201,
+                    "endFilePos": 513
+                  },
+                  "cond": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 175,
+                      "startFilePos": 449,
+                      "endLine": 11,
+                      "endTokenPos": 181,
+                      "endFilePos": 468
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 175,
+                        "startFilePos": 449,
+                        "endLine": 11,
+                        "endTokenPos": 175,
+                        "endFilePos": 456
+                      },
+                      "name": "is_float"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 177,
+                          "startFilePos": 458,
+                          "endLine": 11,
+                          "endTokenPos": 180,
+                          "endFilePos": 467
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 177,
+                            "startFilePos": 458,
+                            "endLine": 11,
+                            "endTokenPos": 180,
+                            "endFilePos": 467
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 177,
+                              "startFilePos": 458,
+                              "endLine": 11,
+                              "endTokenPos": 177,
+                              "endFilePos": 459
+                            },
+                            "name": "a"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 179,
+                              "startFilePos": 461,
+                              "endLine": 11,
+                              "endTokenPos": 179,
+                              "endFilePos": 466,
+                              "kind": 2,
+                              "rawValue": "\"name\""
+                            },
+                            "value": "name"
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "if": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 185,
+                      "startFilePos": 472,
+                      "endLine": 11,
+                      "endTokenPos": 194,
+                      "endFilePos": 500
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 185,
+                        "startFilePos": 472,
+                        "endLine": 11,
+                        "endTokenPos": 185,
+                        "endFilePos": 482
+                      },
+                      "name": "json_encode"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 187,
+                          "startFilePos": 484,
+                          "endLine": 11,
+                          "endTokenPos": 190,
+                          "endFilePos": 493
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 187,
+                            "startFilePos": 484,
+                            "endLine": 11,
+                            "endTokenPos": 190,
+                            "endFilePos": 493
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 187,
+                              "startFilePos": 484,
+                              "endLine": 11,
+                              "endTokenPos": 187,
+                              "endFilePos": 485
+                            },
+                            "name": "a"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 189,
+                              "startFilePos": 487,
+                              "endLine": 11,
+                              "endTokenPos": 189,
+                              "endFilePos": 492,
+                              "kind": 2,
+                              "rawValue": "\"name\""
+                            },
+                            "value": "name"
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 193,
+                          "startFilePos": 496,
+                          "endLine": 11,
+                          "endTokenPos": 193,
+                          "endFilePos": 499
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 193,
+                            "startFilePos": 496,
+                            "endLine": 11,
+                            "endTokenPos": 193,
+                            "endFilePos": 499,
+                            "rawValue": "1344",
+                            "kind": 10
+                          },
+                          "value": 1344
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "else": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 198,
+                      "startFilePos": 504,
+                      "endLine": 11,
+                      "endTokenPos": 201,
+                      "endFilePos": 513
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 198,
+                        "startFilePos": 504,
+                        "endLine": 11,
+                        "endTokenPos": 198,
+                        "endFilePos": 505
+                      },
+                      "name": "a"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 200,
+                        "startFilePos": 507,
+                        "endLine": 11,
+                        "endTokenPos": 200,
+                        "endFilePos": 512,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 206,
+                    "startFilePos": 518,
+                    "endLine": 11,
+                    "endTokenPos": 206,
+                    "endFilePos": 520,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 211,
+                  "startFilePos": 525,
+                  "endLine": 11,
+                  "endTokenPos": 237,
+                  "endFilePos": 592
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 211,
+                    "startFilePos": 525,
+                    "endLine": 11,
+                    "endTokenPos": 217,
+                    "endFilePos": 545
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 211,
+                      "startFilePos": 525,
+                      "endLine": 11,
+                      "endTokenPos": 211,
+                      "endFilePos": 532
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 213,
+                        "startFilePos": 534,
+                        "endLine": 11,
+                        "endTokenPos": 216,
+                        "endFilePos": 544
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 213,
+                          "startFilePos": 534,
+                          "endLine": 11,
+                          "endTokenPos": 216,
+                          "endFilePos": 544
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 213,
+                            "startFilePos": 534,
+                            "endLine": 11,
+                            "endTokenPos": 213,
+                            "endFilePos": 535
+                          },
+                          "name": "a"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 215,
+                            "startFilePos": 537,
+                            "endLine": 11,
+                            "endTokenPos": 215,
+                            "endFilePos": 543,
+                            "kind": 2,
+                            "rawValue": "\"email\""
+                          },
+                          "value": "email"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 221,
+                    "startFilePos": 549,
+                    "endLine": 11,
+                    "endTokenPos": 230,
+                    "endFilePos": 578
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 221,
+                      "startFilePos": 549,
+                      "endLine": 11,
+                      "endTokenPos": 221,
+                      "endFilePos": 559
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 223,
+                        "startFilePos": 561,
+                        "endLine": 11,
+                        "endTokenPos": 226,
+                        "endFilePos": 571
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 223,
+                          "startFilePos": 561,
+                          "endLine": 11,
+                          "endTokenPos": 226,
+                          "endFilePos": 571
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 223,
+                            "startFilePos": 561,
+                            "endLine": 11,
+                            "endTokenPos": 223,
+                            "endFilePos": 562
+                          },
+                          "name": "a"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 225,
+                            "startFilePos": 564,
+                            "endLine": 11,
+                            "endTokenPos": 225,
+                            "endFilePos": 570,
+                            "kind": 2,
+                            "rawValue": "\"email\""
+                          },
+                          "value": "email"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 229,
+                        "startFilePos": 574,
+                        "endLine": 11,
+                        "endTokenPos": 229,
+                        "endFilePos": 577
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 229,
+                          "startFilePos": 574,
+                          "endLine": 11,
+                          "endTokenPos": 229,
+                          "endFilePos": 577,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 234,
+                    "startFilePos": 582,
+                    "endLine": 11,
+                    "endTokenPos": 237,
+                    "endFilePos": 592
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 234,
+                      "startFilePos": 582,
+                      "endLine": 11,
+                      "endTokenPos": 234,
+                      "endFilePos": 583
+                    },
+                    "name": "a"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 236,
+                      "startFilePos": 585,
+                      "endLine": 11,
+                      "endTokenPos": 236,
+                      "endFilePos": 591,
+                      "kind": 2,
+                      "rawValue": "\"email\""
+                    },
+                    "value": "email"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 241,
+                "startFilePos": 596,
+                "endLine": 11,
+                "endTokenPos": 241,
+                "endFilePos": 602
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 241,
+                  "startFilePos": 596,
+                  "endLine": 11,
+                  "endTokenPos": 241,
+                  "endFilePos": 602
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/load_yaml.php.json
+++ b/tests/json-ast/x/php/load_yaml.php.json
@@ -1,0 +1,2745 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 264,
+        "endFilePos": 601
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 263,
+          "endFilePos": 600
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 263,
+            "endFilePos": 600
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 6,
+              "startFilePos": 17,
+              "endLine": 2,
+              "endTokenPos": 260,
+              "endFilePos": 597
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 30,
+                  "endLine": 2,
+                  "endTokenPos": 27,
+                  "endFilePos": 146
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 12,
+                    "startFilePos": 30,
+                    "endLine": 2,
+                    "endTokenPos": 26,
+                    "endFilePos": 145
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 12,
+                      "startFilePos": 30,
+                      "endLine": 2,
+                      "endTokenPos": 12,
+                      "endFilePos": 35
+                    },
+                    "name": "lines"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 39,
+                      "endLine": 2,
+                      "endTokenPos": 26,
+                      "endFilePos": 145
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 16,
+                        "startFilePos": 39,
+                        "endLine": 2,
+                        "endTokenPos": 16,
+                        "endFilePos": 42
+                      },
+                      "name": "file"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 18,
+                          "startFilePos": 44,
+                          "endLine": 2,
+                          "endTokenPos": 18,
+                          "endFilePos": 97
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 18,
+                            "startFilePos": 44,
+                            "endLine": 2,
+                            "endTokenPos": 18,
+                            "endFilePos": 97,
+                            "kind": 2,
+                            "rawValue": "\"\/workspace\/mochi\/tests\/interpreter\/valid\/people.yaml\""
+                          },
+                          "value": "\/workspace\/mochi\/tests\/interpreter\/valid\/people.yaml"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 21,
+                          "startFilePos": 100,
+                          "endLine": 2,
+                          "endTokenPos": 25,
+                          "endFilePos": 144
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_BinaryOp_BitwiseOr",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 21,
+                            "startFilePos": 100,
+                            "endLine": 2,
+                            "endTokenPos": 25,
+                            "endFilePos": 144
+                          },
+                          "left": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 21,
+                              "startFilePos": 100,
+                              "endLine": 2,
+                              "endTokenPos": 21,
+                              "endFilePos": 120
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 21,
+                                "startFilePos": 100,
+                                "endLine": 2,
+                                "endTokenPos": 21,
+                                "endFilePos": 120
+                              },
+                              "name": "FILE_IGNORE_NEW_LINES"
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 25,
+                              "startFilePos": 124,
+                              "endLine": 2,
+                              "endTokenPos": 25,
+                              "endFilePos": 144
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 25,
+                                "startFilePos": 124,
+                                "endLine": 2,
+                                "endTokenPos": 25,
+                                "endFilePos": 144
+                              },
+                              "name": "FILE_SKIP_EMPTY_LINES"
+                            }
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 148,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 158
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 29,
+                    "startFilePos": 148,
+                    "endLine": 2,
+                    "endTokenPos": 34,
+                    "endFilePos": 157
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 29,
+                      "startFilePos": 148,
+                      "endLine": 2,
+                      "endTokenPos": 29,
+                      "endFilePos": 152
+                    },
+                    "name": "rows"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 33,
+                      "startFilePos": 156,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 157,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 37,
+                  "startFilePos": 160,
+                  "endLine": 2,
+                  "endTokenPos": 43,
+                  "endFilePos": 170
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 37,
+                    "startFilePos": 160,
+                    "endLine": 2,
+                    "endTokenPos": 42,
+                    "endFilePos": 169
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 37,
+                      "startFilePos": 160,
+                      "endLine": 2,
+                      "endTokenPos": 37,
+                      "endFilePos": 164
+                    },
+                    "name": "curr"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 41,
+                      "startFilePos": 168,
+                      "endLine": 2,
+                      "endTokenPos": 42,
+                      "endFilePos": 169,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 45,
+                  "startFilePos": 172,
+                  "endLine": 2,
+                  "endTokenPos": 238,
+                  "endFilePos": 553
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 48,
+                    "startFilePos": 181,
+                    "endLine": 2,
+                    "endTokenPos": 48,
+                    "endFilePos": 186
+                  },
+                  "name": "lines"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 52,
+                    "startFilePos": 191,
+                    "endLine": 2,
+                    "endTokenPos": 52,
+                    "endFilePos": 195
+                  },
+                  "name": "line"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 57,
+                      "startFilePos": 200,
+                      "endLine": 2,
+                      "endTokenPos": 65,
+                      "endFilePos": 219
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 57,
+                        "startFilePos": 200,
+                        "endLine": 2,
+                        "endTokenPos": 64,
+                        "endFilePos": 218
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 57,
+                          "startFilePos": 200,
+                          "endLine": 2,
+                          "endTokenPos": 57,
+                          "endFilePos": 204
+                        },
+                        "name": "line"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_FuncCall",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 61,
+                          "startFilePos": 208,
+                          "endLine": 2,
+                          "endTokenPos": 64,
+                          "endFilePos": 218
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 61,
+                            "startFilePos": 208,
+                            "endLine": 2,
+                            "endTokenPos": 61,
+                            "endFilePos": 211
+                          },
+                          "name": "trim"
+                        },
+                        "args": [
+                          {
+                            "nodeType": "Arg",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 63,
+                              "startFilePos": 213,
+                              "endLine": 2,
+                              "endTokenPos": 63,
+                              "endFilePos": 217
+                            },
+                            "name": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 63,
+                                "startFilePos": 213,
+                                "endLine": 2,
+                                "endTokenPos": 63,
+                                "endFilePos": 217
+                              },
+                              "name": "line"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 67,
+                      "startFilePos": 221,
+                      "endLine": 2,
+                      "endTokenPos": 236,
+                      "endFilePos": 551
+                    },
+                    "cond": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 70,
+                        "startFilePos": 225,
+                        "endLine": 2,
+                        "endTokenPos": 76,
+                        "endFilePos": 251
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 70,
+                          "startFilePos": 225,
+                          "endLine": 2,
+                          "endTokenPos": 70,
+                          "endFilePos": 239
+                        },
+                        "name": "str_starts_with"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 72,
+                            "startFilePos": 241,
+                            "endLine": 2,
+                            "endTokenPos": 72,
+                            "endFilePos": 245
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 72,
+                              "startFilePos": 241,
+                              "endLine": 2,
+                              "endTokenPos": 72,
+                              "endFilePos": 245
+                            },
+                            "name": "line"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 75,
+                            "startFilePos": 248,
+                            "endLine": 2,
+                            "endTokenPos": 75,
+                            "endFilePos": 250
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 75,
+                              "startFilePos": 248,
+                              "endLine": 2,
+                              "endTokenPos": 75,
+                              "endFilePos": 250,
+                              "kind": 1,
+                              "rawValue": "'-'"
+                            },
+                            "value": "-"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 81,
+                          "startFilePos": 256,
+                          "endLine": 2,
+                          "endTokenPos": 94,
+                          "endFilePos": 282
+                        },
+                        "cond": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 84,
+                            "startFilePos": 260,
+                            "endLine": 2,
+                            "endTokenPos": 84,
+                            "endFilePos": 264
+                          },
+                          "name": "curr"
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 87,
+                              "startFilePos": 267,
+                              "endLine": 2,
+                              "endTokenPos": 94,
+                              "endFilePos": 282
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 87,
+                                "startFilePos": 267,
+                                "endLine": 2,
+                                "endTokenPos": 93,
+                                "endFilePos": 281
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 87,
+                                  "startFilePos": 267,
+                                  "endLine": 2,
+                                  "endTokenPos": 89,
+                                  "endFilePos": 273
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 87,
+                                    "startFilePos": 267,
+                                    "endLine": 2,
+                                    "endTokenPos": 87,
+                                    "endFilePos": 271
+                                  },
+                                  "name": "rows"
+                                },
+                                "dim": null
+                              },
+                              "expr": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 93,
+                                  "startFilePos": 277,
+                                  "endLine": 2,
+                                  "endTokenPos": 93,
+                                  "endFilePos": 281
+                                },
+                                "name": "curr"
+                              }
+                            }
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 96,
+                          "startFilePos": 284,
+                          "endLine": 2,
+                          "endTokenPos": 102,
+                          "endFilePos": 294
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 96,
+                            "startFilePos": 284,
+                            "endLine": 2,
+                            "endTokenPos": 101,
+                            "endFilePos": 293
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 96,
+                              "startFilePos": 284,
+                              "endLine": 2,
+                              "endTokenPos": 96,
+                              "endFilePos": 288
+                            },
+                            "name": "curr"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 100,
+                              "startFilePos": 292,
+                              "endLine": 2,
+                              "endTokenPos": 101,
+                              "endFilePos": 293,
+                              "kind": 2
+                            },
+                            "items": []
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 104,
+                          "startFilePos": 296,
+                          "endLine": 2,
+                          "endTokenPos": 118,
+                          "endFilePos": 326
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 104,
+                            "startFilePos": 296,
+                            "endLine": 2,
+                            "endTokenPos": 117,
+                            "endFilePos": 325
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 104,
+                              "startFilePos": 296,
+                              "endLine": 2,
+                              "endTokenPos": 104,
+                              "endFilePos": 300
+                            },
+                            "name": "line"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 108,
+                              "startFilePos": 304,
+                              "endLine": 2,
+                              "endTokenPos": 117,
+                              "endFilePos": 325
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 108,
+                                "startFilePos": 304,
+                                "endLine": 2,
+                                "endTokenPos": 108,
+                                "endFilePos": 307
+                              },
+                              "name": "trim"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 110,
+                                  "startFilePos": 309,
+                                  "endLine": 2,
+                                  "endTokenPos": 116,
+                                  "endFilePos": 324
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 110,
+                                    "startFilePos": 309,
+                                    "endLine": 2,
+                                    "endTokenPos": 116,
+                                    "endFilePos": 324
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 110,
+                                      "startFilePos": 309,
+                                      "endLine": 2,
+                                      "endTokenPos": 110,
+                                      "endFilePos": 314
+                                    },
+                                    "name": "substr"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 112,
+                                        "startFilePos": 316,
+                                        "endLine": 2,
+                                        "endTokenPos": 112,
+                                        "endFilePos": 320
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 112,
+                                          "startFilePos": 316,
+                                          "endLine": 2,
+                                          "endTokenPos": 112,
+                                          "endFilePos": 320
+                                        },
+                                        "name": "line"
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 115,
+                                        "startFilePos": 323,
+                                        "endLine": 2,
+                                        "endTokenPos": 115,
+                                        "endFilePos": 323
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_Int",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 115,
+                                          "startFilePos": 323,
+                                          "endLine": 2,
+                                          "endTokenPos": 115,
+                                          "endFilePos": 323,
+                                          "rawValue": "1",
+                                          "kind": 10
+                                        },
+                                        "value": 1
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 120,
+                          "startFilePos": 328,
+                          "endLine": 2,
+                          "endTokenPos": 180,
+                          "endFilePos": 444
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BinaryOp_NotIdentical",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 123,
+                            "startFilePos": 332,
+                            "endLine": 2,
+                            "endTokenPos": 127,
+                            "endFilePos": 343
+                          },
+                          "left": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 123,
+                              "startFilePos": 332,
+                              "endLine": 2,
+                              "endTokenPos": 123,
+                              "endFilePos": 336
+                            },
+                            "name": "line"
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 127,
+                              "startFilePos": 342,
+                              "endLine": 2,
+                              "endTokenPos": 127,
+                              "endFilePos": 343,
+                              "kind": 1,
+                              "rawValue": "''"
+                            },
+                            "value": ""
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 132,
+                              "startFilePos": 348,
+                              "endLine": 2,
+                              "endTokenPos": 156,
+                              "endFilePos": 399
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 132,
+                                "startFilePos": 348,
+                                "endLine": 2,
+                                "endTokenPos": 155,
+                                "endFilePos": 398
+                              },
+                              "var": {
+                                "nodeType": "Expr_List",
+                                "attributes": {
+                                  "kind": 2,
+                                  "startLine": 2,
+                                  "startTokenPos": 132,
+                                  "startFilePos": 348,
+                                  "endLine": 2,
+                                  "endTokenPos": 136,
+                                  "endFilePos": 354
+                                },
+                                "items": [
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 133,
+                                      "startFilePos": 349,
+                                      "endLine": 2,
+                                      "endTokenPos": 133,
+                                      "endFilePos": 350
+                                    },
+                                    "key": null,
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 133,
+                                        "startFilePos": 349,
+                                        "endLine": 2,
+                                        "endTokenPos": 133,
+                                        "endFilePos": 350
+                                      },
+                                      "name": "k"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "ArrayItem",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 135,
+                                      "startFilePos": 352,
+                                      "endLine": 2,
+                                      "endTokenPos": 135,
+                                      "endFilePos": 353
+                                    },
+                                    "key": null,
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 135,
+                                        "startFilePos": 352,
+                                        "endLine": 2,
+                                        "endTokenPos": 135,
+                                        "endFilePos": 353
+                                      },
+                                      "name": "v"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              },
+                              "expr": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 140,
+                                  "startFilePos": 358,
+                                  "endLine": 2,
+                                  "endTokenPos": 155,
+                                  "endFilePos": 398
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 140,
+                                    "startFilePos": 358,
+                                    "endLine": 2,
+                                    "endTokenPos": 140,
+                                    "endFilePos": 366
+                                  },
+                                  "name": "array_map"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 142,
+                                      "startFilePos": 368,
+                                      "endLine": 2,
+                                      "endTokenPos": 142,
+                                      "endFilePos": 373
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 142,
+                                        "startFilePos": 368,
+                                        "endLine": 2,
+                                        "endTokenPos": 142,
+                                        "endFilePos": 373,
+                                        "kind": 1,
+                                        "rawValue": "'trim'"
+                                      },
+                                      "value": "trim"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  },
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 145,
+                                      "startFilePos": 376,
+                                      "endLine": 2,
+                                      "endTokenPos": 154,
+                                      "endFilePos": 397
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 145,
+                                        "startFilePos": 376,
+                                        "endLine": 2,
+                                        "endTokenPos": 154,
+                                        "endFilePos": 397
+                                      },
+                                      "name": {
+                                        "nodeType": "Name",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 145,
+                                          "startFilePos": 376,
+                                          "endLine": 2,
+                                          "endTokenPos": 145,
+                                          "endFilePos": 382
+                                        },
+                                        "name": "explode"
+                                      },
+                                      "args": [
+                                        {
+                                          "nodeType": "Arg",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 147,
+                                            "startFilePos": 384,
+                                            "endLine": 2,
+                                            "endTokenPos": 147,
+                                            "endFilePos": 386
+                                          },
+                                          "name": null,
+                                          "value": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 147,
+                                              "startFilePos": 384,
+                                              "endLine": 2,
+                                              "endTokenPos": 147,
+                                              "endFilePos": 386,
+                                              "kind": 1,
+                                              "rawValue": "':'"
+                                            },
+                                            "value": ":"
+                                          },
+                                          "byRef": false,
+                                          "unpack": false
+                                        },
+                                        {
+                                          "nodeType": "Arg",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 150,
+                                            "startFilePos": 389,
+                                            "endLine": 2,
+                                            "endTokenPos": 150,
+                                            "endFilePos": 393
+                                          },
+                                          "name": null,
+                                          "value": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 150,
+                                              "startFilePos": 389,
+                                              "endLine": 2,
+                                              "endTokenPos": 150,
+                                              "endFilePos": 393
+                                            },
+                                            "name": "line"
+                                          },
+                                          "byRef": false,
+                                          "unpack": false
+                                        },
+                                        {
+                                          "nodeType": "Arg",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 153,
+                                            "startFilePos": 396,
+                                            "endLine": 2,
+                                            "endTokenPos": 153,
+                                            "endFilePos": 396
+                                          },
+                                          "name": null,
+                                          "value": {
+                                            "nodeType": "Scalar_Int",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 153,
+                                              "startFilePos": 396,
+                                              "endLine": 2,
+                                              "endTokenPos": 153,
+                                              "endFilePos": 396,
+                                              "rawValue": "2",
+                                              "kind": 10
+                                            },
+                                            "value": 2
+                                          },
+                                          "byRef": false,
+                                          "unpack": false
+                                        }
+                                      ]
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "nodeType": "Stmt_Expression",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 158,
+                              "startFilePos": 401,
+                              "endLine": 2,
+                              "endTokenPos": 178,
+                              "endFilePos": 442
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Assign",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 158,
+                                "startFilePos": 401,
+                                "endLine": 2,
+                                "endTokenPos": 177,
+                                "endFilePos": 441
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 158,
+                                  "startFilePos": 401,
+                                  "endLine": 2,
+                                  "endTokenPos": 161,
+                                  "endFilePos": 409
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 158,
+                                    "startFilePos": 401,
+                                    "endLine": 2,
+                                    "endTokenPos": 158,
+                                    "endFilePos": 405
+                                  },
+                                  "name": "curr"
+                                },
+                                "dim": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 160,
+                                    "startFilePos": 407,
+                                    "endLine": 2,
+                                    "endTokenPos": 160,
+                                    "endFilePos": 408
+                                  },
+                                  "name": "k"
+                                }
+                              },
+                              "expr": {
+                                "nodeType": "Expr_Ternary",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 165,
+                                  "startFilePos": 413,
+                                  "endLine": 2,
+                                  "endTokenPos": 177,
+                                  "endFilePos": 441
+                                },
+                                "cond": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 165,
+                                    "startFilePos": 413,
+                                    "endLine": 2,
+                                    "endTokenPos": 168,
+                                    "endFilePos": 426
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 165,
+                                      "startFilePos": 413,
+                                      "endLine": 2,
+                                      "endTokenPos": 165,
+                                      "endFilePos": 422
+                                    },
+                                    "name": "is_numeric"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 167,
+                                        "startFilePos": 424,
+                                        "endLine": 2,
+                                        "endTokenPos": 167,
+                                        "endFilePos": 425
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 167,
+                                          "startFilePos": 424,
+                                          "endLine": 2,
+                                          "endTokenPos": 167,
+                                          "endFilePos": 425
+                                        },
+                                        "name": "v"
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "if": {
+                                  "nodeType": "Expr_Cast_Int",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 172,
+                                    "startFilePos": 430,
+                                    "endLine": 2,
+                                    "endTokenPos": 173,
+                                    "endFilePos": 436
+                                  },
+                                  "expr": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 173,
+                                      "startFilePos": 435,
+                                      "endLine": 2,
+                                      "endTokenPos": 173,
+                                      "endFilePos": 436
+                                    },
+                                    "name": "v"
+                                  }
+                                },
+                                "else": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 177,
+                                    "startFilePos": 440,
+                                    "endLine": 2,
+                                    "endTokenPos": 177,
+                                    "endFilePos": 441
+                                  },
+                                  "name": "v"
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": {
+                      "nodeType": "Stmt_Else",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 184,
+                        "startFilePos": 448,
+                        "endLine": 2,
+                        "endTokenPos": 236,
+                        "endFilePos": 551
+                      },
+                      "stmts": [
+                        {
+                          "nodeType": "Stmt_Expression",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 188,
+                            "startFilePos": 455,
+                            "endLine": 2,
+                            "endTokenPos": 212,
+                            "endFilePos": 506
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Assign",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 188,
+                              "startFilePos": 455,
+                              "endLine": 2,
+                              "endTokenPos": 211,
+                              "endFilePos": 505
+                            },
+                            "var": {
+                              "nodeType": "Expr_List",
+                              "attributes": {
+                                "kind": 2,
+                                "startLine": 2,
+                                "startTokenPos": 188,
+                                "startFilePos": 455,
+                                "endLine": 2,
+                                "endTokenPos": 192,
+                                "endFilePos": 461
+                              },
+                              "items": [
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 189,
+                                    "startFilePos": 456,
+                                    "endLine": 2,
+                                    "endTokenPos": 189,
+                                    "endFilePos": 457
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 189,
+                                      "startFilePos": 456,
+                                      "endLine": 2,
+                                      "endTokenPos": 189,
+                                      "endFilePos": 457
+                                    },
+                                    "name": "k"
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "ArrayItem",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 191,
+                                    "startFilePos": 459,
+                                    "endLine": 2,
+                                    "endTokenPos": 191,
+                                    "endFilePos": 460
+                                  },
+                                  "key": null,
+                                  "value": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 191,
+                                      "startFilePos": 459,
+                                      "endLine": 2,
+                                      "endTokenPos": 191,
+                                      "endFilePos": 460
+                                    },
+                                    "name": "v"
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "expr": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 196,
+                                "startFilePos": 465,
+                                "endLine": 2,
+                                "endTokenPos": 211,
+                                "endFilePos": 505
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 196,
+                                  "startFilePos": 465,
+                                  "endLine": 2,
+                                  "endTokenPos": 196,
+                                  "endFilePos": 473
+                                },
+                                "name": "array_map"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 198,
+                                    "startFilePos": 475,
+                                    "endLine": 2,
+                                    "endTokenPos": 198,
+                                    "endFilePos": 480
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 198,
+                                      "startFilePos": 475,
+                                      "endLine": 2,
+                                      "endTokenPos": 198,
+                                      "endFilePos": 480,
+                                      "kind": 1,
+                                      "rawValue": "'trim'"
+                                    },
+                                    "value": "trim"
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 201,
+                                    "startFilePos": 483,
+                                    "endLine": 2,
+                                    "endTokenPos": 210,
+                                    "endFilePos": 504
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_FuncCall",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 201,
+                                      "startFilePos": 483,
+                                      "endLine": 2,
+                                      "endTokenPos": 210,
+                                      "endFilePos": 504
+                                    },
+                                    "name": {
+                                      "nodeType": "Name",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 201,
+                                        "startFilePos": 483,
+                                        "endLine": 2,
+                                        "endTokenPos": 201,
+                                        "endFilePos": 489
+                                      },
+                                      "name": "explode"
+                                    },
+                                    "args": [
+                                      {
+                                        "nodeType": "Arg",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 203,
+                                          "startFilePos": 491,
+                                          "endLine": 2,
+                                          "endTokenPos": 203,
+                                          "endFilePos": 493
+                                        },
+                                        "name": null,
+                                        "value": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 203,
+                                            "startFilePos": 491,
+                                            "endLine": 2,
+                                            "endTokenPos": 203,
+                                            "endFilePos": 493,
+                                            "kind": 1,
+                                            "rawValue": "':'"
+                                          },
+                                          "value": ":"
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      },
+                                      {
+                                        "nodeType": "Arg",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 206,
+                                          "startFilePos": 496,
+                                          "endLine": 2,
+                                          "endTokenPos": 206,
+                                          "endFilePos": 500
+                                        },
+                                        "name": null,
+                                        "value": {
+                                          "nodeType": "Expr_Variable",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 206,
+                                            "startFilePos": 496,
+                                            "endLine": 2,
+                                            "endTokenPos": 206,
+                                            "endFilePos": 500
+                                          },
+                                          "name": "line"
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      },
+                                      {
+                                        "nodeType": "Arg",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 209,
+                                          "startFilePos": 503,
+                                          "endLine": 2,
+                                          "endTokenPos": 209,
+                                          "endFilePos": 503
+                                        },
+                                        "name": null,
+                                        "value": {
+                                          "nodeType": "Scalar_Int",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 209,
+                                            "startFilePos": 503,
+                                            "endLine": 2,
+                                            "endTokenPos": 209,
+                                            "endFilePos": 503,
+                                            "rawValue": "2",
+                                            "kind": 10
+                                          },
+                                          "value": 2
+                                        },
+                                        "byRef": false,
+                                        "unpack": false
+                                      }
+                                    ]
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "nodeType": "Stmt_Expression",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 214,
+                            "startFilePos": 508,
+                            "endLine": 2,
+                            "endTokenPos": 234,
+                            "endFilePos": 549
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Assign",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 214,
+                              "startFilePos": 508,
+                              "endLine": 2,
+                              "endTokenPos": 233,
+                              "endFilePos": 548
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 214,
+                                "startFilePos": 508,
+                                "endLine": 2,
+                                "endTokenPos": 217,
+                                "endFilePos": 516
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 214,
+                                  "startFilePos": 508,
+                                  "endLine": 2,
+                                  "endTokenPos": 214,
+                                  "endFilePos": 512
+                                },
+                                "name": "curr"
+                              },
+                              "dim": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 216,
+                                  "startFilePos": 514,
+                                  "endLine": 2,
+                                  "endTokenPos": 216,
+                                  "endFilePos": 515
+                                },
+                                "name": "k"
+                              }
+                            },
+                            "expr": {
+                              "nodeType": "Expr_Ternary",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 221,
+                                "startFilePos": 520,
+                                "endLine": 2,
+                                "endTokenPos": 233,
+                                "endFilePos": 548
+                              },
+                              "cond": {
+                                "nodeType": "Expr_FuncCall",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 221,
+                                  "startFilePos": 520,
+                                  "endLine": 2,
+                                  "endTokenPos": 224,
+                                  "endFilePos": 533
+                                },
+                                "name": {
+                                  "nodeType": "Name",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 221,
+                                    "startFilePos": 520,
+                                    "endLine": 2,
+                                    "endTokenPos": 221,
+                                    "endFilePos": 529
+                                  },
+                                  "name": "is_numeric"
+                                },
+                                "args": [
+                                  {
+                                    "nodeType": "Arg",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 223,
+                                      "startFilePos": 531,
+                                      "endLine": 2,
+                                      "endTokenPos": 223,
+                                      "endFilePos": 532
+                                    },
+                                    "name": null,
+                                    "value": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 223,
+                                        "startFilePos": 531,
+                                        "endLine": 2,
+                                        "endTokenPos": 223,
+                                        "endFilePos": 532
+                                      },
+                                      "name": "v"
+                                    },
+                                    "byRef": false,
+                                    "unpack": false
+                                  }
+                                ]
+                              },
+                              "if": {
+                                "nodeType": "Expr_Cast_Int",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 228,
+                                  "startFilePos": 537,
+                                  "endLine": 2,
+                                  "endTokenPos": 229,
+                                  "endFilePos": 543
+                                },
+                                "expr": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 229,
+                                    "startFilePos": 542,
+                                    "endLine": 2,
+                                    "endTokenPos": 229,
+                                    "endFilePos": 543
+                                  },
+                                  "name": "v"
+                                }
+                              },
+                              "else": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 233,
+                                  "startFilePos": 547,
+                                  "endLine": 2,
+                                  "endTokenPos": 233,
+                                  "endFilePos": 548
+                                },
+                                "name": "v"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_If",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 240,
+                  "startFilePos": 555,
+                  "endLine": 2,
+                  "endTokenPos": 253,
+                  "endFilePos": 581
+                },
+                "cond": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 243,
+                    "startFilePos": 559,
+                    "endLine": 2,
+                    "endTokenPos": 243,
+                    "endFilePos": 563
+                  },
+                  "name": "curr"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 246,
+                      "startFilePos": 566,
+                      "endLine": 2,
+                      "endTokenPos": 253,
+                      "endFilePos": 581
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 246,
+                        "startFilePos": 566,
+                        "endLine": 2,
+                        "endTokenPos": 252,
+                        "endFilePos": 580
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 246,
+                          "startFilePos": 566,
+                          "endLine": 2,
+                          "endTokenPos": 248,
+                          "endFilePos": 572
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 246,
+                            "startFilePos": 566,
+                            "endLine": 2,
+                            "endTokenPos": 246,
+                            "endFilePos": 570
+                          },
+                          "name": "rows"
+                        },
+                        "dim": null
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 252,
+                          "startFilePos": 576,
+                          "endLine": 2,
+                          "endTokenPos": 252,
+                          "endFilePos": 580
+                        },
+                        "name": "curr"
+                      }
+                    }
+                  }
+                ],
+                "elseifs": [],
+                "else": null
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 255,
+                  "startFilePos": 583,
+                  "endLine": 2,
+                  "endTokenPos": 258,
+                  "endFilePos": 595
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 257,
+                    "startFilePos": 590,
+                    "endLine": 2,
+                    "endTokenPos": 257,
+                    "endFilePos": 594
+                  },
+                  "name": "rows"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 266,
+        "startFilePos": 603,
+        "endLine": 3,
+        "endTokenPos": 272,
+        "endFilePos": 615
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 266,
+          "startFilePos": 603,
+          "endLine": 3,
+          "endTokenPos": 271,
+          "endFilePos": 614
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 266,
+            "startFilePos": 603,
+            "endLine": 3,
+            "endTokenPos": 266,
+            "endFilePos": 609
+          },
+          "name": "adults"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 270,
+            "startFilePos": 613,
+            "endLine": 3,
+            "endTokenPos": 271,
+            "endFilePos": 614,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 274,
+        "startFilePos": 617,
+        "endLine": 8,
+        "endTokenPos": 331,
+        "endFilePos": 736
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 277,
+          "startFilePos": 626,
+          "endLine": 4,
+          "endTokenPos": 277,
+          "endFilePos": 632
+        },
+        "name": "people"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 281,
+          "startFilePos": 637,
+          "endLine": 4,
+          "endTokenPos": 281,
+          "endFilePos": 638
+        },
+        "name": "p"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 286,
+            "startFilePos": 645,
+            "endLine": 7,
+            "endTokenPos": 329,
+            "endFilePos": 734
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 289,
+              "startFilePos": 649,
+              "endLine": 5,
+              "endTokenPos": 296,
+              "endFilePos": 663
+            },
+            "left": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 289,
+                "startFilePos": 649,
+                "endLine": 5,
+                "endTokenPos": 292,
+                "endFilePos": 657
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 289,
+                  "startFilePos": 649,
+                  "endLine": 5,
+                  "endTokenPos": 289,
+                  "endFilePos": 650
+                },
+                "name": "p"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 291,
+                  "startFilePos": 652,
+                  "endLine": 5,
+                  "endTokenPos": 291,
+                  "endFilePos": 656,
+                  "kind": 2,
+                  "rawValue": "\"age\""
+                },
+                "value": "age"
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 296,
+                "startFilePos": 662,
+                "endLine": 5,
+                "endTokenPos": 296,
+                "endFilePos": 663,
+                "rawValue": "18",
+                "kind": 10
+              },
+              "value": 18
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 301,
+                "startFilePos": 672,
+                "endLine": 6,
+                "endTokenPos": 327,
+                "endFilePos": 730
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 301,
+                  "startFilePos": 672,
+                  "endLine": 6,
+                  "endTokenPos": 326,
+                  "endFilePos": 729
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 301,
+                    "startFilePos": 672,
+                    "endLine": 6,
+                    "endTokenPos": 303,
+                    "endFilePos": 680
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 301,
+                      "startFilePos": 672,
+                      "endLine": 6,
+                      "endTokenPos": 301,
+                      "endFilePos": 678
+                    },
+                    "name": "adults"
+                  },
+                  "dim": null
+                },
+                "expr": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 307,
+                    "startFilePos": 684,
+                    "endLine": 6,
+                    "endTokenPos": 326,
+                    "endFilePos": 729,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 308,
+                        "startFilePos": 685,
+                        "endLine": 6,
+                        "endTokenPos": 315,
+                        "endFilePos": 704
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 308,
+                          "startFilePos": 685,
+                          "endLine": 6,
+                          "endTokenPos": 308,
+                          "endFilePos": 690,
+                          "kind": 2,
+                          "rawValue": "\"name\""
+                        },
+                        "value": "name"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 312,
+                          "startFilePos": 695,
+                          "endLine": 6,
+                          "endTokenPos": 315,
+                          "endFilePos": 704
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 312,
+                            "startFilePos": 695,
+                            "endLine": 6,
+                            "endTokenPos": 312,
+                            "endFilePos": 696
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 314,
+                            "startFilePos": 698,
+                            "endLine": 6,
+                            "endTokenPos": 314,
+                            "endFilePos": 703,
+                            "kind": 2,
+                            "rawValue": "\"name\""
+                          },
+                          "value": "name"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 318,
+                        "startFilePos": 707,
+                        "endLine": 6,
+                        "endTokenPos": 325,
+                        "endFilePos": 728
+                      },
+                      "key": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 318,
+                          "startFilePos": 707,
+                          "endLine": 6,
+                          "endTokenPos": 318,
+                          "endFilePos": 713,
+                          "kind": 2,
+                          "rawValue": "\"email\""
+                        },
+                        "value": "email"
+                      },
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 322,
+                          "startFilePos": 718,
+                          "endLine": 6,
+                          "endTokenPos": 325,
+                          "endFilePos": 728
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 322,
+                            "startFilePos": 718,
+                            "endLine": 6,
+                            "endTokenPos": 322,
+                            "endFilePos": 719
+                          },
+                          "name": "p"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 324,
+                            "startFilePos": 721,
+                            "endLine": 6,
+                            "endTokenPos": 324,
+                            "endFilePos": 727,
+                            "kind": 2,
+                            "rawValue": "\"email\""
+                          },
+                          "value": "email"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 333,
+        "startFilePos": 739,
+        "endLine": 12,
+        "endTokenPos": 417,
+        "endFilePos": 929
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 10,
+          "startTokenPos": 336,
+          "startFilePos": 748,
+          "endLine": 10,
+          "endTokenPos": 336,
+          "endFilePos": 754
+        },
+        "name": "adults"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 10,
+          "startTokenPos": 340,
+          "startFilePos": 759,
+          "endLine": 10,
+          "endTokenPos": 340,
+          "endFilePos": 760
+        },
+        "name": "a"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 345,
+            "startFilePos": 767,
+            "endLine": 11,
+            "endTokenPos": 415,
+            "endFilePos": 927
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 347,
+                "startFilePos": 772,
+                "endLine": 11,
+                "endTokenPos": 411,
+                "endFilePos": 917
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 347,
+                  "startFilePos": 772,
+                  "endLine": 11,
+                  "endTokenPos": 379,
+                  "endFilePos": 844
+                },
+                "left": {
+                  "nodeType": "Expr_Ternary",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 348,
+                    "startFilePos": 773,
+                    "endLine": 11,
+                    "endTokenPos": 374,
+                    "endFilePos": 837
+                  },
+                  "cond": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 348,
+                      "startFilePos": 773,
+                      "endLine": 11,
+                      "endTokenPos": 354,
+                      "endFilePos": 792
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 348,
+                        "startFilePos": 773,
+                        "endLine": 11,
+                        "endTokenPos": 348,
+                        "endFilePos": 780
+                      },
+                      "name": "is_float"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 350,
+                          "startFilePos": 782,
+                          "endLine": 11,
+                          "endTokenPos": 353,
+                          "endFilePos": 791
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 350,
+                            "startFilePos": 782,
+                            "endLine": 11,
+                            "endTokenPos": 353,
+                            "endFilePos": 791
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 350,
+                              "startFilePos": 782,
+                              "endLine": 11,
+                              "endTokenPos": 350,
+                              "endFilePos": 783
+                            },
+                            "name": "a"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 352,
+                              "startFilePos": 785,
+                              "endLine": 11,
+                              "endTokenPos": 352,
+                              "endFilePos": 790,
+                              "kind": 2,
+                              "rawValue": "\"name\""
+                            },
+                            "value": "name"
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "if": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 358,
+                      "startFilePos": 796,
+                      "endLine": 11,
+                      "endTokenPos": 367,
+                      "endFilePos": 824
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 358,
+                        "startFilePos": 796,
+                        "endLine": 11,
+                        "endTokenPos": 358,
+                        "endFilePos": 806
+                      },
+                      "name": "json_encode"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 360,
+                          "startFilePos": 808,
+                          "endLine": 11,
+                          "endTokenPos": 363,
+                          "endFilePos": 817
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 360,
+                            "startFilePos": 808,
+                            "endLine": 11,
+                            "endTokenPos": 363,
+                            "endFilePos": 817
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 360,
+                              "startFilePos": 808,
+                              "endLine": 11,
+                              "endTokenPos": 360,
+                              "endFilePos": 809
+                            },
+                            "name": "a"
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 362,
+                              "startFilePos": 811,
+                              "endLine": 11,
+                              "endTokenPos": 362,
+                              "endFilePos": 816,
+                              "kind": 2,
+                              "rawValue": "\"name\""
+                            },
+                            "value": "name"
+                          }
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 366,
+                          "startFilePos": 820,
+                          "endLine": 11,
+                          "endTokenPos": 366,
+                          "endFilePos": 823
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 366,
+                            "startFilePos": 820,
+                            "endLine": 11,
+                            "endTokenPos": 366,
+                            "endFilePos": 823,
+                            "rawValue": "1344",
+                            "kind": 10
+                          },
+                          "value": 1344
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  },
+                  "else": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 371,
+                      "startFilePos": 828,
+                      "endLine": 11,
+                      "endTokenPos": 374,
+                      "endFilePos": 837
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 371,
+                        "startFilePos": 828,
+                        "endLine": 11,
+                        "endTokenPos": 371,
+                        "endFilePos": 829
+                      },
+                      "name": "a"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 373,
+                        "startFilePos": 831,
+                        "endLine": 11,
+                        "endTokenPos": 373,
+                        "endFilePos": 836,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 379,
+                    "startFilePos": 842,
+                    "endLine": 11,
+                    "endTokenPos": 379,
+                    "endFilePos": 844,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Expr_Ternary",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 384,
+                  "startFilePos": 849,
+                  "endLine": 11,
+                  "endTokenPos": 410,
+                  "endFilePos": 916
+                },
+                "cond": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 384,
+                    "startFilePos": 849,
+                    "endLine": 11,
+                    "endTokenPos": 390,
+                    "endFilePos": 869
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 384,
+                      "startFilePos": 849,
+                      "endLine": 11,
+                      "endTokenPos": 384,
+                      "endFilePos": 856
+                    },
+                    "name": "is_float"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 386,
+                        "startFilePos": 858,
+                        "endLine": 11,
+                        "endTokenPos": 389,
+                        "endFilePos": 868
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 386,
+                          "startFilePos": 858,
+                          "endLine": 11,
+                          "endTokenPos": 389,
+                          "endFilePos": 868
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 386,
+                            "startFilePos": 858,
+                            "endLine": 11,
+                            "endTokenPos": 386,
+                            "endFilePos": 859
+                          },
+                          "name": "a"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 388,
+                            "startFilePos": 861,
+                            "endLine": 11,
+                            "endTokenPos": 388,
+                            "endFilePos": 867,
+                            "kind": 2,
+                            "rawValue": "\"email\""
+                          },
+                          "value": "email"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "if": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 394,
+                    "startFilePos": 873,
+                    "endLine": 11,
+                    "endTokenPos": 403,
+                    "endFilePos": 902
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 394,
+                      "startFilePos": 873,
+                      "endLine": 11,
+                      "endTokenPos": 394,
+                      "endFilePos": 883
+                    },
+                    "name": "json_encode"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 396,
+                        "startFilePos": 885,
+                        "endLine": 11,
+                        "endTokenPos": 399,
+                        "endFilePos": 895
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 396,
+                          "startFilePos": 885,
+                          "endLine": 11,
+                          "endTokenPos": 399,
+                          "endFilePos": 895
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 396,
+                            "startFilePos": 885,
+                            "endLine": 11,
+                            "endTokenPos": 396,
+                            "endFilePos": 886
+                          },
+                          "name": "a"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 398,
+                            "startFilePos": 888,
+                            "endLine": 11,
+                            "endTokenPos": 398,
+                            "endFilePos": 894,
+                            "kind": 2,
+                            "rawValue": "\"email\""
+                          },
+                          "value": "email"
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 402,
+                        "startFilePos": 898,
+                        "endLine": 11,
+                        "endTokenPos": 402,
+                        "endFilePos": 901
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 402,
+                          "startFilePos": 898,
+                          "endLine": 11,
+                          "endTokenPos": 402,
+                          "endFilePos": 901,
+                          "rawValue": "1344",
+                          "kind": 10
+                        },
+                        "value": 1344
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "else": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 407,
+                    "startFilePos": 906,
+                    "endLine": 11,
+                    "endTokenPos": 410,
+                    "endFilePos": 916
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 407,
+                      "startFilePos": 906,
+                      "endLine": 11,
+                      "endTokenPos": 407,
+                      "endFilePos": 907
+                    },
+                    "name": "a"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 409,
+                      "startFilePos": 909,
+                      "endLine": 11,
+                      "endTokenPos": 409,
+                      "endFilePos": 915,
+                      "kind": 2,
+                      "rawValue": "\"email\""
+                    },
+                    "value": "email"
+                  }
+                }
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 414,
+                "startFilePos": 920,
+                "endLine": 11,
+                "endTokenPos": 414,
+                "endFilePos": 926
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 414,
+                  "startFilePos": 920,
+                  "endLine": 11,
+                  "endTokenPos": 414,
+                  "endFilePos": 926
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_assign.php.json
+++ b/tests/json-ast/x/php/map_assign.php.json
@@ -1,0 +1,430 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 12,
+        "endFilePos": 30
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 11,
+          "endFilePos": 29
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "scores"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 11,
+            "endFilePos": 29,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 28
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 23,
+                  "kind": 2,
+                  "rawValue": "\"alice\""
+                },
+                "value": "alice"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 28,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 28,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 14,
+        "startFilePos": 32,
+        "endLine": 3,
+        "endTokenPos": 22,
+        "endFilePos": 50
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 14,
+          "startFilePos": 32,
+          "endLine": 3,
+          "endTokenPos": 21,
+          "endFilePos": 49
+        },
+        "var": {
+          "nodeType": "Expr_ArrayDimFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 14,
+            "startFilePos": 32,
+            "endLine": 3,
+            "endTokenPos": 17,
+            "endFilePos": 45
+          },
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 14,
+              "startFilePos": 32,
+              "endLine": 3,
+              "endTokenPos": 14,
+              "endFilePos": 38
+            },
+            "name": "scores"
+          },
+          "dim": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 16,
+              "startFilePos": 40,
+              "endLine": 3,
+              "endTokenPos": 16,
+              "endFilePos": 44,
+              "kind": 2,
+              "rawValue": "\"bob\""
+            },
+            "value": "bob"
+          }
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 21,
+            "startFilePos": 49,
+            "endLine": 3,
+            "endTokenPos": 21,
+            "endFilePos": 49,
+            "rawValue": "2",
+            "kind": 10
+          },
+          "value": 2
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 24,
+        "startFilePos": 52,
+        "endLine": 4,
+        "endTokenPos": 58,
+        "endFilePos": 145
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 27,
+            "startFilePos": 58,
+            "endLine": 4,
+            "endTokenPos": 53,
+            "endFilePos": 134
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 27,
+              "startFilePos": 58,
+              "endLine": 4,
+              "endTokenPos": 33,
+              "endFilePos": 81
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 27,
+                "startFilePos": 58,
+                "endLine": 4,
+                "endTokenPos": 27,
+                "endFilePos": 65
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 29,
+                  "startFilePos": 67,
+                  "endLine": 4,
+                  "endTokenPos": 32,
+                  "endFilePos": 80
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 29,
+                    "startFilePos": 67,
+                    "endLine": 4,
+                    "endTokenPos": 32,
+                    "endFilePos": 80
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 29,
+                      "startFilePos": 67,
+                      "endLine": 4,
+                      "endTokenPos": 29,
+                      "endFilePos": 73
+                    },
+                    "name": "scores"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 31,
+                      "startFilePos": 75,
+                      "endLine": 4,
+                      "endTokenPos": 31,
+                      "endFilePos": 79,
+                      "kind": 2,
+                      "rawValue": "\"bob\""
+                    },
+                    "value": "bob"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 37,
+              "startFilePos": 85,
+              "endLine": 4,
+              "endTokenPos": 46,
+              "endFilePos": 117
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 37,
+                "startFilePos": 85,
+                "endLine": 4,
+                "endTokenPos": 37,
+                "endFilePos": 95
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 39,
+                  "startFilePos": 97,
+                  "endLine": 4,
+                  "endTokenPos": 42,
+                  "endFilePos": 110
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 39,
+                    "startFilePos": 97,
+                    "endLine": 4,
+                    "endTokenPos": 42,
+                    "endFilePos": 110
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 39,
+                      "startFilePos": 97,
+                      "endLine": 4,
+                      "endTokenPos": 39,
+                      "endFilePos": 103
+                    },
+                    "name": "scores"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 41,
+                      "startFilePos": 105,
+                      "endLine": 4,
+                      "endTokenPos": 41,
+                      "endFilePos": 109,
+                      "kind": 2,
+                      "rawValue": "\"bob\""
+                    },
+                    "value": "bob"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 45,
+                  "startFilePos": 113,
+                  "endLine": 4,
+                  "endTokenPos": 45,
+                  "endFilePos": 116
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 45,
+                    "startFilePos": 113,
+                    "endLine": 4,
+                    "endTokenPos": 45,
+                    "endFilePos": 116,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 50,
+              "startFilePos": 121,
+              "endLine": 4,
+              "endTokenPos": 53,
+              "endFilePos": 134
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 50,
+                "startFilePos": 121,
+                "endLine": 4,
+                "endTokenPos": 50,
+                "endFilePos": 127
+              },
+              "name": "scores"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 52,
+                "startFilePos": 129,
+                "endLine": 4,
+                "endTokenPos": 52,
+                "endFilePos": 133,
+                "kind": 2,
+                "rawValue": "\"bob\""
+              },
+              "value": "bob"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 57,
+            "startFilePos": 138,
+            "endLine": 4,
+            "endTokenPos": 57,
+            "endFilePos": 144
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 57,
+              "startFilePos": 138,
+              "endLine": 4,
+              "endTokenPos": 57,
+              "endFilePos": 144
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_in_operator.php.json
+++ b/tests/json-ast/x/php/map_in_operator.php.json
@@ -1,0 +1,442 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 19,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 18,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 18,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 12,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 22,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 27,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 21,
+        "startFilePos": 33,
+        "endLine": 3,
+        "endTokenPos": 43,
+        "endFilePos": 91
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 24,
+            "startFilePos": 39,
+            "endLine": 3,
+            "endTokenPos": 38,
+            "endFilePos": 80
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 24,
+              "startFilePos": 39,
+              "endLine": 3,
+              "endTokenPos": 30,
+              "endFilePos": 61
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 24,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 24,
+                "endFilePos": 54
+              },
+              "name": "array_key_exists"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 26,
+                  "startFilePos": 56,
+                  "endLine": 3,
+                  "endTokenPos": 26,
+                  "endFilePos": 56
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 26,
+                    "startFilePos": 56,
+                    "endLine": 3,
+                    "endTokenPos": 26,
+                    "endFilePos": 56,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 29,
+                  "startFilePos": 59,
+                  "endLine": 3,
+                  "endTokenPos": 29,
+                  "endFilePos": 60
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 29,
+                    "startFilePos": 59,
+                    "endLine": 3,
+                    "endTokenPos": 29,
+                    "endFilePos": 60
+                  },
+                  "name": "m"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 34,
+              "startFilePos": 65,
+              "endLine": 3,
+              "endTokenPos": 34,
+              "endFilePos": 70,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 38,
+              "startFilePos": 74,
+              "endLine": 3,
+              "endTokenPos": 38,
+              "endFilePos": 80,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 42,
+            "startFilePos": 84,
+            "endLine": 3,
+            "endTokenPos": 42,
+            "endFilePos": 90
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 42,
+              "startFilePos": 84,
+              "endLine": 3,
+              "endTokenPos": 42,
+              "endFilePos": 90
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 45,
+        "startFilePos": 93,
+        "endLine": 4,
+        "endTokenPos": 67,
+        "endFilePos": 151
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 48,
+            "startFilePos": 99,
+            "endLine": 4,
+            "endTokenPos": 62,
+            "endFilePos": 140
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 48,
+              "startFilePos": 99,
+              "endLine": 4,
+              "endTokenPos": 54,
+              "endFilePos": 121
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 48,
+                "startFilePos": 99,
+                "endLine": 4,
+                "endTokenPos": 48,
+                "endFilePos": 114
+              },
+              "name": "array_key_exists"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 50,
+                  "startFilePos": 116,
+                  "endLine": 4,
+                  "endTokenPos": 50,
+                  "endFilePos": 116
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 50,
+                    "startFilePos": 116,
+                    "endLine": 4,
+                    "endTokenPos": 50,
+                    "endFilePos": 116,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 53,
+                  "startFilePos": 119,
+                  "endLine": 4,
+                  "endTokenPos": 53,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 53,
+                    "startFilePos": 119,
+                    "endLine": 4,
+                    "endTokenPos": 53,
+                    "endFilePos": 120
+                  },
+                  "name": "m"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 58,
+              "startFilePos": 125,
+              "endLine": 4,
+              "endTokenPos": 58,
+              "endFilePos": 130,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 62,
+              "startFilePos": 134,
+              "endLine": 4,
+              "endTokenPos": 62,
+              "endFilePos": 140,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 66,
+            "startFilePos": 144,
+            "endLine": 4,
+            "endTokenPos": 66,
+            "endFilePos": 150
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 66,
+              "startFilePos": 144,
+              "endLine": 4,
+              "endTokenPos": 66,
+              "endFilePos": 150
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_index.php.json
+++ b/tests/json-ast/x/php/map_index.php.json
@@ -1,0 +1,398 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 19,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 18,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 18,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 14,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 24,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 29,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 21,
+        "startFilePos": 33,
+        "endLine": 3,
+        "endTokenPos": 55,
+        "endFilePos": 105
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 24,
+            "startFilePos": 39,
+            "endLine": 3,
+            "endTokenPos": 50,
+            "endFilePos": 94
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 24,
+              "startFilePos": 39,
+              "endLine": 3,
+              "endTokenPos": 30,
+              "endFilePos": 55
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 24,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 24,
+                "endFilePos": 46
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 26,
+                  "startFilePos": 48,
+                  "endLine": 3,
+                  "endTokenPos": 29,
+                  "endFilePos": 54
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 26,
+                    "startFilePos": 48,
+                    "endLine": 3,
+                    "endTokenPos": 29,
+                    "endFilePos": 54
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 26,
+                      "startFilePos": 48,
+                      "endLine": 3,
+                      "endTokenPos": 26,
+                      "endFilePos": 49
+                    },
+                    "name": "m"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 28,
+                      "startFilePos": 51,
+                      "endLine": 3,
+                      "endTokenPos": 28,
+                      "endFilePos": 53,
+                      "kind": 2,
+                      "rawValue": "\"b\""
+                    },
+                    "value": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 34,
+              "startFilePos": 59,
+              "endLine": 3,
+              "endTokenPos": 43,
+              "endFilePos": 84
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 34,
+                "startFilePos": 59,
+                "endLine": 3,
+                "endTokenPos": 34,
+                "endFilePos": 69
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 36,
+                  "startFilePos": 71,
+                  "endLine": 3,
+                  "endTokenPos": 39,
+                  "endFilePos": 77
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 36,
+                    "startFilePos": 71,
+                    "endLine": 3,
+                    "endTokenPos": 39,
+                    "endFilePos": 77
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 71,
+                      "endLine": 3,
+                      "endTokenPos": 36,
+                      "endFilePos": 72
+                    },
+                    "name": "m"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 38,
+                      "startFilePos": 74,
+                      "endLine": 3,
+                      "endTokenPos": 38,
+                      "endFilePos": 76,
+                      "kind": 2,
+                      "rawValue": "\"b\""
+                    },
+                    "value": "b"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 42,
+                  "startFilePos": 80,
+                  "endLine": 3,
+                  "endTokenPos": 42,
+                  "endFilePos": 83
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 42,
+                    "startFilePos": 80,
+                    "endLine": 3,
+                    "endTokenPos": 42,
+                    "endFilePos": 83,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 47,
+              "startFilePos": 88,
+              "endLine": 3,
+              "endTokenPos": 50,
+              "endFilePos": 94
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 47,
+                "startFilePos": 88,
+                "endLine": 3,
+                "endTokenPos": 47,
+                "endFilePos": 89
+              },
+              "name": "m"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 49,
+                "startFilePos": 91,
+                "endLine": 3,
+                "endTokenPos": 49,
+                "endFilePos": 93,
+                "kind": 2,
+                "rawValue": "\"b\""
+              },
+              "value": "b"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 54,
+            "startFilePos": 98,
+            "endLine": 3,
+            "endTokenPos": 54,
+            "endFilePos": 104
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 54,
+              "startFilePos": 98,
+              "endLine": 3,
+              "endTokenPos": 54,
+              "endFilePos": 104
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_int_key.php.json
+++ b/tests/json-ast/x/php/map_int_key.php.json
@@ -1,0 +1,398 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 19,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 18,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 18,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 12,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 22,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 27,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 21,
+        "startFilePos": 33,
+        "endLine": 3,
+        "endTokenPos": 55,
+        "endFilePos": 99
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 24,
+            "startFilePos": 39,
+            "endLine": 3,
+            "endTokenPos": 50,
+            "endFilePos": 88
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 24,
+              "startFilePos": 39,
+              "endLine": 3,
+              "endTokenPos": 30,
+              "endFilePos": 53
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 24,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 24,
+                "endFilePos": 46
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 26,
+                  "startFilePos": 48,
+                  "endLine": 3,
+                  "endTokenPos": 29,
+                  "endFilePos": 52
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 26,
+                    "startFilePos": 48,
+                    "endLine": 3,
+                    "endTokenPos": 29,
+                    "endFilePos": 52
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 26,
+                      "startFilePos": 48,
+                      "endLine": 3,
+                      "endTokenPos": 26,
+                      "endFilePos": 49
+                    },
+                    "name": "m"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 28,
+                      "startFilePos": 51,
+                      "endLine": 3,
+                      "endTokenPos": 28,
+                      "endFilePos": 51,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 34,
+              "startFilePos": 57,
+              "endLine": 3,
+              "endTokenPos": 43,
+              "endFilePos": 80
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 34,
+                "startFilePos": 57,
+                "endLine": 3,
+                "endTokenPos": 34,
+                "endFilePos": 67
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 36,
+                  "startFilePos": 69,
+                  "endLine": 3,
+                  "endTokenPos": 39,
+                  "endFilePos": 73
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 36,
+                    "startFilePos": 69,
+                    "endLine": 3,
+                    "endTokenPos": 39,
+                    "endFilePos": 73
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 69,
+                      "endLine": 3,
+                      "endTokenPos": 36,
+                      "endFilePos": 70
+                    },
+                    "name": "m"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 38,
+                      "startFilePos": 72,
+                      "endLine": 3,
+                      "endTokenPos": 38,
+                      "endFilePos": 72,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 42,
+                  "startFilePos": 76,
+                  "endLine": 3,
+                  "endTokenPos": 42,
+                  "endFilePos": 79
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 42,
+                    "startFilePos": 76,
+                    "endLine": 3,
+                    "endTokenPos": 42,
+                    "endFilePos": 79,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 47,
+              "startFilePos": 84,
+              "endLine": 3,
+              "endTokenPos": 50,
+              "endFilePos": 88
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 47,
+                "startFilePos": 84,
+                "endLine": 3,
+                "endTokenPos": 47,
+                "endFilePos": 85
+              },
+              "name": "m"
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 49,
+                "startFilePos": 87,
+                "endLine": 3,
+                "endTokenPos": 49,
+                "endFilePos": 87,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 54,
+            "startFilePos": 92,
+            "endLine": 3,
+            "endTokenPos": 54,
+            "endFilePos": 98
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 54,
+              "startFilePos": 92,
+              "endLine": 3,
+              "endTokenPos": 54,
+              "endFilePos": 98
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_literal_dynamic.php.json
+++ b/tests/json-ast/x/php/map_literal_dynamic.php.json
@@ -1,0 +1,754 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "3",
+            "kind": 10
+          },
+          "value": 3
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 3,
+        "endTokenPos": 13,
+        "endFilePos": 20
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 14,
+          "endLine": 3,
+          "endTokenPos": 12,
+          "endFilePos": 19
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 14,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 15
+          },
+          "name": "y"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 19,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 19,
+            "rawValue": "4",
+            "kind": 10
+          },
+          "value": 4
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 15,
+        "startFilePos": 22,
+        "endLine": 4,
+        "endTokenPos": 33,
+        "endFilePos": 49
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 15,
+          "startFilePos": 22,
+          "endLine": 4,
+          "endTokenPos": 32,
+          "endFilePos": 48
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 15,
+            "startFilePos": 22,
+            "endLine": 4,
+            "endTokenPos": 15,
+            "endFilePos": 23
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 19,
+            "startFilePos": 27,
+            "endLine": 4,
+            "endTokenPos": 32,
+            "endFilePos": 48,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 20,
+                "startFilePos": 28,
+                "endLine": 4,
+                "endTokenPos": 24,
+                "endFilePos": 36
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 20,
+                  "startFilePos": 28,
+                  "endLine": 4,
+                  "endTokenPos": 20,
+                  "endFilePos": 30,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 24,
+                  "startFilePos": 35,
+                  "endLine": 4,
+                  "endTokenPos": 24,
+                  "endFilePos": 36
+                },
+                "name": "x"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 27,
+                "startFilePos": 39,
+                "endLine": 4,
+                "endTokenPos": 31,
+                "endFilePos": 47
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 27,
+                  "startFilePos": 39,
+                  "endLine": 4,
+                  "endTokenPos": 27,
+                  "endFilePos": 41,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 31,
+                  "startFilePos": 46,
+                  "endLine": 4,
+                  "endTokenPos": 31,
+                  "endFilePos": 47
+                },
+                "name": "y"
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 35,
+        "startFilePos": 51,
+        "endLine": 5,
+        "endTokenPos": 105,
+        "endFilePos": 190
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_BinaryOp_Concat",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 37,
+            "startFilePos": 56,
+            "endLine": 5,
+            "endTokenPos": 101,
+            "endFilePos": 180
+          },
+          "left": {
+            "nodeType": "Expr_BinaryOp_Concat",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 37,
+              "startFilePos": 56,
+              "endLine": 5,
+              "endTokenPos": 69,
+              "endFilePos": 119
+            },
+            "left": {
+              "nodeType": "Expr_Ternary",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 38,
+                "startFilePos": 57,
+                "endLine": 5,
+                "endTokenPos": 64,
+                "endFilePos": 112
+              },
+              "cond": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 38,
+                  "startFilePos": 57,
+                  "endLine": 5,
+                  "endTokenPos": 44,
+                  "endFilePos": 73
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 38,
+                    "startFilePos": 57,
+                    "endLine": 5,
+                    "endTokenPos": 38,
+                    "endFilePos": 64
+                  },
+                  "name": "is_float"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 40,
+                      "startFilePos": 66,
+                      "endLine": 5,
+                      "endTokenPos": 43,
+                      "endFilePos": 72
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 40,
+                        "startFilePos": 66,
+                        "endLine": 5,
+                        "endTokenPos": 43,
+                        "endFilePos": 72
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 40,
+                          "startFilePos": 66,
+                          "endLine": 5,
+                          "endTokenPos": 40,
+                          "endFilePos": 67
+                        },
+                        "name": "m"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 42,
+                          "startFilePos": 69,
+                          "endLine": 5,
+                          "endTokenPos": 42,
+                          "endFilePos": 71,
+                          "kind": 2,
+                          "rawValue": "\"a\""
+                        },
+                        "value": "a"
+                      }
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "if": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 48,
+                  "startFilePos": 77,
+                  "endLine": 5,
+                  "endTokenPos": 57,
+                  "endFilePos": 102
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 48,
+                    "startFilePos": 77,
+                    "endLine": 5,
+                    "endTokenPos": 48,
+                    "endFilePos": 87
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 50,
+                      "startFilePos": 89,
+                      "endLine": 5,
+                      "endTokenPos": 53,
+                      "endFilePos": 95
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 50,
+                        "startFilePos": 89,
+                        "endLine": 5,
+                        "endTokenPos": 53,
+                        "endFilePos": 95
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 50,
+                          "startFilePos": 89,
+                          "endLine": 5,
+                          "endTokenPos": 50,
+                          "endFilePos": 90
+                        },
+                        "name": "m"
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 52,
+                          "startFilePos": 92,
+                          "endLine": 5,
+                          "endTokenPos": 52,
+                          "endFilePos": 94,
+                          "kind": 2,
+                          "rawValue": "\"a\""
+                        },
+                        "value": "a"
+                      }
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 56,
+                      "startFilePos": 98,
+                      "endLine": 5,
+                      "endTokenPos": 56,
+                      "endFilePos": 101
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 56,
+                        "startFilePos": 98,
+                        "endLine": 5,
+                        "endTokenPos": 56,
+                        "endFilePos": 101,
+                        "rawValue": "1344",
+                        "kind": 10
+                      },
+                      "value": 1344
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "else": {
+                "nodeType": "Expr_ArrayDimFetch",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 61,
+                  "startFilePos": 106,
+                  "endLine": 5,
+                  "endTokenPos": 64,
+                  "endFilePos": 112
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 61,
+                    "startFilePos": 106,
+                    "endLine": 5,
+                    "endTokenPos": 61,
+                    "endFilePos": 107
+                  },
+                  "name": "m"
+                },
+                "dim": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 63,
+                    "startFilePos": 109,
+                    "endLine": 5,
+                    "endTokenPos": 63,
+                    "endFilePos": 111,
+                    "kind": 2,
+                    "rawValue": "\"a\""
+                  },
+                  "value": "a"
+                }
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 69,
+                "startFilePos": 117,
+                "endLine": 5,
+                "endTokenPos": 69,
+                "endFilePos": 119,
+                "kind": 2,
+                "rawValue": "\" \""
+              },
+              "value": " "
+            }
+          },
+          "right": {
+            "nodeType": "Expr_Ternary",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 74,
+              "startFilePos": 124,
+              "endLine": 5,
+              "endTokenPos": 100,
+              "endFilePos": 179
+            },
+            "cond": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 74,
+                "startFilePos": 124,
+                "endLine": 5,
+                "endTokenPos": 80,
+                "endFilePos": 140
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 74,
+                  "startFilePos": 124,
+                  "endLine": 5,
+                  "endTokenPos": 74,
+                  "endFilePos": 131
+                },
+                "name": "is_float"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 76,
+                    "startFilePos": 133,
+                    "endLine": 5,
+                    "endTokenPos": 79,
+                    "endFilePos": 139
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 76,
+                      "startFilePos": 133,
+                      "endLine": 5,
+                      "endTokenPos": 79,
+                      "endFilePos": 139
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 76,
+                        "startFilePos": 133,
+                        "endLine": 5,
+                        "endTokenPos": 76,
+                        "endFilePos": 134
+                      },
+                      "name": "m"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 78,
+                        "startFilePos": 136,
+                        "endLine": 5,
+                        "endTokenPos": 78,
+                        "endFilePos": 138,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    }
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "if": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 84,
+                "startFilePos": 144,
+                "endLine": 5,
+                "endTokenPos": 93,
+                "endFilePos": 169
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 84,
+                  "startFilePos": 144,
+                  "endLine": 5,
+                  "endTokenPos": 84,
+                  "endFilePos": 154
+                },
+                "name": "json_encode"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 86,
+                    "startFilePos": 156,
+                    "endLine": 5,
+                    "endTokenPos": 89,
+                    "endFilePos": 162
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 86,
+                      "startFilePos": 156,
+                      "endLine": 5,
+                      "endTokenPos": 89,
+                      "endFilePos": 162
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 86,
+                        "startFilePos": 156,
+                        "endLine": 5,
+                        "endTokenPos": 86,
+                        "endFilePos": 157
+                      },
+                      "name": "m"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 88,
+                        "startFilePos": 159,
+                        "endLine": 5,
+                        "endTokenPos": 88,
+                        "endFilePos": 161,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    }
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 92,
+                    "startFilePos": 165,
+                    "endLine": 5,
+                    "endTokenPos": 92,
+                    "endFilePos": 168
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 92,
+                      "startFilePos": 165,
+                      "endLine": 5,
+                      "endTokenPos": 92,
+                      "endFilePos": 168,
+                      "rawValue": "1344",
+                      "kind": 10
+                    },
+                    "value": 1344
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "else": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 97,
+                "startFilePos": 173,
+                "endLine": 5,
+                "endTokenPos": 100,
+                "endFilePos": 179
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 97,
+                  "startFilePos": 173,
+                  "endLine": 5,
+                  "endTokenPos": 97,
+                  "endFilePos": 174
+                },
+                "name": "m"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 99,
+                  "startFilePos": 176,
+                  "endLine": 5,
+                  "endTokenPos": 99,
+                  "endFilePos": 178,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              }
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 104,
+            "startFilePos": 183,
+            "endLine": 5,
+            "endTokenPos": 104,
+            "endFilePos": 189
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 104,
+              "startFilePos": 183,
+              "endLine": 5,
+              "endTokenPos": 104,
+              "endFilePos": 189
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_membership.php.json
+++ b/tests/json-ast/x/php/map_membership.php.json
@@ -1,0 +1,442 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 19,
+        "endFilePos": 31
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 18,
+          "endFilePos": 30
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 18,
+            "endFilePos": 30,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 14,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 24,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 29,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 21,
+        "startFilePos": 33,
+        "endLine": 3,
+        "endTokenPos": 43,
+        "endFilePos": 93
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 24,
+            "startFilePos": 39,
+            "endLine": 3,
+            "endTokenPos": 38,
+            "endFilePos": 82
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 24,
+              "startFilePos": 39,
+              "endLine": 3,
+              "endTokenPos": 30,
+              "endFilePos": 63
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 24,
+                "startFilePos": 39,
+                "endLine": 3,
+                "endTokenPos": 24,
+                "endFilePos": 54
+              },
+              "name": "array_key_exists"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 26,
+                  "startFilePos": 56,
+                  "endLine": 3,
+                  "endTokenPos": 26,
+                  "endFilePos": 58
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 26,
+                    "startFilePos": 56,
+                    "endLine": 3,
+                    "endTokenPos": 26,
+                    "endFilePos": 58,
+                    "kind": 2,
+                    "rawValue": "\"a\""
+                  },
+                  "value": "a"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 29,
+                  "startFilePos": 61,
+                  "endLine": 3,
+                  "endTokenPos": 29,
+                  "endFilePos": 62
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 29,
+                    "startFilePos": 61,
+                    "endLine": 3,
+                    "endTokenPos": 29,
+                    "endFilePos": 62
+                  },
+                  "name": "m"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 34,
+              "startFilePos": 67,
+              "endLine": 3,
+              "endTokenPos": 34,
+              "endFilePos": 72,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 38,
+              "startFilePos": 76,
+              "endLine": 3,
+              "endTokenPos": 38,
+              "endFilePos": 82,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 42,
+            "startFilePos": 86,
+            "endLine": 3,
+            "endTokenPos": 42,
+            "endFilePos": 92
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 42,
+              "startFilePos": 86,
+              "endLine": 3,
+              "endTokenPos": 42,
+              "endFilePos": 92
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 45,
+        "startFilePos": 95,
+        "endLine": 4,
+        "endTokenPos": 67,
+        "endFilePos": 155
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 48,
+            "startFilePos": 101,
+            "endLine": 4,
+            "endTokenPos": 62,
+            "endFilePos": 144
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 48,
+              "startFilePos": 101,
+              "endLine": 4,
+              "endTokenPos": 54,
+              "endFilePos": 125
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 48,
+                "startFilePos": 101,
+                "endLine": 4,
+                "endTokenPos": 48,
+                "endFilePos": 116
+              },
+              "name": "array_key_exists"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 50,
+                  "startFilePos": 118,
+                  "endLine": 4,
+                  "endTokenPos": 50,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 50,
+                    "startFilePos": 118,
+                    "endLine": 4,
+                    "endTokenPos": 50,
+                    "endFilePos": 120,
+                    "kind": 2,
+                    "rawValue": "\"c\""
+                  },
+                  "value": "c"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 53,
+                  "startFilePos": 123,
+                  "endLine": 4,
+                  "endTokenPos": 53,
+                  "endFilePos": 124
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 53,
+                    "startFilePos": 123,
+                    "endLine": 4,
+                    "endTokenPos": 53,
+                    "endFilePos": 124
+                  },
+                  "name": "m"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 58,
+              "startFilePos": 129,
+              "endLine": 4,
+              "endTokenPos": 58,
+              "endFilePos": 134,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 62,
+              "startFilePos": 138,
+              "endLine": 4,
+              "endTokenPos": 62,
+              "endFilePos": 144,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 66,
+            "startFilePos": 148,
+            "endLine": 4,
+            "endTokenPos": 66,
+            "endFilePos": 154
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 66,
+              "startFilePos": 148,
+              "endLine": 4,
+              "endTokenPos": 66,
+              "endFilePos": 154
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/map_nested_assign.php.json
+++ b/tests/json-ast/x/php/map_nested_assign.php.json
@@ -1,0 +1,571 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 18,
+        "endFilePos": 41
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 17,
+          "endFilePos": 40
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "data"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 17,
+            "endFilePos": 40,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 16,
+                "endFilePos": 39
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 21,
+                  "kind": 2,
+                  "rawValue": "\"outer\""
+                },
+                "value": "outer"
+              },
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 26,
+                  "endLine": 2,
+                  "endTokenPos": 16,
+                  "endFilePos": 39,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 11,
+                      "startFilePos": 27,
+                      "endLine": 2,
+                      "endTokenPos": 15,
+                      "endFilePos": 38
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 27,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 33,
+                        "kind": 2,
+                        "rawValue": "\"inner\""
+                      },
+                      "value": "inner"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 15,
+                        "startFilePos": 38,
+                        "endLine": 2,
+                        "endTokenPos": 15,
+                        "endFilePos": 38,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 20,
+        "startFilePos": 43,
+        "endLine": 3,
+        "endTokenPos": 31,
+        "endFilePos": 70
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 20,
+          "startFilePos": 43,
+          "endLine": 3,
+          "endTokenPos": 30,
+          "endFilePos": 69
+        },
+        "var": {
+          "nodeType": "Expr_ArrayDimFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 20,
+            "startFilePos": 43,
+            "endLine": 3,
+            "endTokenPos": 26,
+            "endFilePos": 65
+          },
+          "var": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 20,
+              "startFilePos": 43,
+              "endLine": 3,
+              "endTokenPos": 23,
+              "endFilePos": 56
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 20,
+                "startFilePos": 43,
+                "endLine": 3,
+                "endTokenPos": 20,
+                "endFilePos": 47
+              },
+              "name": "data"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 22,
+                "startFilePos": 49,
+                "endLine": 3,
+                "endTokenPos": 22,
+                "endFilePos": 55,
+                "kind": 2,
+                "rawValue": "\"outer\""
+              },
+              "value": "outer"
+            }
+          },
+          "dim": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 25,
+              "startFilePos": 58,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 64,
+              "kind": 2,
+              "rawValue": "\"inner\""
+            },
+            "value": "inner"
+          }
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 30,
+            "startFilePos": 69,
+            "endLine": 3,
+            "endTokenPos": 30,
+            "endFilePos": 69,
+            "rawValue": "2",
+            "kind": 10
+          },
+          "value": 2
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 33,
+        "startFilePos": 72,
+        "endLine": 4,
+        "endTokenPos": 76,
+        "endFilePos": 192
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 36,
+            "startFilePos": 78,
+            "endLine": 4,
+            "endTokenPos": 71,
+            "endFilePos": 181
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 36,
+              "startFilePos": 78,
+              "endLine": 4,
+              "endTokenPos": 45,
+              "endFilePos": 110
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 36,
+                "startFilePos": 78,
+                "endLine": 4,
+                "endTokenPos": 36,
+                "endFilePos": 85
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 38,
+                  "startFilePos": 87,
+                  "endLine": 4,
+                  "endTokenPos": 44,
+                  "endFilePos": 109
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 38,
+                    "startFilePos": 87,
+                    "endLine": 4,
+                    "endTokenPos": 44,
+                    "endFilePos": 109
+                  },
+                  "var": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 38,
+                      "startFilePos": 87,
+                      "endLine": 4,
+                      "endTokenPos": 41,
+                      "endFilePos": 100
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 38,
+                        "startFilePos": 87,
+                        "endLine": 4,
+                        "endTokenPos": 38,
+                        "endFilePos": 91
+                      },
+                      "name": "data"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 40,
+                        "startFilePos": 93,
+                        "endLine": 4,
+                        "endTokenPos": 40,
+                        "endFilePos": 99,
+                        "kind": 2,
+                        "rawValue": "\"outer\""
+                      },
+                      "value": "outer"
+                    }
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 43,
+                      "startFilePos": 102,
+                      "endLine": 4,
+                      "endTokenPos": 43,
+                      "endFilePos": 108,
+                      "kind": 2,
+                      "rawValue": "\"inner\""
+                    },
+                    "value": "inner"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 49,
+              "startFilePos": 114,
+              "endLine": 4,
+              "endTokenPos": 61,
+              "endFilePos": 155
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 49,
+                "startFilePos": 114,
+                "endLine": 4,
+                "endTokenPos": 49,
+                "endFilePos": 124
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 51,
+                  "startFilePos": 126,
+                  "endLine": 4,
+                  "endTokenPos": 57,
+                  "endFilePos": 148
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 51,
+                    "startFilePos": 126,
+                    "endLine": 4,
+                    "endTokenPos": 57,
+                    "endFilePos": 148
+                  },
+                  "var": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 51,
+                      "startFilePos": 126,
+                      "endLine": 4,
+                      "endTokenPos": 54,
+                      "endFilePos": 139
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 51,
+                        "startFilePos": 126,
+                        "endLine": 4,
+                        "endTokenPos": 51,
+                        "endFilePos": 130
+                      },
+                      "name": "data"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 53,
+                        "startFilePos": 132,
+                        "endLine": 4,
+                        "endTokenPos": 53,
+                        "endFilePos": 138,
+                        "kind": 2,
+                        "rawValue": "\"outer\""
+                      },
+                      "value": "outer"
+                    }
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 56,
+                      "startFilePos": 141,
+                      "endLine": 4,
+                      "endTokenPos": 56,
+                      "endFilePos": 147,
+                      "kind": 2,
+                      "rawValue": "\"inner\""
+                    },
+                    "value": "inner"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 60,
+                  "startFilePos": 151,
+                  "endLine": 4,
+                  "endTokenPos": 60,
+                  "endFilePos": 154
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 60,
+                    "startFilePos": 151,
+                    "endLine": 4,
+                    "endTokenPos": 60,
+                    "endFilePos": 154,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 65,
+              "startFilePos": 159,
+              "endLine": 4,
+              "endTokenPos": 71,
+              "endFilePos": 181
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 65,
+                "startFilePos": 159,
+                "endLine": 4,
+                "endTokenPos": 68,
+                "endFilePos": 172
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 65,
+                  "startFilePos": 159,
+                  "endLine": 4,
+                  "endTokenPos": 65,
+                  "endFilePos": 163
+                },
+                "name": "data"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 67,
+                  "startFilePos": 165,
+                  "endLine": 4,
+                  "endTokenPos": 67,
+                  "endFilePos": 171,
+                  "kind": 2,
+                  "rawValue": "\"outer\""
+                },
+                "value": "outer"
+              }
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 70,
+                "startFilePos": 174,
+                "endLine": 4,
+                "endTokenPos": 70,
+                "endFilePos": 180,
+                "kind": 2,
+                "rawValue": "\"inner\""
+              },
+              "value": "inner"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 75,
+            "startFilePos": 185,
+            "endLine": 4,
+            "endTokenPos": 75,
+            "endFilePos": 191
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 75,
+              "startFilePos": 185,
+              "endLine": 4,
+              "endTokenPos": 75,
+              "endFilePos": 191
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/match_expr.php.json
+++ b/tests/json-ast/x/php/match_expr.php.json
@@ -1,0 +1,308 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "2",
+            "kind": 10
+          },
+          "value": 2
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 8,
+        "endTokenPos": 48,
+        "endFilePos": 112
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 14,
+          "endLine": 8,
+          "endTokenPos": 47,
+          "endFilePos": 111
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 14,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 19
+          },
+          "name": "label"
+        },
+        "expr": {
+          "nodeType": "Expr_Match",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 23,
+            "endLine": 8,
+            "endTokenPos": 47,
+            "endFilePos": 111
+          },
+          "cond": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 14,
+              "startFilePos": 29,
+              "endLine": 3,
+              "endTokenPos": 14,
+              "endFilePos": 30
+            },
+            "name": "x"
+          },
+          "arms": [
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 19,
+                "startFilePos": 39,
+                "endLine": 4,
+                "endTokenPos": 23,
+                "endFilePos": 48
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 19,
+                    "startFilePos": 39,
+                    "endLine": 4,
+                    "endTokenPos": 19,
+                    "endFilePos": 39,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 23,
+                  "startFilePos": 44,
+                  "endLine": 4,
+                  "endTokenPos": 23,
+                  "endFilePos": 48,
+                  "kind": 2,
+                  "rawValue": "\"one\""
+                },
+                "value": "one"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 26,
+                "startFilePos": 55,
+                "endLine": 5,
+                "endTokenPos": 30,
+                "endFilePos": 64
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 26,
+                    "startFilePos": 55,
+                    "endLine": 5,
+                    "endTokenPos": 26,
+                    "endFilePos": 55,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 30,
+                  "startFilePos": 60,
+                  "endLine": 5,
+                  "endTokenPos": 30,
+                  "endFilePos": 64,
+                  "kind": 2,
+                  "rawValue": "\"two\""
+                },
+                "value": "two"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 33,
+                "startFilePos": 71,
+                "endLine": 6,
+                "endTokenPos": 37,
+                "endFilePos": 82
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 33,
+                    "startFilePos": 71,
+                    "endLine": 6,
+                    "endTokenPos": 33,
+                    "endFilePos": 71,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 37,
+                  "startFilePos": 76,
+                  "endLine": 6,
+                  "endTokenPos": 37,
+                  "endFilePos": 82,
+                  "kind": 2,
+                  "rawValue": "\"three\""
+                },
+                "value": "three"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 40,
+                "startFilePos": 89,
+                "endLine": 7,
+                "endTokenPos": 44,
+                "endFilePos": 108
+              },
+              "conds": null,
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 44,
+                  "startFilePos": 100,
+                  "endLine": 7,
+                  "endTokenPos": 44,
+                  "endFilePos": 108,
+                  "kind": 2,
+                  "rawValue": "\"unknown\""
+                },
+                "value": "unknown"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 9,
+        "startTokenPos": 50,
+        "startFilePos": 114,
+        "endLine": 9,
+        "endTokenPos": 56,
+        "endFilePos": 134
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 52,
+            "startFilePos": 119,
+            "endLine": 9,
+            "endTokenPos": 52,
+            "endFilePos": 124
+          },
+          "name": "label"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 55,
+            "startFilePos": 127,
+            "endLine": 9,
+            "endTokenPos": 55,
+            "endFilePos": 133
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 55,
+              "startFilePos": 127,
+              "endLine": 9,
+              "endTokenPos": 55,
+              "endFilePos": 133
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/match_full.php.json
+++ b/tests/json-ast/x/php/match_full.php.json
@@ -1,0 +1,1704 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "2",
+            "kind": 10
+          },
+          "value": 2
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 8,
+        "endTokenPos": 48,
+        "endFilePos": 112
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 14,
+          "endLine": 8,
+          "endTokenPos": 47,
+          "endFilePos": 111
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 14,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 19
+          },
+          "name": "label"
+        },
+        "expr": {
+          "nodeType": "Expr_Match",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 23,
+            "endLine": 8,
+            "endTokenPos": 47,
+            "endFilePos": 111
+          },
+          "cond": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 14,
+              "startFilePos": 29,
+              "endLine": 3,
+              "endTokenPos": 14,
+              "endFilePos": 30
+            },
+            "name": "x"
+          },
+          "arms": [
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 19,
+                "startFilePos": 39,
+                "endLine": 4,
+                "endTokenPos": 23,
+                "endFilePos": 48
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 19,
+                    "startFilePos": 39,
+                    "endLine": 4,
+                    "endTokenPos": 19,
+                    "endFilePos": 39,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 23,
+                  "startFilePos": 44,
+                  "endLine": 4,
+                  "endTokenPos": 23,
+                  "endFilePos": 48,
+                  "kind": 2,
+                  "rawValue": "\"one\""
+                },
+                "value": "one"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 26,
+                "startFilePos": 55,
+                "endLine": 5,
+                "endTokenPos": 30,
+                "endFilePos": 64
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 26,
+                    "startFilePos": 55,
+                    "endLine": 5,
+                    "endTokenPos": 26,
+                    "endFilePos": 55,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 30,
+                  "startFilePos": 60,
+                  "endLine": 5,
+                  "endTokenPos": 30,
+                  "endFilePos": 64,
+                  "kind": 2,
+                  "rawValue": "\"two\""
+                },
+                "value": "two"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 33,
+                "startFilePos": 71,
+                "endLine": 6,
+                "endTokenPos": 37,
+                "endFilePos": 82
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 33,
+                    "startFilePos": 71,
+                    "endLine": 6,
+                    "endTokenPos": 33,
+                    "endFilePos": 71,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 37,
+                  "startFilePos": 76,
+                  "endLine": 6,
+                  "endTokenPos": 37,
+                  "endFilePos": 82,
+                  "kind": 2,
+                  "rawValue": "\"three\""
+                },
+                "value": "three"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 40,
+                "startFilePos": 89,
+                "endLine": 7,
+                "endTokenPos": 44,
+                "endFilePos": 108
+              },
+              "conds": null,
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 44,
+                  "startFilePos": 100,
+                  "endLine": 7,
+                  "endTokenPos": 44,
+                  "endFilePos": 108,
+                  "kind": 2,
+                  "rawValue": "\"unknown\""
+                },
+                "value": "unknown"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 9,
+        "startTokenPos": 50,
+        "startFilePos": 114,
+        "endLine": 9,
+        "endTokenPos": 56,
+        "endFilePos": 134
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 52,
+            "startFilePos": 119,
+            "endLine": 9,
+            "endTokenPos": 52,
+            "endFilePos": 124
+          },
+          "name": "label"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 55,
+            "startFilePos": 127,
+            "endLine": 9,
+            "endTokenPos": 55,
+            "endFilePos": 133
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 55,
+              "startFilePos": 127,
+              "endLine": 9,
+              "endTokenPos": 55,
+              "endFilePos": 133
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 58,
+        "startFilePos": 136,
+        "endLine": 10,
+        "endTokenPos": 63,
+        "endFilePos": 148
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 10,
+          "startTokenPos": 58,
+          "startFilePos": 136,
+          "endLine": 10,
+          "endTokenPos": 62,
+          "endFilePos": 147
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 58,
+            "startFilePos": 136,
+            "endLine": 10,
+            "endTokenPos": 58,
+            "endFilePos": 139
+          },
+          "name": "day"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 62,
+            "startFilePos": 143,
+            "endLine": 10,
+            "endTokenPos": 62,
+            "endFilePos": 147,
+            "kind": 2,
+            "rawValue": "\"sun\""
+          },
+          "value": "sun"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 11,
+        "startTokenPos": 65,
+        "startFilePos": 150,
+        "endLine": 16,
+        "endTokenPos": 105,
+        "endFilePos": 268
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 11,
+          "startTokenPos": 65,
+          "startFilePos": 150,
+          "endLine": 16,
+          "endTokenPos": 104,
+          "endFilePos": 267
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 65,
+            "startFilePos": 150,
+            "endLine": 11,
+            "endTokenPos": 65,
+            "endFilePos": 154
+          },
+          "name": "mood"
+        },
+        "expr": {
+          "nodeType": "Expr_Match",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 69,
+            "startFilePos": 158,
+            "endLine": 16,
+            "endTokenPos": 104,
+            "endFilePos": 267
+          },
+          "cond": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 71,
+              "startFilePos": 164,
+              "endLine": 11,
+              "endTokenPos": 71,
+              "endFilePos": 167
+            },
+            "name": "day"
+          },
+          "arms": [
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 76,
+                "startFilePos": 176,
+                "endLine": 12,
+                "endTokenPos": 80,
+                "endFilePos": 191
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 76,
+                    "startFilePos": 176,
+                    "endLine": 12,
+                    "endTokenPos": 76,
+                    "endFilePos": 180,
+                    "kind": 2,
+                    "rawValue": "\"mon\""
+                  },
+                  "value": "mon"
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 80,
+                  "startFilePos": 185,
+                  "endLine": 12,
+                  "endTokenPos": 80,
+                  "endFilePos": 191,
+                  "kind": 2,
+                  "rawValue": "\"tired\""
+                },
+                "value": "tired"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 83,
+                "startFilePos": 198,
+                "endLine": 13,
+                "endTokenPos": 87,
+                "endFilePos": 215
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 13,
+                    "startTokenPos": 83,
+                    "startFilePos": 198,
+                    "endLine": 13,
+                    "endTokenPos": 83,
+                    "endFilePos": 202,
+                    "kind": 2,
+                    "rawValue": "\"fri\""
+                  },
+                  "value": "fri"
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 87,
+                  "startFilePos": 207,
+                  "endLine": 13,
+                  "endTokenPos": 87,
+                  "endFilePos": 215,
+                  "kind": 2,
+                  "rawValue": "\"excited\""
+                },
+                "value": "excited"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 90,
+                "startFilePos": 222,
+                "endLine": 14,
+                "endTokenPos": 94,
+                "endFilePos": 239
+              },
+              "conds": [
+                {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 90,
+                    "startFilePos": 222,
+                    "endLine": 14,
+                    "endTokenPos": 90,
+                    "endFilePos": 226,
+                    "kind": 2,
+                    "rawValue": "\"sun\""
+                  },
+                  "value": "sun"
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 94,
+                  "startFilePos": 231,
+                  "endLine": 14,
+                  "endTokenPos": 94,
+                  "endFilePos": 239,
+                  "kind": 2,
+                  "rawValue": "\"relaxed\""
+                },
+                "value": "relaxed"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 97,
+                "startFilePos": 246,
+                "endLine": 15,
+                "endTokenPos": 101,
+                "endFilePos": 264
+              },
+              "conds": null,
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 101,
+                  "startFilePos": 257,
+                  "endLine": 15,
+                  "endTokenPos": 101,
+                  "endFilePos": 264,
+                  "kind": 2,
+                  "rawValue": "\"normal\""
+                },
+                "value": "normal"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 17,
+        "startTokenPos": 107,
+        "startFilePos": 270,
+        "endLine": 17,
+        "endTokenPos": 113,
+        "endFilePos": 289
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 17,
+            "startTokenPos": 109,
+            "startFilePos": 275,
+            "endLine": 17,
+            "endTokenPos": 109,
+            "endFilePos": 279
+          },
+          "name": "mood"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 17,
+            "startTokenPos": 112,
+            "startFilePos": 282,
+            "endLine": 17,
+            "endTokenPos": 112,
+            "endFilePos": 288
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 112,
+              "startFilePos": 282,
+              "endLine": 17,
+              "endTokenPos": 112,
+              "endFilePos": 288
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 18,
+        "startTokenPos": 115,
+        "startFilePos": 291,
+        "endLine": 18,
+        "endTokenPos": 120,
+        "endFilePos": 301
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 18,
+          "startTokenPos": 115,
+          "startFilePos": 291,
+          "endLine": 18,
+          "endTokenPos": 119,
+          "endFilePos": 300
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 115,
+            "startFilePos": 291,
+            "endLine": 18,
+            "endTokenPos": 115,
+            "endFilePos": 293
+          },
+          "name": "ok"
+        },
+        "expr": {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 119,
+            "startFilePos": 297,
+            "endLine": 18,
+            "endTokenPos": 119,
+            "endFilePos": 300
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 18,
+              "startTokenPos": 119,
+              "startFilePos": 297,
+              "endLine": 18,
+              "endTokenPos": 119,
+              "endFilePos": 300
+            },
+            "name": "true"
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 19,
+        "startTokenPos": 122,
+        "startFilePos": 303,
+        "endLine": 22,
+        "endTokenPos": 148,
+        "endFilePos": 375
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 19,
+          "startTokenPos": 122,
+          "startFilePos": 303,
+          "endLine": 22,
+          "endTokenPos": 147,
+          "endFilePos": 374
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 122,
+            "startFilePos": 303,
+            "endLine": 19,
+            "endTokenPos": 122,
+            "endFilePos": 309
+          },
+          "name": "status"
+        },
+        "expr": {
+          "nodeType": "Expr_Match",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 126,
+            "startFilePos": 313,
+            "endLine": 22,
+            "endTokenPos": 147,
+            "endFilePos": 374
+          },
+          "cond": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 19,
+              "startTokenPos": 128,
+              "startFilePos": 319,
+              "endLine": 19,
+              "endTokenPos": 128,
+              "endFilePos": 321
+            },
+            "name": "ok"
+          },
+          "arms": [
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 20,
+                "startTokenPos": 133,
+                "startFilePos": 330,
+                "endLine": 20,
+                "endTokenPos": 137,
+                "endFilePos": 348
+              },
+              "conds": [
+                {
+                  "nodeType": "Expr_ConstFetch",
+                  "attributes": {
+                    "startLine": 20,
+                    "startTokenPos": 133,
+                    "startFilePos": 330,
+                    "endLine": 20,
+                    "endTokenPos": 133,
+                    "endFilePos": 333
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 20,
+                      "startTokenPos": 133,
+                      "startFilePos": 330,
+                      "endLine": 20,
+                      "endTokenPos": 133,
+                      "endFilePos": 333
+                    },
+                    "name": "true"
+                  }
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 20,
+                  "startTokenPos": 137,
+                  "startFilePos": 338,
+                  "endLine": 20,
+                  "endTokenPos": 137,
+                  "endFilePos": 348,
+                  "kind": 2,
+                  "rawValue": "\"confirmed\""
+                },
+                "value": "confirmed"
+              }
+            },
+            {
+              "nodeType": "MatchArm",
+              "attributes": {
+                "startLine": 21,
+                "startTokenPos": 140,
+                "startFilePos": 355,
+                "endLine": 21,
+                "endTokenPos": 144,
+                "endFilePos": 371
+              },
+              "conds": [
+                {
+                  "nodeType": "Expr_ConstFetch",
+                  "attributes": {
+                    "startLine": 21,
+                    "startTokenPos": 140,
+                    "startFilePos": 355,
+                    "endLine": 21,
+                    "endTokenPos": 140,
+                    "endFilePos": 359
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 21,
+                      "startTokenPos": 140,
+                      "startFilePos": 355,
+                      "endLine": 21,
+                      "endTokenPos": 140,
+                      "endFilePos": 359
+                    },
+                    "name": "false"
+                  }
+                }
+              ],
+              "body": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 21,
+                  "startTokenPos": 144,
+                  "startFilePos": 364,
+                  "endLine": 21,
+                  "endTokenPos": 144,
+                  "endFilePos": 371,
+                  "kind": 2,
+                  "rawValue": "\"denied\""
+                },
+                "value": "denied"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 23,
+        "startTokenPos": 150,
+        "startFilePos": 377,
+        "endLine": 23,
+        "endTokenPos": 156,
+        "endFilePos": 398
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 23,
+            "startTokenPos": 152,
+            "startFilePos": 382,
+            "endLine": 23,
+            "endTokenPos": 152,
+            "endFilePos": 388
+          },
+          "name": "status"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 23,
+            "startTokenPos": 155,
+            "startFilePos": 391,
+            "endLine": 23,
+            "endTokenPos": 155,
+            "endFilePos": 397
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 23,
+              "startTokenPos": 155,
+              "startFilePos": 391,
+              "endLine": 23,
+              "endTokenPos": 155,
+              "endFilePos": 397
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 24,
+        "startTokenPos": 158,
+        "startFilePos": 400,
+        "endLine": 30,
+        "endTokenPos": 200,
+        "endFilePos": 504
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 24,
+          "startTokenPos": 160,
+          "startFilePos": 409,
+          "endLine": 24,
+          "endTokenPos": 160,
+          "endFilePos": 416
+        },
+        "name": "classify"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 24,
+            "startTokenPos": 162,
+            "startFilePos": 418,
+            "endLine": 24,
+            "endTokenPos": 162,
+            "endFilePos": 419
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 24,
+              "startTokenPos": 162,
+              "startFilePos": 418,
+              "endLine": 24,
+              "endTokenPos": 162,
+              "endFilePos": 419
+            },
+            "name": "n"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 25,
+            "startTokenPos": 167,
+            "startFilePos": 426,
+            "endLine": 29,
+            "endTokenPos": 198,
+            "endFilePos": 502
+          },
+          "expr": {
+            "nodeType": "Expr_Match",
+            "attributes": {
+              "startLine": 25,
+              "startTokenPos": 169,
+              "startFilePos": 433,
+              "endLine": 29,
+              "endTokenPos": 197,
+              "endFilePos": 501
+            },
+            "cond": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 25,
+                "startTokenPos": 171,
+                "startFilePos": 439,
+                "endLine": 25,
+                "endTokenPos": 171,
+                "endFilePos": 440
+              },
+              "name": "n"
+            },
+            "arms": [
+              {
+                "nodeType": "MatchArm",
+                "attributes": {
+                  "startLine": 26,
+                  "startTokenPos": 176,
+                  "startFilePos": 449,
+                  "endLine": 26,
+                  "endTokenPos": 180,
+                  "endFilePos": 459
+                },
+                "conds": [
+                  {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 26,
+                      "startTokenPos": 176,
+                      "startFilePos": 449,
+                      "endLine": 26,
+                      "endTokenPos": 176,
+                      "endFilePos": 449,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  }
+                ],
+                "body": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 26,
+                    "startTokenPos": 180,
+                    "startFilePos": 454,
+                    "endLine": 26,
+                    "endTokenPos": 180,
+                    "endFilePos": 459,
+                    "kind": 2,
+                    "rawValue": "\"zero\""
+                  },
+                  "value": "zero"
+                }
+              },
+              {
+                "nodeType": "MatchArm",
+                "attributes": {
+                  "startLine": 27,
+                  "startTokenPos": 183,
+                  "startFilePos": 466,
+                  "endLine": 27,
+                  "endTokenPos": 187,
+                  "endFilePos": 475
+                },
+                "conds": [
+                  {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 27,
+                      "startTokenPos": 183,
+                      "startFilePos": 466,
+                      "endLine": 27,
+                      "endTokenPos": 183,
+                      "endFilePos": 466,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                ],
+                "body": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 27,
+                    "startTokenPos": 187,
+                    "startFilePos": 471,
+                    "endLine": 27,
+                    "endTokenPos": 187,
+                    "endFilePos": 475,
+                    "kind": 2,
+                    "rawValue": "\"one\""
+                  },
+                  "value": "one"
+                }
+              },
+              {
+                "nodeType": "MatchArm",
+                "attributes": {
+                  "startLine": 28,
+                  "startTokenPos": 190,
+                  "startFilePos": 482,
+                  "endLine": 28,
+                  "endTokenPos": 194,
+                  "endFilePos": 498
+                },
+                "conds": null,
+                "body": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 28,
+                    "startTokenPos": 194,
+                    "startFilePos": 493,
+                    "endLine": 28,
+                    "endTokenPos": 194,
+                    "endFilePos": 498,
+                    "kind": 2,
+                    "rawValue": "\"many\""
+                  },
+                  "value": "many"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 31,
+        "startTokenPos": 202,
+        "startFilePos": 506,
+        "endLine": 31,
+        "endTokenPos": 236,
+        "endFilePos": 590
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 31,
+            "startTokenPos": 205,
+            "startFilePos": 512,
+            "endLine": 31,
+            "endTokenPos": 231,
+            "endFilePos": 579
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 31,
+              "startTokenPos": 205,
+              "startFilePos": 512,
+              "endLine": 31,
+              "endTokenPos": 211,
+              "endFilePos": 532
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 31,
+                "startTokenPos": 205,
+                "startFilePos": 512,
+                "endLine": 31,
+                "endTokenPos": 205,
+                "endFilePos": 519
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 207,
+                  "startFilePos": 521,
+                  "endLine": 31,
+                  "endTokenPos": 210,
+                  "endFilePos": 531
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 31,
+                    "startTokenPos": 207,
+                    "startFilePos": 521,
+                    "endLine": 31,
+                    "endTokenPos": 210,
+                    "endFilePos": 531
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 31,
+                      "startTokenPos": 207,
+                      "startFilePos": 521,
+                      "endLine": 31,
+                      "endTokenPos": 207,
+                      "endFilePos": 528
+                    },
+                    "name": "classify"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 31,
+                        "startTokenPos": 209,
+                        "startFilePos": 530,
+                        "endLine": 31,
+                        "endTokenPos": 209,
+                        "endFilePos": 530
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 31,
+                          "startTokenPos": 209,
+                          "startFilePos": 530,
+                          "endLine": 31,
+                          "endTokenPos": 209,
+                          "endFilePos": 530,
+                          "rawValue": "0",
+                          "kind": 10
+                        },
+                        "value": 0
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 31,
+              "startTokenPos": 215,
+              "startFilePos": 536,
+              "endLine": 31,
+              "endTokenPos": 224,
+              "endFilePos": 565
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 31,
+                "startTokenPos": 215,
+                "startFilePos": 536,
+                "endLine": 31,
+                "endTokenPos": 215,
+                "endFilePos": 546
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 217,
+                  "startFilePos": 548,
+                  "endLine": 31,
+                  "endTokenPos": 220,
+                  "endFilePos": 558
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 31,
+                    "startTokenPos": 217,
+                    "startFilePos": 548,
+                    "endLine": 31,
+                    "endTokenPos": 220,
+                    "endFilePos": 558
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 31,
+                      "startTokenPos": 217,
+                      "startFilePos": 548,
+                      "endLine": 31,
+                      "endTokenPos": 217,
+                      "endFilePos": 555
+                    },
+                    "name": "classify"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 31,
+                        "startTokenPos": 219,
+                        "startFilePos": 557,
+                        "endLine": 31,
+                        "endTokenPos": 219,
+                        "endFilePos": 557
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 31,
+                          "startTokenPos": 219,
+                          "startFilePos": 557,
+                          "endLine": 31,
+                          "endTokenPos": 219,
+                          "endFilePos": 557,
+                          "rawValue": "0",
+                          "kind": 10
+                        },
+                        "value": 0
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 223,
+                  "startFilePos": 561,
+                  "endLine": 31,
+                  "endTokenPos": 223,
+                  "endFilePos": 564
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 31,
+                    "startTokenPos": 223,
+                    "startFilePos": 561,
+                    "endLine": 31,
+                    "endTokenPos": 223,
+                    "endFilePos": 564,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 31,
+              "startTokenPos": 228,
+              "startFilePos": 569,
+              "endLine": 31,
+              "endTokenPos": 231,
+              "endFilePos": 579
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 31,
+                "startTokenPos": 228,
+                "startFilePos": 569,
+                "endLine": 31,
+                "endTokenPos": 228,
+                "endFilePos": 576
+              },
+              "name": "classify"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 31,
+                  "startTokenPos": 230,
+                  "startFilePos": 578,
+                  "endLine": 31,
+                  "endTokenPos": 230,
+                  "endFilePos": 578
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 31,
+                    "startTokenPos": 230,
+                    "startFilePos": 578,
+                    "endLine": 31,
+                    "endTokenPos": 230,
+                    "endFilePos": 578,
+                    "rawValue": "0",
+                    "kind": 10
+                  },
+                  "value": 0
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 31,
+            "startTokenPos": 235,
+            "startFilePos": 583,
+            "endLine": 31,
+            "endTokenPos": 235,
+            "endFilePos": 589
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 31,
+              "startTokenPos": 235,
+              "startFilePos": 583,
+              "endLine": 31,
+              "endTokenPos": 235,
+              "endFilePos": 589
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 32,
+        "startTokenPos": 238,
+        "startFilePos": 592,
+        "endLine": 32,
+        "endTokenPos": 272,
+        "endFilePos": 676
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 241,
+            "startFilePos": 598,
+            "endLine": 32,
+            "endTokenPos": 267,
+            "endFilePos": 665
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 241,
+              "startFilePos": 598,
+              "endLine": 32,
+              "endTokenPos": 247,
+              "endFilePos": 618
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 241,
+                "startFilePos": 598,
+                "endLine": 32,
+                "endTokenPos": 241,
+                "endFilePos": 605
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 243,
+                  "startFilePos": 607,
+                  "endLine": 32,
+                  "endTokenPos": 246,
+                  "endFilePos": 617
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 32,
+                    "startTokenPos": 243,
+                    "startFilePos": 607,
+                    "endLine": 32,
+                    "endTokenPos": 246,
+                    "endFilePos": 617
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 243,
+                      "startFilePos": 607,
+                      "endLine": 32,
+                      "endTokenPos": 243,
+                      "endFilePos": 614
+                    },
+                    "name": "classify"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 245,
+                        "startFilePos": 616,
+                        "endLine": 32,
+                        "endTokenPos": 245,
+                        "endFilePos": 616
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 32,
+                          "startTokenPos": 245,
+                          "startFilePos": 616,
+                          "endLine": 32,
+                          "endTokenPos": 245,
+                          "endFilePos": 616,
+                          "rawValue": "5",
+                          "kind": 10
+                        },
+                        "value": 5
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 251,
+              "startFilePos": 622,
+              "endLine": 32,
+              "endTokenPos": 260,
+              "endFilePos": 651
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 251,
+                "startFilePos": 622,
+                "endLine": 32,
+                "endTokenPos": 251,
+                "endFilePos": 632
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 253,
+                  "startFilePos": 634,
+                  "endLine": 32,
+                  "endTokenPos": 256,
+                  "endFilePos": 644
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 32,
+                    "startTokenPos": 253,
+                    "startFilePos": 634,
+                    "endLine": 32,
+                    "endTokenPos": 256,
+                    "endFilePos": 644
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 32,
+                      "startTokenPos": 253,
+                      "startFilePos": 634,
+                      "endLine": 32,
+                      "endTokenPos": 253,
+                      "endFilePos": 641
+                    },
+                    "name": "classify"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 32,
+                        "startTokenPos": 255,
+                        "startFilePos": 643,
+                        "endLine": 32,
+                        "endTokenPos": 255,
+                        "endFilePos": 643
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 32,
+                          "startTokenPos": 255,
+                          "startFilePos": 643,
+                          "endLine": 32,
+                          "endTokenPos": 255,
+                          "endFilePos": 643,
+                          "rawValue": "5",
+                          "kind": 10
+                        },
+                        "value": 5
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 259,
+                  "startFilePos": 647,
+                  "endLine": 32,
+                  "endTokenPos": 259,
+                  "endFilePos": 650
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 32,
+                    "startTokenPos": 259,
+                    "startFilePos": 647,
+                    "endLine": 32,
+                    "endTokenPos": 259,
+                    "endFilePos": 650,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 264,
+              "startFilePos": 655,
+              "endLine": 32,
+              "endTokenPos": 267,
+              "endFilePos": 665
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 32,
+                "startTokenPos": 264,
+                "startFilePos": 655,
+                "endLine": 32,
+                "endTokenPos": 264,
+                "endFilePos": 662
+              },
+              "name": "classify"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 32,
+                  "startTokenPos": 266,
+                  "startFilePos": 664,
+                  "endLine": 32,
+                  "endTokenPos": 266,
+                  "endFilePos": 664
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 32,
+                    "startTokenPos": 266,
+                    "startFilePos": 664,
+                    "endLine": 32,
+                    "endTokenPos": 266,
+                    "endFilePos": 664,
+                    "rawValue": "5",
+                    "kind": 10
+                  },
+                  "value": 5
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 271,
+            "startFilePos": 669,
+            "endLine": 32,
+            "endTokenPos": 271,
+            "endFilePos": 675
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 271,
+              "startFilePos": 669,
+              "endLine": 32,
+              "endTokenPos": 271,
+              "endFilePos": 675
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/math_ops.php.json
+++ b/tests/json-ast/x/php/math_ops.php.json
@@ -1,0 +1,814 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 38,
+        "endFilePos": 72
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 33,
+            "endFilePos": 61
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 11,
+              "endFilePos": 26
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 25
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 10,
+                    "endFilePos": 25
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 21,
+                      "rawValue": "6",
+                      "kind": 10
+                    },
+                    "value": 6
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 10,
+                      "startFilePos": 25,
+                      "endLine": 2,
+                      "endTokenPos": 10,
+                      "endFilePos": 25,
+                      "rawValue": "7",
+                      "kind": 10
+                    },
+                    "value": 7
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 15,
+              "startFilePos": 30,
+              "endLine": 2,
+              "endTokenPos": 25,
+              "endFilePos": 53
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 15,
+                "startFilePos": 30,
+                "endLine": 2,
+                "endTokenPos": 15,
+                "endFilePos": 40
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 42,
+                  "endLine": 2,
+                  "endTokenPos": 21,
+                  "endFilePos": 46
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mul",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 17,
+                    "startFilePos": 42,
+                    "endLine": 2,
+                    "endTokenPos": 21,
+                    "endFilePos": 46
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 17,
+                      "startFilePos": 42,
+                      "endLine": 2,
+                      "endTokenPos": 17,
+                      "endFilePos": 42,
+                      "rawValue": "6",
+                      "kind": 10
+                    },
+                    "value": 6
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 46,
+                      "endLine": 2,
+                      "endTokenPos": 21,
+                      "endFilePos": 46,
+                      "rawValue": "7",
+                      "kind": 10
+                    },
+                    "value": 7
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 49,
+                  "endLine": 2,
+                  "endTokenPos": 24,
+                  "endFilePos": 52
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 24,
+                    "startFilePos": 49,
+                    "endLine": 2,
+                    "endTokenPos": 24,
+                    "endFilePos": 52,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Mul",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 29,
+              "startFilePos": 57,
+              "endLine": 2,
+              "endTokenPos": 33,
+              "endFilePos": 61
+            },
+            "left": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 29,
+                "startFilePos": 57,
+                "endLine": 2,
+                "endTokenPos": 29,
+                "endFilePos": 57,
+                "rawValue": "6",
+                "kind": 10
+              },
+              "value": 6
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 33,
+                "startFilePos": 61,
+                "endLine": 2,
+                "endTokenPos": 33,
+                "endFilePos": 61,
+                "rawValue": "7",
+                "kind": 10
+              },
+              "value": 7
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 37,
+            "startFilePos": 65,
+            "endLine": 2,
+            "endTokenPos": 37,
+            "endFilePos": 71
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 37,
+              "startFilePos": 65,
+              "endLine": 2,
+              "endTokenPos": 37,
+              "endFilePos": 71
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 40,
+        "startFilePos": 74,
+        "endLine": 3,
+        "endTokenPos": 77,
+        "endFilePos": 140
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 43,
+            "startFilePos": 80,
+            "endLine": 3,
+            "endTokenPos": 72,
+            "endFilePos": 129
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 43,
+              "startFilePos": 80,
+              "endLine": 3,
+              "endTokenPos": 50,
+              "endFilePos": 94
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 43,
+                "startFilePos": 80,
+                "endLine": 3,
+                "endTokenPos": 43,
+                "endFilePos": 87
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 45,
+                  "startFilePos": 89,
+                  "endLine": 3,
+                  "endTokenPos": 49,
+                  "endFilePos": 93
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Div",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 45,
+                    "startFilePos": 89,
+                    "endLine": 3,
+                    "endTokenPos": 49,
+                    "endFilePos": 93
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 45,
+                      "startFilePos": 89,
+                      "endLine": 3,
+                      "endTokenPos": 45,
+                      "endFilePos": 89,
+                      "rawValue": "7",
+                      "kind": 10
+                    },
+                    "value": 7
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 49,
+                      "startFilePos": 93,
+                      "endLine": 3,
+                      "endTokenPos": 49,
+                      "endFilePos": 93,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 54,
+              "startFilePos": 98,
+              "endLine": 3,
+              "endTokenPos": 64,
+              "endFilePos": 121
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 54,
+                "startFilePos": 98,
+                "endLine": 3,
+                "endTokenPos": 54,
+                "endFilePos": 108
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 56,
+                  "startFilePos": 110,
+                  "endLine": 3,
+                  "endTokenPos": 60,
+                  "endFilePos": 114
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Div",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 56,
+                    "startFilePos": 110,
+                    "endLine": 3,
+                    "endTokenPos": 60,
+                    "endFilePos": 114
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 56,
+                      "startFilePos": 110,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 110,
+                      "rawValue": "7",
+                      "kind": 10
+                    },
+                    "value": 7
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 60,
+                      "startFilePos": 114,
+                      "endLine": 3,
+                      "endTokenPos": 60,
+                      "endFilePos": 114,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 63,
+                  "startFilePos": 117,
+                  "endLine": 3,
+                  "endTokenPos": 63,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 63,
+                    "startFilePos": 117,
+                    "endLine": 3,
+                    "endTokenPos": 63,
+                    "endFilePos": 120,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Div",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 68,
+              "startFilePos": 125,
+              "endLine": 3,
+              "endTokenPos": 72,
+              "endFilePos": 129
+            },
+            "left": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 68,
+                "startFilePos": 125,
+                "endLine": 3,
+                "endTokenPos": 68,
+                "endFilePos": 125,
+                "rawValue": "7",
+                "kind": 10
+              },
+              "value": 7
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 72,
+                "startFilePos": 129,
+                "endLine": 3,
+                "endTokenPos": 72,
+                "endFilePos": 129,
+                "rawValue": "2",
+                "kind": 10
+              },
+              "value": 2
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 76,
+            "startFilePos": 133,
+            "endLine": 3,
+            "endTokenPos": 76,
+            "endFilePos": 139
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 76,
+              "startFilePos": 133,
+              "endLine": 3,
+              "endTokenPos": 76,
+              "endFilePos": 139
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 79,
+        "startFilePos": 142,
+        "endLine": 4,
+        "endTokenPos": 116,
+        "endFilePos": 208
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 82,
+            "startFilePos": 148,
+            "endLine": 4,
+            "endTokenPos": 111,
+            "endFilePos": 197
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 82,
+              "startFilePos": 148,
+              "endLine": 4,
+              "endTokenPos": 89,
+              "endFilePos": 162
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 82,
+                "startFilePos": 148,
+                "endLine": 4,
+                "endTokenPos": 82,
+                "endFilePos": 155
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 84,
+                  "startFilePos": 157,
+                  "endLine": 4,
+                  "endTokenPos": 88,
+                  "endFilePos": 161
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mod",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 84,
+                    "startFilePos": 157,
+                    "endLine": 4,
+                    "endTokenPos": 88,
+                    "endFilePos": 161
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 84,
+                      "startFilePos": 157,
+                      "endLine": 4,
+                      "endTokenPos": 84,
+                      "endFilePos": 157,
+                      "rawValue": "7",
+                      "kind": 10
+                    },
+                    "value": 7
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 88,
+                      "startFilePos": 161,
+                      "endLine": 4,
+                      "endTokenPos": 88,
+                      "endFilePos": 161,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 93,
+              "startFilePos": 166,
+              "endLine": 4,
+              "endTokenPos": 103,
+              "endFilePos": 189
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 93,
+                "startFilePos": 166,
+                "endLine": 4,
+                "endTokenPos": 93,
+                "endFilePos": 176
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 95,
+                  "startFilePos": 178,
+                  "endLine": 4,
+                  "endTokenPos": 99,
+                  "endFilePos": 182
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Mod",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 95,
+                    "startFilePos": 178,
+                    "endLine": 4,
+                    "endTokenPos": 99,
+                    "endFilePos": 182
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 95,
+                      "startFilePos": 178,
+                      "endLine": 4,
+                      "endTokenPos": 95,
+                      "endFilePos": 178,
+                      "rawValue": "7",
+                      "kind": 10
+                    },
+                    "value": 7
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 99,
+                      "startFilePos": 182,
+                      "endLine": 4,
+                      "endTokenPos": 99,
+                      "endFilePos": 182,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 102,
+                  "startFilePos": 185,
+                  "endLine": 4,
+                  "endTokenPos": 102,
+                  "endFilePos": 188
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 102,
+                    "startFilePos": 185,
+                    "endLine": 4,
+                    "endTokenPos": 102,
+                    "endFilePos": 188,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Mod",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 107,
+              "startFilePos": 193,
+              "endLine": 4,
+              "endTokenPos": 111,
+              "endFilePos": 197
+            },
+            "left": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 107,
+                "startFilePos": 193,
+                "endLine": 4,
+                "endTokenPos": 107,
+                "endFilePos": 193,
+                "rawValue": "7",
+                "kind": 10
+              },
+              "value": 7
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 111,
+                "startFilePos": 197,
+                "endLine": 4,
+                "endTokenPos": 111,
+                "endFilePos": 197,
+                "rawValue": "2",
+                "kind": 10
+              },
+              "value": 2
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 115,
+            "startFilePos": 201,
+            "endLine": 4,
+            "endTokenPos": 115,
+            "endFilePos": 207
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 115,
+              "startFilePos": 201,
+              "endLine": 4,
+              "endTokenPos": 115,
+              "endFilePos": 207
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/membership.php.json
+++ b/tests/json-ast/x/php/membership.php.json
@@ -1,0 +1,444 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 23
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 22
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "nums"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 22,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 21,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 21
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 21,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 25,
+        "endLine": 3,
+        "endTokenPos": 38,
+        "endFilePos": 78
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 19,
+            "startFilePos": 31,
+            "endLine": 3,
+            "endTokenPos": 33,
+            "endFilePos": 67
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 19,
+              "startFilePos": 31,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 48
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 19,
+                "startFilePos": 31,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 38
+              },
+              "name": "in_array"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 21,
+                  "startFilePos": 40,
+                  "endLine": 3,
+                  "endTokenPos": 21,
+                  "endFilePos": 40
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 21,
+                    "startFilePos": 40,
+                    "endLine": 3,
+                    "endTokenPos": 21,
+                    "endFilePos": 40,
+                    "rawValue": "2",
+                    "kind": 10
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 24,
+                  "startFilePos": 43,
+                  "endLine": 3,
+                  "endTokenPos": 24,
+                  "endFilePos": 47
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 24,
+                    "startFilePos": 43,
+                    "endLine": 3,
+                    "endTokenPos": 24,
+                    "endFilePos": 47
+                  },
+                  "name": "nums"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 29,
+              "startFilePos": 52,
+              "endLine": 3,
+              "endTokenPos": 29,
+              "endFilePos": 57,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 33,
+              "startFilePos": 61,
+              "endLine": 3,
+              "endTokenPos": 33,
+              "endFilePos": 67,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 37,
+            "startFilePos": 71,
+            "endLine": 3,
+            "endTokenPos": 37,
+            "endFilePos": 77
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 37,
+              "startFilePos": 71,
+              "endLine": 3,
+              "endTokenPos": 37,
+              "endFilePos": 77
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 40,
+        "startFilePos": 80,
+        "endLine": 4,
+        "endTokenPos": 62,
+        "endFilePos": 133
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 43,
+            "startFilePos": 86,
+            "endLine": 4,
+            "endTokenPos": 57,
+            "endFilePos": 122
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 43,
+              "startFilePos": 86,
+              "endLine": 4,
+              "endTokenPos": 49,
+              "endFilePos": 103
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 43,
+                "startFilePos": 86,
+                "endLine": 4,
+                "endTokenPos": 43,
+                "endFilePos": 93
+              },
+              "name": "in_array"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 45,
+                  "startFilePos": 95,
+                  "endLine": 4,
+                  "endTokenPos": 45,
+                  "endFilePos": 95
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 45,
+                    "startFilePos": 95,
+                    "endLine": 4,
+                    "endTokenPos": 45,
+                    "endFilePos": 95,
+                    "rawValue": "4",
+                    "kind": 10
+                  },
+                  "value": 4
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 48,
+                  "startFilePos": 98,
+                  "endLine": 4,
+                  "endTokenPos": 48,
+                  "endFilePos": 102
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 48,
+                    "startFilePos": 98,
+                    "endLine": 4,
+                    "endTokenPos": 48,
+                    "endFilePos": 102
+                  },
+                  "name": "nums"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 53,
+              "startFilePos": 107,
+              "endLine": 4,
+              "endTokenPos": 53,
+              "endFilePos": 112,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 57,
+              "startFilePos": 116,
+              "endLine": 4,
+              "endTokenPos": 57,
+              "endFilePos": 122,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 61,
+            "startFilePos": 126,
+            "endLine": 4,
+            "endTokenPos": 61,
+            "endFilePos": 132
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 61,
+              "startFilePos": 126,
+              "endLine": 4,
+              "endTokenPos": 61,
+              "endFilePos": 132
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/min_max_builtin.php.json
+++ b/tests/json-ast/x/php/min_max_builtin.php.json
@@ -1,0 +1,748 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 23
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 22
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "nums"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 22,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 21,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 21
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 21,
+                  "rawValue": "4",
+                  "kind": 10
+                },
+                "value": 4
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 25,
+        "endLine": 3,
+        "endTokenPos": 50,
+        "endFilePos": 106
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 19,
+            "startFilePos": 31,
+            "endLine": 3,
+            "endTokenPos": 45,
+            "endFilePos": 95
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 19,
+              "startFilePos": 31,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 50
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 19,
+                "startFilePos": 31,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 38
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 21,
+                  "startFilePos": 40,
+                  "endLine": 3,
+                  "endTokenPos": 24,
+                  "endFilePos": 49
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 21,
+                    "startFilePos": 40,
+                    "endLine": 3,
+                    "endTokenPos": 24,
+                    "endFilePos": 49
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 21,
+                      "startFilePos": 40,
+                      "endLine": 3,
+                      "endTokenPos": 21,
+                      "endFilePos": 42
+                    },
+                    "name": "min"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 23,
+                        "startFilePos": 44,
+                        "endLine": 3,
+                        "endTokenPos": 23,
+                        "endFilePos": 48
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 23,
+                          "startFilePos": 44,
+                          "endLine": 3,
+                          "endTokenPos": 23,
+                          "endFilePos": 48
+                        },
+                        "name": "nums"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 29,
+              "startFilePos": 54,
+              "endLine": 3,
+              "endTokenPos": 38,
+              "endFilePos": 82
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 29,
+                "startFilePos": 54,
+                "endLine": 3,
+                "endTokenPos": 29,
+                "endFilePos": 64
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 31,
+                  "startFilePos": 66,
+                  "endLine": 3,
+                  "endTokenPos": 34,
+                  "endFilePos": 75
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 31,
+                    "startFilePos": 66,
+                    "endLine": 3,
+                    "endTokenPos": 34,
+                    "endFilePos": 75
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 31,
+                      "startFilePos": 66,
+                      "endLine": 3,
+                      "endTokenPos": 31,
+                      "endFilePos": 68
+                    },
+                    "name": "min"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 33,
+                        "startFilePos": 70,
+                        "endLine": 3,
+                        "endTokenPos": 33,
+                        "endFilePos": 74
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 33,
+                          "startFilePos": 70,
+                          "endLine": 3,
+                          "endTokenPos": 33,
+                          "endFilePos": 74
+                        },
+                        "name": "nums"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 37,
+                  "startFilePos": 78,
+                  "endLine": 3,
+                  "endTokenPos": 37,
+                  "endFilePos": 81
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 37,
+                    "startFilePos": 78,
+                    "endLine": 3,
+                    "endTokenPos": 37,
+                    "endFilePos": 81,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 42,
+              "startFilePos": 86,
+              "endLine": 3,
+              "endTokenPos": 45,
+              "endFilePos": 95
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 42,
+                "startFilePos": 86,
+                "endLine": 3,
+                "endTokenPos": 42,
+                "endFilePos": 88
+              },
+              "name": "min"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 44,
+                  "startFilePos": 90,
+                  "endLine": 3,
+                  "endTokenPos": 44,
+                  "endFilePos": 94
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 44,
+                    "startFilePos": 90,
+                    "endLine": 3,
+                    "endTokenPos": 44,
+                    "endFilePos": 94
+                  },
+                  "name": "nums"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 49,
+            "startFilePos": 99,
+            "endLine": 3,
+            "endTokenPos": 49,
+            "endFilePos": 105
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 49,
+              "startFilePos": 99,
+              "endLine": 3,
+              "endTokenPos": 49,
+              "endFilePos": 105
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 52,
+        "startFilePos": 108,
+        "endLine": 4,
+        "endTokenPos": 86,
+        "endFilePos": 189
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 55,
+            "startFilePos": 114,
+            "endLine": 4,
+            "endTokenPos": 81,
+            "endFilePos": 178
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 55,
+              "startFilePos": 114,
+              "endLine": 4,
+              "endTokenPos": 61,
+              "endFilePos": 133
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 55,
+                "startFilePos": 114,
+                "endLine": 4,
+                "endTokenPos": 55,
+                "endFilePos": 121
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 57,
+                  "startFilePos": 123,
+                  "endLine": 4,
+                  "endTokenPos": 60,
+                  "endFilePos": 132
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 57,
+                    "startFilePos": 123,
+                    "endLine": 4,
+                    "endTokenPos": 60,
+                    "endFilePos": 132
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 57,
+                      "startFilePos": 123,
+                      "endLine": 4,
+                      "endTokenPos": 57,
+                      "endFilePos": 125
+                    },
+                    "name": "max"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 59,
+                        "startFilePos": 127,
+                        "endLine": 4,
+                        "endTokenPos": 59,
+                        "endFilePos": 131
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 59,
+                          "startFilePos": 127,
+                          "endLine": 4,
+                          "endTokenPos": 59,
+                          "endFilePos": 131
+                        },
+                        "name": "nums"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 65,
+              "startFilePos": 137,
+              "endLine": 4,
+              "endTokenPos": 74,
+              "endFilePos": 165
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 65,
+                "startFilePos": 137,
+                "endLine": 4,
+                "endTokenPos": 65,
+                "endFilePos": 147
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 67,
+                  "startFilePos": 149,
+                  "endLine": 4,
+                  "endTokenPos": 70,
+                  "endFilePos": 158
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 67,
+                    "startFilePos": 149,
+                    "endLine": 4,
+                    "endTokenPos": 70,
+                    "endFilePos": 158
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 67,
+                      "startFilePos": 149,
+                      "endLine": 4,
+                      "endTokenPos": 67,
+                      "endFilePos": 151
+                    },
+                    "name": "max"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 69,
+                        "startFilePos": 153,
+                        "endLine": 4,
+                        "endTokenPos": 69,
+                        "endFilePos": 157
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 69,
+                          "startFilePos": 153,
+                          "endLine": 4,
+                          "endTokenPos": 69,
+                          "endFilePos": 157
+                        },
+                        "name": "nums"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 73,
+                  "startFilePos": 161,
+                  "endLine": 4,
+                  "endTokenPos": 73,
+                  "endFilePos": 164
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 73,
+                    "startFilePos": 161,
+                    "endLine": 4,
+                    "endTokenPos": 73,
+                    "endFilePos": 164,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 78,
+              "startFilePos": 169,
+              "endLine": 4,
+              "endTokenPos": 81,
+              "endFilePos": 178
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 78,
+                "startFilePos": 169,
+                "endLine": 4,
+                "endTokenPos": 78,
+                "endFilePos": 171
+              },
+              "name": "max"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 80,
+                  "startFilePos": 173,
+                  "endLine": 4,
+                  "endTokenPos": 80,
+                  "endFilePos": 177
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 80,
+                    "startFilePos": 173,
+                    "endLine": 4,
+                    "endTokenPos": 80,
+                    "endFilePos": 177
+                  },
+                  "name": "nums"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 85,
+            "startFilePos": 182,
+            "endLine": 4,
+            "endTokenPos": 85,
+            "endFilePos": 188
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 85,
+              "startFilePos": 182,
+              "endLine": 4,
+              "endTokenPos": 85,
+              "endFilePos": 188
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/nested_function.php.json
+++ b/tests/json-ast/x/php/nested_function.php.json
@@ -1,0 +1,595 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 7,
+        "endTokenPos": 47,
+        "endFilePos": 103
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 19
+        },
+        "name": "outer"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 21,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 22
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 21,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 22
+            },
+            "name": "x"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 10,
+            "startFilePos": 29,
+            "endLine": 5,
+            "endTokenPos": 37,
+            "endFilePos": 81
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 10,
+              "startFilePos": 29,
+              "endLine": 5,
+              "endTokenPos": 36,
+              "endFilePos": 80
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 10,
+                "startFilePos": 29,
+                "endLine": 3,
+                "endTokenPos": 10,
+                "endFilePos": 34
+              },
+              "name": "inner"
+            },
+            "expr": {
+              "nodeType": "Expr_Closure",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 14,
+                "startFilePos": 38,
+                "endLine": 5,
+                "endTokenPos": 36,
+                "endFilePos": 80
+              },
+              "static": false,
+              "byRef": false,
+              "params": [
+                {
+                  "nodeType": "Param",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 16,
+                    "startFilePos": 47,
+                    "endLine": 3,
+                    "endTokenPos": 16,
+                    "endFilePos": 48
+                  },
+                  "type": null,
+                  "byRef": false,
+                  "variadic": false,
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 16,
+                      "startFilePos": 47,
+                      "endLine": 3,
+                      "endTokenPos": 16,
+                      "endFilePos": 48
+                    },
+                    "name": "y"
+                  },
+                  "default": null,
+                  "flags": 0,
+                  "attrGroups": [],
+                  "hooks": []
+                }
+              ],
+              "uses": [
+                {
+                  "nodeType": "ClosureUse",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 22,
+                    "startFilePos": 56,
+                    "endLine": 3,
+                    "endTokenPos": 22,
+                    "endFilePos": 57
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 22,
+                      "startFilePos": 56,
+                      "endLine": 3,
+                      "endTokenPos": 22,
+                      "endFilePos": 57
+                    },
+                    "name": "x"
+                  },
+                  "byRef": false
+                }
+              ],
+              "returnType": null,
+              "stmts": [
+                {
+                  "nodeType": "Stmt_Return",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 27,
+                    "startFilePos": 64,
+                    "endLine": 4,
+                    "endTokenPos": 34,
+                    "endFilePos": 78
+                  },
+                  "expr": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 29,
+                      "startFilePos": 71,
+                      "endLine": 4,
+                      "endTokenPos": 33,
+                      "endFilePos": 77
+                    },
+                    "left": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 29,
+                        "startFilePos": 71,
+                        "endLine": 4,
+                        "endTokenPos": 29,
+                        "endFilePos": 72
+                      },
+                      "name": "x"
+                    },
+                    "right": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 33,
+                        "startFilePos": 76,
+                        "endLine": 4,
+                        "endTokenPos": 33,
+                        "endFilePos": 77
+                      },
+                      "name": "y"
+                    }
+                  }
+                }
+              ],
+              "attrGroups": []
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 39,
+            "startFilePos": 85,
+            "endLine": 6,
+            "endTokenPos": 45,
+            "endFilePos": 101
+          },
+          "expr": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 41,
+              "startFilePos": 92,
+              "endLine": 6,
+              "endTokenPos": 44,
+              "endFilePos": 100
+            },
+            "name": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 41,
+                "startFilePos": 92,
+                "endLine": 6,
+                "endTokenPos": 41,
+                "endFilePos": 97
+              },
+              "name": "inner"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 43,
+                  "startFilePos": 99,
+                  "endLine": 6,
+                  "endTokenPos": 43,
+                  "endFilePos": 99
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 43,
+                    "startFilePos": 99,
+                    "endLine": 6,
+                    "endTokenPos": 43,
+                    "endFilePos": 99,
+                    "rawValue": "5",
+                    "kind": 10
+                  },
+                  "value": 5
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 49,
+        "startFilePos": 105,
+        "endLine": 8,
+        "endTokenPos": 83,
+        "endFilePos": 180
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 52,
+            "startFilePos": 111,
+            "endLine": 8,
+            "endTokenPos": 78,
+            "endFilePos": 169
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 52,
+              "startFilePos": 111,
+              "endLine": 8,
+              "endTokenPos": 58,
+              "endFilePos": 128
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 52,
+                "startFilePos": 111,
+                "endLine": 8,
+                "endTokenPos": 52,
+                "endFilePos": 118
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 54,
+                  "startFilePos": 120,
+                  "endLine": 8,
+                  "endTokenPos": 57,
+                  "endFilePos": 127
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 54,
+                    "startFilePos": 120,
+                    "endLine": 8,
+                    "endTokenPos": 57,
+                    "endFilePos": 127
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 54,
+                      "startFilePos": 120,
+                      "endLine": 8,
+                      "endTokenPos": 54,
+                      "endFilePos": 124
+                    },
+                    "name": "outer"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 56,
+                        "startFilePos": 126,
+                        "endLine": 8,
+                        "endTokenPos": 56,
+                        "endFilePos": 126
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 56,
+                          "startFilePos": 126,
+                          "endLine": 8,
+                          "endTokenPos": 56,
+                          "endFilePos": 126,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 62,
+              "startFilePos": 132,
+              "endLine": 8,
+              "endTokenPos": 71,
+              "endFilePos": 158
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 62,
+                "startFilePos": 132,
+                "endLine": 8,
+                "endTokenPos": 62,
+                "endFilePos": 142
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 64,
+                  "startFilePos": 144,
+                  "endLine": 8,
+                  "endTokenPos": 67,
+                  "endFilePos": 151
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 64,
+                    "startFilePos": 144,
+                    "endLine": 8,
+                    "endTokenPos": 67,
+                    "endFilePos": 151
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 64,
+                      "startFilePos": 144,
+                      "endLine": 8,
+                      "endTokenPos": 64,
+                      "endFilePos": 148
+                    },
+                    "name": "outer"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 66,
+                        "startFilePos": 150,
+                        "endLine": 8,
+                        "endTokenPos": 66,
+                        "endFilePos": 150
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 66,
+                          "startFilePos": 150,
+                          "endLine": 8,
+                          "endTokenPos": 66,
+                          "endFilePos": 150,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 70,
+                  "startFilePos": 154,
+                  "endLine": 8,
+                  "endTokenPos": 70,
+                  "endFilePos": 157
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 70,
+                    "startFilePos": 154,
+                    "endLine": 8,
+                    "endTokenPos": 70,
+                    "endFilePos": 157,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 75,
+              "startFilePos": 162,
+              "endLine": 8,
+              "endTokenPos": 78,
+              "endFilePos": 169
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 75,
+                "startFilePos": 162,
+                "endLine": 8,
+                "endTokenPos": 75,
+                "endFilePos": 166
+              },
+              "name": "outer"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 77,
+                  "startFilePos": 168,
+                  "endLine": 8,
+                  "endTokenPos": 77,
+                  "endFilePos": 168
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 77,
+                    "startFilePos": 168,
+                    "endLine": 8,
+                    "endTokenPos": 77,
+                    "endFilePos": 168,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 82,
+            "startFilePos": 173,
+            "endLine": 8,
+            "endTokenPos": 82,
+            "endFilePos": 179
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 82,
+              "startFilePos": 173,
+              "endLine": 8,
+              "endTokenPos": 82,
+              "endFilePos": 179
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/order_by_map.php.json
+++ b/tests/json-ast/x/php/order_by_map.php.json
@@ -1,0 +1,1116 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 53,
+        "endFilePos": 80
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 52,
+          "endFilePos": 79
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "data"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 52,
+            "endFilePos": 79,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 34
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 34,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 16,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 23
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 16,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 18,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 23,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 23,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 26,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 33
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 26,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 28,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 33,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 33,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 37,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 56
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 37,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 56,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 38,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 45
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 38,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 40,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 45,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 45,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 48,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 55
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 48,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 50,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 55,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 55,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 59,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 78
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 59,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 78,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 60,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 67
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 60,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 62,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 67,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 67,
+                        "rawValue": "0",
+                        "kind": 10
+                      },
+                      "value": 0
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 70,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 77
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 70,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 72,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 77,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 77,
+                        "rawValue": "5",
+                        "kind": 10
+                      },
+                      "value": 5
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 55,
+        "startFilePos": 82,
+        "endLine": 3,
+        "endTokenPos": 61,
+        "endFilePos": 94
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 55,
+          "startFilePos": 82,
+          "endLine": 3,
+          "endTokenPos": 60,
+          "endFilePos": 93
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 82,
+            "endLine": 3,
+            "endTokenPos": 55,
+            "endFilePos": 88
+          },
+          "name": "sorted"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 59,
+            "startFilePos": 92,
+            "endLine": 3,
+            "endTokenPos": 60,
+            "endFilePos": 93,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 63,
+        "startFilePos": 96,
+        "endLine": 6,
+        "endTokenPos": 84,
+        "endFilePos": 138
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 66,
+          "startFilePos": 105,
+          "endLine": 4,
+          "endTokenPos": 66,
+          "endFilePos": 109
+        },
+        "name": "data"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 70,
+          "startFilePos": 114,
+          "endLine": 4,
+          "endTokenPos": 70,
+          "endFilePos": 115
+        },
+        "name": "x"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 75,
+            "startFilePos": 122,
+            "endLine": 5,
+            "endTokenPos": 82,
+            "endFilePos": 136
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 75,
+              "startFilePos": 122,
+              "endLine": 5,
+              "endTokenPos": 81,
+              "endFilePos": 135
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 75,
+                "startFilePos": 122,
+                "endLine": 5,
+                "endTokenPos": 77,
+                "endFilePos": 130
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 75,
+                  "startFilePos": 122,
+                  "endLine": 5,
+                  "endTokenPos": 75,
+                  "endFilePos": 128
+                },
+                "name": "sorted"
+              },
+              "dim": null
+            },
+            "expr": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 81,
+                "startFilePos": 134,
+                "endLine": 5,
+                "endTokenPos": 81,
+                "endFilePos": 135
+              },
+              "name": "x"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 86,
+        "startFilePos": 141,
+        "endLine": 8,
+        "endTokenPos": 143,
+        "endFilePos": 313
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 88,
+            "startFilePos": 146,
+            "endLine": 8,
+            "endTokenPos": 139,
+            "endFilePos": 303
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 88,
+              "startFilePos": 146,
+              "endLine": 8,
+              "endTokenPos": 88,
+              "endFilePos": 156
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 90,
+                "startFilePos": 158,
+                "endLine": 8,
+                "endTokenPos": 90,
+                "endFilePos": 164
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 90,
+                  "startFilePos": 158,
+                  "endLine": 8,
+                  "endTokenPos": 90,
+                  "endFilePos": 164,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 93,
+                "startFilePos": 167,
+                "endLine": 8,
+                "endTokenPos": 93,
+                "endFilePos": 173
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 93,
+                  "startFilePos": 167,
+                  "endLine": 8,
+                  "endTokenPos": 93,
+                  "endFilePos": 173,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 96,
+                "startFilePos": 176,
+                "endLine": 8,
+                "endTokenPos": 138,
+                "endFilePos": 302
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 96,
+                  "startFilePos": 176,
+                  "endLine": 8,
+                  "endTokenPos": 138,
+                  "endFilePos": 302
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 96,
+                    "startFilePos": 176,
+                    "endLine": 8,
+                    "endTokenPos": 96,
+                    "endFilePos": 186
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 98,
+                      "startFilePos": 188,
+                      "endLine": 8,
+                      "endTokenPos": 98,
+                      "endFilePos": 193
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 98,
+                        "startFilePos": 188,
+                        "endLine": 8,
+                        "endTokenPos": 98,
+                        "endFilePos": 193,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 101,
+                      "startFilePos": 196,
+                      "endLine": 8,
+                      "endTokenPos": 101,
+                      "endFilePos": 201
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 101,
+                        "startFilePos": 196,
+                        "endLine": 8,
+                        "endTokenPos": 101,
+                        "endFilePos": 201,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 104,
+                      "startFilePos": 204,
+                      "endLine": 8,
+                      "endTokenPos": 137,
+                      "endFilePos": 301
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 104,
+                        "startFilePos": 204,
+                        "endLine": 8,
+                        "endTokenPos": 137,
+                        "endFilePos": 301
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 104,
+                          "startFilePos": 204,
+                          "endLine": 8,
+                          "endTokenPos": 104,
+                          "endFilePos": 214
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 106,
+                            "startFilePos": 216,
+                            "endLine": 8,
+                            "endTokenPos": 106,
+                            "endFilePos": 219
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 106,
+                              "startFilePos": 216,
+                              "endLine": 8,
+                              "endTokenPos": 106,
+                              "endFilePos": 219,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 109,
+                            "startFilePos": 222,
+                            "endLine": 8,
+                            "endTokenPos": 109,
+                            "endFilePos": 224
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 109,
+                              "startFilePos": 222,
+                              "endLine": 8,
+                              "endTokenPos": 109,
+                              "endFilePos": 224,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 112,
+                            "startFilePos": 227,
+                            "endLine": 8,
+                            "endTokenPos": 136,
+                            "endFilePos": 300
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 112,
+                              "startFilePos": 227,
+                              "endLine": 8,
+                              "endTokenPos": 136,
+                              "endFilePos": 300
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 112,
+                                "startFilePos": 227,
+                                "endLine": 8,
+                                "endTokenPos": 112,
+                                "endFilePos": 237
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 8,
+                                  "startTokenPos": 114,
+                                  "startFilePos": 239,
+                                  "endLine": 8,
+                                  "endTokenPos": 114,
+                                  "endFilePos": 241
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 8,
+                                    "startTokenPos": 114,
+                                    "startFilePos": 239,
+                                    "endLine": 8,
+                                    "endTokenPos": 114,
+                                    "endFilePos": 241,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 8,
+                                  "startTokenPos": 117,
+                                  "startFilePos": 244,
+                                  "endLine": 8,
+                                  "endTokenPos": 117,
+                                  "endFilePos": 247
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 8,
+                                    "startTokenPos": 117,
+                                    "startFilePos": 244,
+                                    "endLine": 8,
+                                    "endTokenPos": 117,
+                                    "endFilePos": 247,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 8,
+                                  "startTokenPos": 120,
+                                  "startFilePos": 250,
+                                  "endLine": 8,
+                                  "endTokenPos": 135,
+                                  "endFilePos": 299
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 8,
+                                    "startTokenPos": 120,
+                                    "startFilePos": 250,
+                                    "endLine": 8,
+                                    "endTokenPos": 135,
+                                    "endFilePos": 299
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 8,
+                                      "startTokenPos": 120,
+                                      "startFilePos": 250,
+                                      "endLine": 8,
+                                      "endTokenPos": 120,
+                                      "endFilePos": 260
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 8,
+                                        "startTokenPos": 122,
+                                        "startFilePos": 262,
+                                        "endLine": 8,
+                                        "endTokenPos": 122,
+                                        "endFilePos": 264
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 8,
+                                          "startTokenPos": 122,
+                                          "startFilePos": 262,
+                                          "endLine": 8,
+                                          "endTokenPos": 122,
+                                          "endFilePos": 264,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 8,
+                                        "startTokenPos": 125,
+                                        "startFilePos": 267,
+                                        "endLine": 8,
+                                        "endTokenPos": 125,
+                                        "endFilePos": 270
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 8,
+                                          "startTokenPos": 125,
+                                          "startFilePos": 267,
+                                          "endLine": 8,
+                                          "endTokenPos": 125,
+                                          "endFilePos": 270,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 8,
+                                        "startTokenPos": 128,
+                                        "startFilePos": 273,
+                                        "endLine": 8,
+                                        "endTokenPos": 134,
+                                        "endFilePos": 298
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 8,
+                                          "startTokenPos": 128,
+                                          "startFilePos": 273,
+                                          "endLine": 8,
+                                          "endTokenPos": 134,
+                                          "endFilePos": 298
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 8,
+                                            "startTokenPos": 128,
+                                            "startFilePos": 273,
+                                            "endLine": 8,
+                                            "endTokenPos": 128,
+                                            "endFilePos": 283
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 8,
+                                              "startTokenPos": 130,
+                                              "startFilePos": 285,
+                                              "endLine": 8,
+                                              "endTokenPos": 130,
+                                              "endFilePos": 291
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 8,
+                                                "startTokenPos": 130,
+                                                "startFilePos": 285,
+                                                "endLine": 8,
+                                                "endTokenPos": 130,
+                                                "endFilePos": 291
+                                              },
+                                              "name": "sorted"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 8,
+                                              "startTokenPos": 133,
+                                              "startFilePos": 294,
+                                              "endLine": 8,
+                                              "endTokenPos": 133,
+                                              "endFilePos": 297
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 8,
+                                                "startTokenPos": 133,
+                                                "startFilePos": 294,
+                                                "endLine": 8,
+                                                "endTokenPos": 133,
+                                                "endFilePos": 297,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 142,
+            "startFilePos": 306,
+            "endLine": 8,
+            "endTokenPos": 142,
+            "endFilePos": 312
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 142,
+              "startFilePos": 306,
+              "endLine": 8,
+              "endTokenPos": 142,
+              "endFilePos": 312
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/outer_join.php.json
+++ b/tests/json-ast/x/php/outer_join.php.json
@@ -1,0 +1,5275 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 69,
+        "endFilePos": 147
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 68,
+          "endFilePos": 146
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 68,
+            "endFilePos": 146,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 82,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 113
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 82,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 113,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 83,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 86,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 91,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 91,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 94,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 99,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 104,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 54,
+                "startFilePos": 116,
+                "endLine": 2,
+                "endTokenPos": 67,
+                "endFilePos": 145
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 54,
+                  "startFilePos": 116,
+                  "endLine": 2,
+                  "endTokenPos": 67,
+                  "endFilePos": 145,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 117,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 125
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 117,
+                        "endLine": 2,
+                        "endTokenPos": 55,
+                        "endFilePos": 120,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 59,
+                        "startFilePos": 125,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 125,
+                        "rawValue": "4",
+                        "kind": 10
+                      },
+                      "value": 4
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 62,
+                      "startFilePos": 128,
+                      "endLine": 2,
+                      "endTokenPos": 66,
+                      "endFilePos": 144
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 62,
+                        "startFilePos": 128,
+                        "endLine": 2,
+                        "endTokenPos": 62,
+                        "endFilePos": 133,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 66,
+                        "startFilePos": 138,
+                        "endLine": 2,
+                        "endTokenPos": 66,
+                        "endFilePos": 144,
+                        "kind": 2,
+                        "rawValue": "\"Diana\""
+                      },
+                      "value": "Diana"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 71,
+        "startFilePos": 149,
+        "endLine": 3,
+        "endTokenPos": 167,
+        "endFilePos": 358
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 71,
+          "startFilePos": 149,
+          "endLine": 3,
+          "endTokenPos": 166,
+          "endFilePos": 357
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 71,
+            "startFilePos": 149,
+            "endLine": 3,
+            "endTokenPos": 71,
+            "endFilePos": 155
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 75,
+            "startFilePos": 159,
+            "endLine": 3,
+            "endTokenPos": 166,
+            "endFilePos": 357,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 76,
+                "startFilePos": 160,
+                "endLine": 3,
+                "endTokenPos": 96,
+                "endFilePos": 207
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 76,
+                  "startFilePos": 160,
+                  "endLine": 3,
+                  "endTokenPos": 96,
+                  "endFilePos": 207,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 77,
+                      "startFilePos": 161,
+                      "endLine": 3,
+                      "endTokenPos": 81,
+                      "endFilePos": 171
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 77,
+                        "startFilePos": 161,
+                        "endLine": 3,
+                        "endTokenPos": 77,
+                        "endFilePos": 164,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 81,
+                        "startFilePos": 169,
+                        "endLine": 3,
+                        "endTokenPos": 81,
+                        "endFilePos": 171,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 174,
+                      "endLine": 3,
+                      "endTokenPos": 88,
+                      "endFilePos": 190
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 84,
+                        "startFilePos": 174,
+                        "endLine": 3,
+                        "endTokenPos": 84,
+                        "endFilePos": 185,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 88,
+                        "startFilePos": 190,
+                        "endLine": 3,
+                        "endTokenPos": 88,
+                        "endFilePos": 190,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 91,
+                      "startFilePos": 193,
+                      "endLine": 3,
+                      "endTokenPos": 95,
+                      "endFilePos": 206
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 91,
+                        "startFilePos": 193,
+                        "endLine": 3,
+                        "endTokenPos": 91,
+                        "endFilePos": 199,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 95,
+                        "startFilePos": 204,
+                        "endLine": 3,
+                        "endTokenPos": 95,
+                        "endFilePos": 206,
+                        "rawValue": "250",
+                        "kind": 10
+                      },
+                      "value": 250
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 99,
+                "startFilePos": 210,
+                "endLine": 3,
+                "endTokenPos": 119,
+                "endFilePos": 257
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 99,
+                  "startFilePos": 210,
+                  "endLine": 3,
+                  "endTokenPos": 119,
+                  "endFilePos": 257,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 100,
+                      "startFilePos": 211,
+                      "endLine": 3,
+                      "endTokenPos": 104,
+                      "endFilePos": 221
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 100,
+                        "startFilePos": 211,
+                        "endLine": 3,
+                        "endTokenPos": 100,
+                        "endFilePos": 214,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 104,
+                        "startFilePos": 219,
+                        "endLine": 3,
+                        "endTokenPos": 104,
+                        "endFilePos": 221,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 107,
+                      "startFilePos": 224,
+                      "endLine": 3,
+                      "endTokenPos": 111,
+                      "endFilePos": 240
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 107,
+                        "startFilePos": 224,
+                        "endLine": 3,
+                        "endTokenPos": 107,
+                        "endFilePos": 235,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 111,
+                        "startFilePos": 240,
+                        "endLine": 3,
+                        "endTokenPos": 111,
+                        "endFilePos": 240,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 114,
+                      "startFilePos": 243,
+                      "endLine": 3,
+                      "endTokenPos": 118,
+                      "endFilePos": 256
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 114,
+                        "startFilePos": 243,
+                        "endLine": 3,
+                        "endTokenPos": 114,
+                        "endFilePos": 249,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 118,
+                        "startFilePos": 254,
+                        "endLine": 3,
+                        "endTokenPos": 118,
+                        "endFilePos": 256,
+                        "rawValue": "125",
+                        "kind": 10
+                      },
+                      "value": 125
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 122,
+                "startFilePos": 260,
+                "endLine": 3,
+                "endTokenPos": 142,
+                "endFilePos": 307
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 122,
+                  "startFilePos": 260,
+                  "endLine": 3,
+                  "endTokenPos": 142,
+                  "endFilePos": 307,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 123,
+                      "startFilePos": 261,
+                      "endLine": 3,
+                      "endTokenPos": 127,
+                      "endFilePos": 271
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 123,
+                        "startFilePos": 261,
+                        "endLine": 3,
+                        "endTokenPos": 123,
+                        "endFilePos": 264,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 127,
+                        "startFilePos": 269,
+                        "endLine": 3,
+                        "endTokenPos": 127,
+                        "endFilePos": 271,
+                        "rawValue": "102",
+                        "kind": 10
+                      },
+                      "value": 102
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 130,
+                      "startFilePos": 274,
+                      "endLine": 3,
+                      "endTokenPos": 134,
+                      "endFilePos": 290
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 130,
+                        "startFilePos": 274,
+                        "endLine": 3,
+                        "endTokenPos": 130,
+                        "endFilePos": 285,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 134,
+                        "startFilePos": 290,
+                        "endLine": 3,
+                        "endTokenPos": 134,
+                        "endFilePos": 290,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 137,
+                      "startFilePos": 293,
+                      "endLine": 3,
+                      "endTokenPos": 141,
+                      "endFilePos": 306
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 137,
+                        "startFilePos": 293,
+                        "endLine": 3,
+                        "endTokenPos": 137,
+                        "endFilePos": 299,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 141,
+                        "startFilePos": 304,
+                        "endLine": 3,
+                        "endTokenPos": 141,
+                        "endFilePos": 306,
+                        "rawValue": "300",
+                        "kind": 10
+                      },
+                      "value": 300
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 145,
+                "startFilePos": 310,
+                "endLine": 3,
+                "endTokenPos": 165,
+                "endFilePos": 356
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 145,
+                  "startFilePos": 310,
+                  "endLine": 3,
+                  "endTokenPos": 165,
+                  "endFilePos": 356,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 146,
+                      "startFilePos": 311,
+                      "endLine": 3,
+                      "endTokenPos": 150,
+                      "endFilePos": 321
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 146,
+                        "startFilePos": 311,
+                        "endLine": 3,
+                        "endTokenPos": 146,
+                        "endFilePos": 314,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 150,
+                        "startFilePos": 319,
+                        "endLine": 3,
+                        "endTokenPos": 150,
+                        "endFilePos": 321,
+                        "rawValue": "103",
+                        "kind": 10
+                      },
+                      "value": 103
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 153,
+                      "startFilePos": 324,
+                      "endLine": 3,
+                      "endTokenPos": 157,
+                      "endFilePos": 340
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 153,
+                        "startFilePos": 324,
+                        "endLine": 3,
+                        "endTokenPos": 153,
+                        "endFilePos": 335,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 157,
+                        "startFilePos": 340,
+                        "endLine": 3,
+                        "endTokenPos": 157,
+                        "endFilePos": 340,
+                        "rawValue": "5",
+                        "kind": 10
+                      },
+                      "value": 5
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 160,
+                      "startFilePos": 343,
+                      "endLine": 3,
+                      "endTokenPos": 164,
+                      "endFilePos": 355
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 160,
+                        "startFilePos": 343,
+                        "endLine": 3,
+                        "endTokenPos": 160,
+                        "endFilePos": 349,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 164,
+                        "startFilePos": 354,
+                        "endLine": 3,
+                        "endTokenPos": 164,
+                        "endFilePos": 355,
+                        "rawValue": "80",
+                        "kind": 10
+                      },
+                      "value": 80
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 169,
+        "startFilePos": 360,
+        "endLine": 31,
+        "endTokenPos": 439,
+        "endFilePos": 1046
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 169,
+          "startFilePos": 360,
+          "endLine": 31,
+          "endTokenPos": 438,
+          "endFilePos": 1045
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 169,
+            "startFilePos": 360,
+            "endLine": 4,
+            "endTokenPos": 169,
+            "endFilePos": 366
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 173,
+            "startFilePos": 370,
+            "endLine": 31,
+            "endTokenPos": 438,
+            "endFilePos": 1045
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 174,
+              "startFilePos": 371,
+              "endLine": 31,
+              "endTokenPos": 435,
+              "endFilePos": 1042
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 181,
+                  "startFilePos": 387,
+                  "endLine": 4,
+                  "endTokenPos": 181,
+                  "endFilePos": 396
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 181,
+                    "startFilePos": 387,
+                    "endLine": 4,
+                    "endTokenPos": 181,
+                    "endFilePos": 396
+                  },
+                  "name": "customers"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 184,
+                  "startFilePos": 399,
+                  "endLine": 4,
+                  "endTokenPos": 184,
+                  "endFilePos": 405
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 184,
+                    "startFilePos": 399,
+                    "endLine": 4,
+                    "endTokenPos": 184,
+                    "endFilePos": 405
+                  },
+                  "name": "orders"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 189,
+                  "startFilePos": 412,
+                  "endLine": 5,
+                  "endTokenPos": 195,
+                  "endFilePos": 424
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 189,
+                    "startFilePos": 412,
+                    "endLine": 5,
+                    "endTokenPos": 194,
+                    "endFilePos": 423
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 189,
+                      "startFilePos": 412,
+                      "endLine": 5,
+                      "endTokenPos": 189,
+                      "endFilePos": 418
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 193,
+                      "startFilePos": 422,
+                      "endLine": 5,
+                      "endTokenPos": 194,
+                      "endFilePos": 423,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 197,
+                  "startFilePos": 428,
+                  "endLine": 17,
+                  "endTokenPos": 321,
+                  "endFilePos": 743
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 200,
+                    "startFilePos": 437,
+                    "endLine": 6,
+                    "endTokenPos": 200,
+                    "endFilePos": 443
+                  },
+                  "name": "orders"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 204,
+                    "startFilePos": 448,
+                    "endLine": 6,
+                    "endTokenPos": 204,
+                    "endFilePos": 449
+                  },
+                  "name": "o"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 209,
+                      "startFilePos": 458,
+                      "endLine": 7,
+                      "endTokenPos": 214,
+                      "endFilePos": 474
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 209,
+                        "startFilePos": 458,
+                        "endLine": 7,
+                        "endTokenPos": 213,
+                        "endFilePos": 473
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 209,
+                          "startFilePos": 458,
+                          "endLine": 7,
+                          "endTokenPos": 209,
+                          "endFilePos": 465
+                        },
+                        "name": "matched"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ConstFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 213,
+                          "startFilePos": 469,
+                          "endLine": 7,
+                          "endTokenPos": 213,
+                          "endFilePos": 473
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 213,
+                            "startFilePos": 469,
+                            "endLine": 7,
+                            "endTokenPos": 213,
+                            "endFilePos": 473
+                          },
+                          "name": "false"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 216,
+                      "startFilePos": 480,
+                      "endLine": 12,
+                      "endTokenPos": 279,
+                      "endFilePos": 642
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 219,
+                        "startFilePos": 489,
+                        "endLine": 8,
+                        "endTokenPos": 219,
+                        "endFilePos": 498
+                      },
+                      "name": "customers"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 223,
+                        "startFilePos": 503,
+                        "endLine": 8,
+                        "endTokenPos": 223,
+                        "endFilePos": 504
+                      },
+                      "name": "c"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 228,
+                          "startFilePos": 515,
+                          "endLine": 9,
+                          "endTokenPos": 248,
+                          "endFilePos": 560
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 231,
+                            "startFilePos": 519,
+                            "endLine": 9,
+                            "endTokenPos": 244,
+                            "endFilePos": 549
+                          },
+                          "expr": {
+                            "nodeType": "Expr_BinaryOp_Equal",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 233,
+                              "startFilePos": 521,
+                              "endLine": 9,
+                              "endTokenPos": 243,
+                              "endFilePos": 548
+                            },
+                            "left": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 233,
+                                "startFilePos": 521,
+                                "endLine": 9,
+                                "endTokenPos": 236,
+                                "endFilePos": 536
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 233,
+                                  "startFilePos": 521,
+                                  "endLine": 9,
+                                  "endTokenPos": 233,
+                                  "endFilePos": 522
+                                },
+                                "name": "o"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 235,
+                                  "startFilePos": 524,
+                                  "endLine": 9,
+                                  "endTokenPos": 235,
+                                  "endFilePos": 535,
+                                  "kind": 2,
+                                  "rawValue": "\"customerId\""
+                                },
+                                "value": "customerId"
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 240,
+                                "startFilePos": 541,
+                                "endLine": 9,
+                                "endTokenPos": 243,
+                                "endFilePos": 548
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 240,
+                                  "startFilePos": 541,
+                                  "endLine": 9,
+                                  "endTokenPos": 240,
+                                  "endFilePos": 542
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 242,
+                                  "startFilePos": 544,
+                                  "endLine": 9,
+                                  "endTokenPos": 242,
+                                  "endFilePos": 547,
+                                  "kind": 2,
+                                  "rawValue": "\"id\""
+                                },
+                                "value": "id"
+                              }
+                            }
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Continue",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 247,
+                              "startFilePos": 552,
+                              "endLine": 9,
+                              "endTokenPos": 248,
+                              "endFilePos": 560
+                            },
+                            "num": null
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 250,
+                          "startFilePos": 568,
+                          "endLine": 10,
+                          "endTokenPos": 255,
+                          "endFilePos": 583
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 250,
+                            "startFilePos": 568,
+                            "endLine": 10,
+                            "endTokenPos": 254,
+                            "endFilePos": 582
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 250,
+                              "startFilePos": 568,
+                              "endLine": 10,
+                              "endTokenPos": 250,
+                              "endFilePos": 575
+                            },
+                            "name": "matched"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 254,
+                              "startFilePos": 579,
+                              "endLine": 10,
+                              "endTokenPos": 254,
+                              "endFilePos": 582
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 254,
+                                "startFilePos": 579,
+                                "endLine": 10,
+                                "endTokenPos": 254,
+                                "endFilePos": 582
+                              },
+                              "name": "true"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 257,
+                          "startFilePos": 591,
+                          "endLine": 11,
+                          "endTokenPos": 277,
+                          "endFilePos": 636
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 257,
+                            "startFilePos": 591,
+                            "endLine": 11,
+                            "endTokenPos": 276,
+                            "endFilePos": 635
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 257,
+                              "startFilePos": 591,
+                              "endLine": 11,
+                              "endTokenPos": 259,
+                              "endFilePos": 599
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 257,
+                                "startFilePos": 591,
+                                "endLine": 11,
+                                "endTokenPos": 257,
+                                "endFilePos": 597
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 263,
+                              "startFilePos": 603,
+                              "endLine": 11,
+                              "endTokenPos": 276,
+                              "endFilePos": 635,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 264,
+                                  "startFilePos": 604,
+                                  "endLine": 11,
+                                  "endTokenPos": 268,
+                                  "endFilePos": 616
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 264,
+                                    "startFilePos": 604,
+                                    "endLine": 11,
+                                    "endTokenPos": 264,
+                                    "endFilePos": 610,
+                                    "kind": 2,
+                                    "rawValue": "\"order\""
+                                  },
+                                  "value": "order"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 268,
+                                    "startFilePos": 615,
+                                    "endLine": 11,
+                                    "endTokenPos": 268,
+                                    "endFilePos": 616
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 271,
+                                  "startFilePos": 619,
+                                  "endLine": 11,
+                                  "endTokenPos": 275,
+                                  "endFilePos": 634
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 271,
+                                    "startFilePos": 619,
+                                    "endLine": 11,
+                                    "endTokenPos": 271,
+                                    "endFilePos": 628,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 275,
+                                    "startFilePos": 633,
+                                    "endLine": 11,
+                                    "endTokenPos": 275,
+                                    "endFilePos": 634
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 281,
+                      "startFilePos": 648,
+                      "endLine": 16,
+                      "endTokenPos": 319,
+                      "endFilePos": 739
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 284,
+                        "startFilePos": 652,
+                        "endLine": 13,
+                        "endTokenPos": 285,
+                        "endFilePos": 660
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 285,
+                          "startFilePos": 653,
+                          "endLine": 13,
+                          "endTokenPos": 285,
+                          "endFilePos": 660
+                        },
+                        "name": "matched"
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 14,
+                          "startTokenPos": 290,
+                          "startFilePos": 671,
+                          "endLine": 14,
+                          "endTokenPos": 295,
+                          "endFilePos": 680
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 14,
+                            "startTokenPos": 290,
+                            "startFilePos": 671,
+                            "endLine": 14,
+                            "endTokenPos": 294,
+                            "endFilePos": 679
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 290,
+                              "startFilePos": 671,
+                              "endLine": 14,
+                              "endTokenPos": 290,
+                              "endFilePos": 672
+                            },
+                            "name": "c"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 294,
+                              "startFilePos": 676,
+                              "endLine": 14,
+                              "endTokenPos": 294,
+                              "endFilePos": 679
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 14,
+                                "startTokenPos": 294,
+                                "startFilePos": 676,
+                                "endLine": 14,
+                                "endTokenPos": 294,
+                                "endFilePos": 679
+                              },
+                              "name": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 297,
+                          "startFilePos": 688,
+                          "endLine": 15,
+                          "endTokenPos": 317,
+                          "endFilePos": 733
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 297,
+                            "startFilePos": 688,
+                            "endLine": 15,
+                            "endTokenPos": 316,
+                            "endFilePos": 732
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 297,
+                              "startFilePos": 688,
+                              "endLine": 15,
+                              "endTokenPos": 299,
+                              "endFilePos": 696
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 297,
+                                "startFilePos": 688,
+                                "endLine": 15,
+                                "endTokenPos": 297,
+                                "endFilePos": 694
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 303,
+                              "startFilePos": 700,
+                              "endLine": 15,
+                              "endTokenPos": 316,
+                              "endFilePos": 732,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 304,
+                                  "startFilePos": 701,
+                                  "endLine": 15,
+                                  "endTokenPos": 308,
+                                  "endFilePos": 713
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 304,
+                                    "startFilePos": 701,
+                                    "endLine": 15,
+                                    "endTokenPos": 304,
+                                    "endFilePos": 707,
+                                    "kind": 2,
+                                    "rawValue": "\"order\""
+                                  },
+                                  "value": "order"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 308,
+                                    "startFilePos": 712,
+                                    "endLine": 15,
+                                    "endTokenPos": 308,
+                                    "endFilePos": 713
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 311,
+                                  "startFilePos": 716,
+                                  "endLine": 15,
+                                  "endTokenPos": 315,
+                                  "endFilePos": 731
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 311,
+                                    "startFilePos": 716,
+                                    "endLine": 15,
+                                    "endTokenPos": 311,
+                                    "endFilePos": 725,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 315,
+                                    "startFilePos": 730,
+                                    "endLine": 15,
+                                    "endTokenPos": 315,
+                                    "endFilePos": 731
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 323,
+                  "startFilePos": 747,
+                  "endLine": 29,
+                  "endTokenPos": 428,
+                  "endFilePos": 1022
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 326,
+                    "startFilePos": 756,
+                    "endLine": 18,
+                    "endTokenPos": 326,
+                    "endFilePos": 765
+                  },
+                  "name": "customers"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 330,
+                    "startFilePos": 770,
+                    "endLine": 18,
+                    "endTokenPos": 330,
+                    "endFilePos": 771
+                  },
+                  "name": "c"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 19,
+                      "startTokenPos": 335,
+                      "startFilePos": 780,
+                      "endLine": 19,
+                      "endTokenPos": 340,
+                      "endFilePos": 796
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 19,
+                        "startTokenPos": 335,
+                        "startFilePos": 780,
+                        "endLine": 19,
+                        "endTokenPos": 339,
+                        "endFilePos": 795
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 19,
+                          "startTokenPos": 335,
+                          "startFilePos": 780,
+                          "endLine": 19,
+                          "endTokenPos": 335,
+                          "endFilePos": 787
+                        },
+                        "name": "matched"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ConstFetch",
+                        "attributes": {
+                          "startLine": 19,
+                          "startTokenPos": 339,
+                          "startFilePos": 791,
+                          "endLine": 19,
+                          "endTokenPos": 339,
+                          "endFilePos": 795
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 19,
+                            "startTokenPos": 339,
+                            "startFilePos": 791,
+                            "endLine": 19,
+                            "endTokenPos": 339,
+                            "endFilePos": 795
+                          },
+                          "name": "false"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 20,
+                      "startTokenPos": 342,
+                      "startFilePos": 802,
+                      "endLine": 24,
+                      "endTokenPos": 386,
+                      "endFilePos": 921
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 20,
+                        "startTokenPos": 345,
+                        "startFilePos": 811,
+                        "endLine": 20,
+                        "endTokenPos": 345,
+                        "endFilePos": 817
+                      },
+                      "name": "orders"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 20,
+                        "startTokenPos": 349,
+                        "startFilePos": 822,
+                        "endLine": 20,
+                        "endTokenPos": 349,
+                        "endFilePos": 823
+                      },
+                      "name": "o"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 21,
+                          "startTokenPos": 354,
+                          "startFilePos": 834,
+                          "endLine": 21,
+                          "endTokenPos": 374,
+                          "endFilePos": 879
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 21,
+                            "startTokenPos": 357,
+                            "startFilePos": 838,
+                            "endLine": 21,
+                            "endTokenPos": 370,
+                            "endFilePos": 868
+                          },
+                          "expr": {
+                            "nodeType": "Expr_BinaryOp_Equal",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 359,
+                              "startFilePos": 840,
+                              "endLine": 21,
+                              "endTokenPos": 369,
+                              "endFilePos": 867
+                            },
+                            "left": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 359,
+                                "startFilePos": 840,
+                                "endLine": 21,
+                                "endTokenPos": 362,
+                                "endFilePos": 855
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 21,
+                                  "startTokenPos": 359,
+                                  "startFilePos": 840,
+                                  "endLine": 21,
+                                  "endTokenPos": 359,
+                                  "endFilePos": 841
+                                },
+                                "name": "o"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 21,
+                                  "startTokenPos": 361,
+                                  "startFilePos": 843,
+                                  "endLine": 21,
+                                  "endTokenPos": 361,
+                                  "endFilePos": 854,
+                                  "kind": 2,
+                                  "rawValue": "\"customerId\""
+                                },
+                                "value": "customerId"
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 21,
+                                "startTokenPos": 366,
+                                "startFilePos": 860,
+                                "endLine": 21,
+                                "endTokenPos": 369,
+                                "endFilePos": 867
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 21,
+                                  "startTokenPos": 366,
+                                  "startFilePos": 860,
+                                  "endLine": 21,
+                                  "endTokenPos": 366,
+                                  "endFilePos": 861
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 21,
+                                  "startTokenPos": 368,
+                                  "startFilePos": 863,
+                                  "endLine": 21,
+                                  "endTokenPos": 368,
+                                  "endFilePos": 866,
+                                  "kind": 2,
+                                  "rawValue": "\"id\""
+                                },
+                                "value": "id"
+                              }
+                            }
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Continue",
+                            "attributes": {
+                              "startLine": 21,
+                              "startTokenPos": 373,
+                              "startFilePos": 871,
+                              "endLine": 21,
+                              "endTokenPos": 374,
+                              "endFilePos": 879
+                            },
+                            "num": null
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 22,
+                          "startTokenPos": 376,
+                          "startFilePos": 887,
+                          "endLine": 22,
+                          "endTokenPos": 381,
+                          "endFilePos": 902
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 22,
+                            "startTokenPos": 376,
+                            "startFilePos": 887,
+                            "endLine": 22,
+                            "endTokenPos": 380,
+                            "endFilePos": 901
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 376,
+                              "startFilePos": 887,
+                              "endLine": 22,
+                              "endTokenPos": 376,
+                              "endFilePos": 894
+                            },
+                            "name": "matched"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 22,
+                              "startTokenPos": 380,
+                              "startFilePos": 898,
+                              "endLine": 22,
+                              "endTokenPos": 380,
+                              "endFilePos": 901
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 22,
+                                "startTokenPos": 380,
+                                "startFilePos": 898,
+                                "endLine": 22,
+                                "endTokenPos": 380,
+                                "endFilePos": 901
+                              },
+                              "name": "true"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Break",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 383,
+                          "startFilePos": 910,
+                          "endLine": 23,
+                          "endTokenPos": 384,
+                          "endFilePos": 915
+                        },
+                        "num": null
+                      }
+                    ]
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 25,
+                      "startTokenPos": 388,
+                      "startFilePos": 927,
+                      "endLine": 28,
+                      "endTokenPos": 426,
+                      "endFilePos": 1018
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 25,
+                        "startTokenPos": 391,
+                        "startFilePos": 931,
+                        "endLine": 25,
+                        "endTokenPos": 392,
+                        "endFilePos": 939
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 25,
+                          "startTokenPos": 392,
+                          "startFilePos": 932,
+                          "endLine": 25,
+                          "endTokenPos": 392,
+                          "endFilePos": 939
+                        },
+                        "name": "matched"
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 26,
+                          "startTokenPos": 397,
+                          "startFilePos": 950,
+                          "endLine": 26,
+                          "endTokenPos": 402,
+                          "endFilePos": 959
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 26,
+                            "startTokenPos": 397,
+                            "startFilePos": 950,
+                            "endLine": 26,
+                            "endTokenPos": 401,
+                            "endFilePos": 958
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 26,
+                              "startTokenPos": 397,
+                              "startFilePos": 950,
+                              "endLine": 26,
+                              "endTokenPos": 397,
+                              "endFilePos": 951
+                            },
+                            "name": "o"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 26,
+                              "startTokenPos": 401,
+                              "startFilePos": 955,
+                              "endLine": 26,
+                              "endTokenPos": 401,
+                              "endFilePos": 958
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 26,
+                                "startTokenPos": 401,
+                                "startFilePos": 955,
+                                "endLine": 26,
+                                "endTokenPos": 401,
+                                "endFilePos": 958
+                              },
+                              "name": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 27,
+                          "startTokenPos": 404,
+                          "startFilePos": 967,
+                          "endLine": 27,
+                          "endTokenPos": 424,
+                          "endFilePos": 1012
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 27,
+                            "startTokenPos": 404,
+                            "startFilePos": 967,
+                            "endLine": 27,
+                            "endTokenPos": 423,
+                            "endFilePos": 1011
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 404,
+                              "startFilePos": 967,
+                              "endLine": 27,
+                              "endTokenPos": 406,
+                              "endFilePos": 975
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 27,
+                                "startTokenPos": 404,
+                                "startFilePos": 967,
+                                "endLine": 27,
+                                "endTokenPos": 404,
+                                "endFilePos": 973
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 27,
+                              "startTokenPos": 410,
+                              "startFilePos": 979,
+                              "endLine": 27,
+                              "endTokenPos": 423,
+                              "endFilePos": 1011,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 27,
+                                  "startTokenPos": 411,
+                                  "startFilePos": 980,
+                                  "endLine": 27,
+                                  "endTokenPos": 415,
+                                  "endFilePos": 992
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 27,
+                                    "startTokenPos": 411,
+                                    "startFilePos": 980,
+                                    "endLine": 27,
+                                    "endTokenPos": 411,
+                                    "endFilePos": 986,
+                                    "kind": 2,
+                                    "rawValue": "\"order\""
+                                  },
+                                  "value": "order"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 27,
+                                    "startTokenPos": 415,
+                                    "startFilePos": 991,
+                                    "endLine": 27,
+                                    "endTokenPos": 415,
+                                    "endFilePos": 992
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 27,
+                                  "startTokenPos": 418,
+                                  "startFilePos": 995,
+                                  "endLine": 27,
+                                  "endTokenPos": 422,
+                                  "endFilePos": 1010
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 27,
+                                    "startTokenPos": 418,
+                                    "startFilePos": 995,
+                                    "endLine": 27,
+                                    "endTokenPos": 418,
+                                    "endFilePos": 1004,
+                                    "kind": 2,
+                                    "rawValue": "\"customer\""
+                                  },
+                                  "value": "customer"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 27,
+                                    "startTokenPos": 422,
+                                    "startFilePos": 1009,
+                                    "endLine": 27,
+                                    "endTokenPos": 422,
+                                    "endFilePos": 1010
+                                  },
+                                  "name": "c"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 30,
+                  "startTokenPos": 430,
+                  "startFilePos": 1026,
+                  "endLine": 30,
+                  "endTokenPos": 433,
+                  "endFilePos": 1040
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 30,
+                    "startTokenPos": 432,
+                    "startFilePos": 1033,
+                    "endLine": 30,
+                    "endTokenPos": 432,
+                    "endFilePos": 1039
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 32,
+        "startTokenPos": 441,
+        "startFilePos": 1048,
+        "endLine": 32,
+        "endTokenPos": 447,
+        "endFilePos": 1095
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 443,
+            "startFilePos": 1053,
+            "endLine": 32,
+            "endTokenPos": 443,
+            "endFilePos": 1085,
+            "kind": 2,
+            "rawValue": "\"--- Outer Join using syntax ---\""
+          },
+          "value": "--- Outer Join using syntax ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 32,
+            "startTokenPos": 446,
+            "startFilePos": 1088,
+            "endLine": 32,
+            "endTokenPos": 446,
+            "endFilePos": 1094
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 32,
+              "startTokenPos": 446,
+              "startFilePos": 1088,
+              "endLine": 32,
+              "endTokenPos": 446,
+              "endFilePos": 1094
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 33,
+        "startTokenPos": 449,
+        "startFilePos": 1097,
+        "endLine": 43,
+        "endTokenPos": 842,
+        "endFilePos": 2037
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 33,
+          "startTokenPos": 452,
+          "startFilePos": 1106,
+          "endLine": 33,
+          "endTokenPos": 452,
+          "endFilePos": 1112
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 33,
+          "startTokenPos": 456,
+          "startFilePos": 1117,
+          "endLine": 33,
+          "endTokenPos": 456,
+          "endFilePos": 1120
+        },
+        "name": "row"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 34,
+            "startTokenPos": 461,
+            "startFilePos": 1127,
+            "endLine": 42,
+            "endTokenPos": 840,
+            "endFilePos": 2035
+          },
+          "cond": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 34,
+              "startTokenPos": 464,
+              "startFilePos": 1131,
+              "endLine": 34,
+              "endTokenPos": 467,
+              "endFilePos": 1143
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 34,
+                "startTokenPos": 464,
+                "startFilePos": 1131,
+                "endLine": 34,
+                "endTokenPos": 464,
+                "endFilePos": 1134
+              },
+              "name": "row"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 34,
+                "startTokenPos": 466,
+                "startFilePos": 1136,
+                "endLine": 34,
+                "endTokenPos": 466,
+                "endFilePos": 1142,
+                "kind": 2,
+                "rawValue": "\"order\""
+              },
+              "value": "order"
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_If",
+              "attributes": {
+                "startLine": 35,
+                "startTokenPos": 472,
+                "startFilePos": 1150,
+                "endLine": 39,
+                "endTokenPos": 770,
+                "endFilePos": 1853
+              },
+              "cond": {
+                "nodeType": "Expr_ArrayDimFetch",
+                "attributes": {
+                  "startLine": 35,
+                  "startTokenPos": 475,
+                  "startFilePos": 1154,
+                  "endLine": 35,
+                  "endTokenPos": 478,
+                  "endFilePos": 1169
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 35,
+                    "startTokenPos": 475,
+                    "startFilePos": 1154,
+                    "endLine": 35,
+                    "endTokenPos": 475,
+                    "endFilePos": 1157
+                  },
+                  "name": "row"
+                },
+                "dim": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 35,
+                    "startTokenPos": 477,
+                    "startFilePos": 1159,
+                    "endLine": 35,
+                    "endTokenPos": 477,
+                    "endFilePos": 1168,
+                    "kind": 2,
+                    "rawValue": "\"customer\""
+                  },
+                  "value": "customer"
+                }
+              },
+              "stmts": [
+                {
+                  "nodeType": "Stmt_Echo",
+                  "attributes": {
+                    "startLine": 36,
+                    "startTokenPos": 483,
+                    "startFilePos": 1176,
+                    "endLine": 36,
+                    "endTokenPos": 640,
+                    "endFilePos": 1557
+                  },
+                  "exprs": [
+                    {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 36,
+                        "startTokenPos": 485,
+                        "startFilePos": 1181,
+                        "endLine": 36,
+                        "endTokenPos": 636,
+                        "endFilePos": 1547
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 36,
+                          "startTokenPos": 485,
+                          "startFilePos": 1181,
+                          "endLine": 36,
+                          "endTokenPos": 595,
+                          "endFilePos": 1441
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 36,
+                            "startTokenPos": 485,
+                            "startFilePos": 1181,
+                            "endLine": 36,
+                            "endTokenPos": 591,
+                            "endFilePos": 1435
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 36,
+                              "startTokenPos": 485,
+                              "startFilePos": 1181,
+                              "endLine": 36,
+                              "endTokenPos": 587,
+                              "endFilePos": 1427
+                            },
+                            "left": {
+                              "nodeType": "Expr_BinaryOp_Concat",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 485,
+                                "startFilePos": 1181,
+                                "endLine": 36,
+                                "endTokenPos": 583,
+                                "endFilePos": 1421
+                              },
+                              "left": {
+                                "nodeType": "Expr_BinaryOp_Concat",
+                                "attributes": {
+                                  "startLine": 36,
+                                  "startTokenPos": 485,
+                                  "startFilePos": 1181,
+                                  "endLine": 36,
+                                  "endTokenPos": 542,
+                                  "endFilePos": 1309
+                                },
+                                "left": {
+                                  "nodeType": "Expr_BinaryOp_Concat",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 485,
+                                    "startFilePos": 1181,
+                                    "endLine": 36,
+                                    "endTokenPos": 538,
+                                    "endFilePos": 1303
+                                  },
+                                  "left": {
+                                    "nodeType": "Expr_BinaryOp_Concat",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 485,
+                                      "startFilePos": 1181,
+                                      "endLine": 36,
+                                      "endTokenPos": 534,
+                                      "endFilePos": 1296
+                                    },
+                                    "left": {
+                                      "nodeType": "Expr_BinaryOp_Concat",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 485,
+                                        "startFilePos": 1181,
+                                        "endLine": 36,
+                                        "endTokenPos": 530,
+                                        "endFilePos": 1290
+                                      },
+                                      "left": {
+                                        "nodeType": "Expr_BinaryOp_Concat",
+                                        "attributes": {
+                                          "startLine": 36,
+                                          "startTokenPos": 485,
+                                          "startFilePos": 1181,
+                                          "endLine": 36,
+                                          "endTokenPos": 489,
+                                          "endFilePos": 1193
+                                        },
+                                        "left": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 485,
+                                            "startFilePos": 1181,
+                                            "endLine": 36,
+                                            "endTokenPos": 485,
+                                            "endFilePos": 1187,
+                                            "kind": 2,
+                                            "rawValue": "\"Order\""
+                                          },
+                                          "value": "Order"
+                                        },
+                                        "right": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 489,
+                                            "startFilePos": 1191,
+                                            "endLine": 36,
+                                            "endTokenPos": 489,
+                                            "endFilePos": 1193,
+                                            "kind": 2,
+                                            "rawValue": "\" \""
+                                          },
+                                          "value": " "
+                                        }
+                                      },
+                                      "right": {
+                                        "nodeType": "Expr_Ternary",
+                                        "attributes": {
+                                          "startLine": 36,
+                                          "startTokenPos": 494,
+                                          "startFilePos": 1198,
+                                          "endLine": 36,
+                                          "endTokenPos": 529,
+                                          "endFilePos": 1289
+                                        },
+                                        "cond": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 494,
+                                            "startFilePos": 1198,
+                                            "endLine": 36,
+                                            "endTokenPos": 503,
+                                            "endFilePos": 1226
+                                          },
+                                          "name": {
+                                            "nodeType": "Name",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 494,
+                                              "startFilePos": 1198,
+                                              "endLine": 36,
+                                              "endTokenPos": 494,
+                                              "endFilePos": 1205
+                                            },
+                                            "name": "is_float"
+                                          },
+                                          "args": [
+                                            {
+                                              "nodeType": "Arg",
+                                              "attributes": {
+                                                "startLine": 36,
+                                                "startTokenPos": 496,
+                                                "startFilePos": 1207,
+                                                "endLine": 36,
+                                                "endTokenPos": 502,
+                                                "endFilePos": 1225
+                                              },
+                                              "name": null,
+                                              "value": {
+                                                "nodeType": "Expr_ArrayDimFetch",
+                                                "attributes": {
+                                                  "startLine": 36,
+                                                  "startTokenPos": 496,
+                                                  "startFilePos": 1207,
+                                                  "endLine": 36,
+                                                  "endTokenPos": 502,
+                                                  "endFilePos": 1225
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 36,
+                                                    "startTokenPos": 496,
+                                                    "startFilePos": 1207,
+                                                    "endLine": 36,
+                                                    "endTokenPos": 499,
+                                                    "endFilePos": 1219
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 36,
+                                                      "startTokenPos": 496,
+                                                      "startFilePos": 1207,
+                                                      "endLine": 36,
+                                                      "endTokenPos": 496,
+                                                      "endFilePos": 1210
+                                                    },
+                                                    "name": "row"
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 36,
+                                                      "startTokenPos": 498,
+                                                      "startFilePos": 1212,
+                                                      "endLine": 36,
+                                                      "endTokenPos": 498,
+                                                      "endFilePos": 1218,
+                                                      "kind": 2,
+                                                      "rawValue": "\"order\""
+                                                    },
+                                                    "value": "order"
+                                                  }
+                                                },
+                                                "dim": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 36,
+                                                    "startTokenPos": 501,
+                                                    "startFilePos": 1221,
+                                                    "endLine": 36,
+                                                    "endTokenPos": 501,
+                                                    "endFilePos": 1224,
+                                                    "kind": 2,
+                                                    "rawValue": "\"id\""
+                                                  },
+                                                  "value": "id"
+                                                }
+                                              },
+                                              "byRef": false,
+                                              "unpack": false
+                                            }
+                                          ]
+                                        },
+                                        "if": {
+                                          "nodeType": "Expr_FuncCall",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 507,
+                                            "startFilePos": 1230,
+                                            "endLine": 36,
+                                            "endTokenPos": 519,
+                                            "endFilePos": 1267
+                                          },
+                                          "name": {
+                                            "nodeType": "Name",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 507,
+                                              "startFilePos": 1230,
+                                              "endLine": 36,
+                                              "endTokenPos": 507,
+                                              "endFilePos": 1240
+                                            },
+                                            "name": "json_encode"
+                                          },
+                                          "args": [
+                                            {
+                                              "nodeType": "Arg",
+                                              "attributes": {
+                                                "startLine": 36,
+                                                "startTokenPos": 509,
+                                                "startFilePos": 1242,
+                                                "endLine": 36,
+                                                "endTokenPos": 515,
+                                                "endFilePos": 1260
+                                              },
+                                              "name": null,
+                                              "value": {
+                                                "nodeType": "Expr_ArrayDimFetch",
+                                                "attributes": {
+                                                  "startLine": 36,
+                                                  "startTokenPos": 509,
+                                                  "startFilePos": 1242,
+                                                  "endLine": 36,
+                                                  "endTokenPos": 515,
+                                                  "endFilePos": 1260
+                                                },
+                                                "var": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 36,
+                                                    "startTokenPos": 509,
+                                                    "startFilePos": 1242,
+                                                    "endLine": 36,
+                                                    "endTokenPos": 512,
+                                                    "endFilePos": 1254
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 36,
+                                                      "startTokenPos": 509,
+                                                      "startFilePos": 1242,
+                                                      "endLine": 36,
+                                                      "endTokenPos": 509,
+                                                      "endFilePos": 1245
+                                                    },
+                                                    "name": "row"
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 36,
+                                                      "startTokenPos": 511,
+                                                      "startFilePos": 1247,
+                                                      "endLine": 36,
+                                                      "endTokenPos": 511,
+                                                      "endFilePos": 1253,
+                                                      "kind": 2,
+                                                      "rawValue": "\"order\""
+                                                    },
+                                                    "value": "order"
+                                                  }
+                                                },
+                                                "dim": {
+                                                  "nodeType": "Scalar_String",
+                                                  "attributes": {
+                                                    "startLine": 36,
+                                                    "startTokenPos": 514,
+                                                    "startFilePos": 1256,
+                                                    "endLine": 36,
+                                                    "endTokenPos": 514,
+                                                    "endFilePos": 1259,
+                                                    "kind": 2,
+                                                    "rawValue": "\"id\""
+                                                  },
+                                                  "value": "id"
+                                                }
+                                              },
+                                              "byRef": false,
+                                              "unpack": false
+                                            },
+                                            {
+                                              "nodeType": "Arg",
+                                              "attributes": {
+                                                "startLine": 36,
+                                                "startTokenPos": 518,
+                                                "startFilePos": 1263,
+                                                "endLine": 36,
+                                                "endTokenPos": 518,
+                                                "endFilePos": 1266
+                                              },
+                                              "name": null,
+                                              "value": {
+                                                "nodeType": "Scalar_Int",
+                                                "attributes": {
+                                                  "startLine": 36,
+                                                  "startTokenPos": 518,
+                                                  "startFilePos": 1263,
+                                                  "endLine": 36,
+                                                  "endTokenPos": 518,
+                                                  "endFilePos": 1266,
+                                                  "rawValue": "1344",
+                                                  "kind": 10
+                                                },
+                                                "value": 1344
+                                              },
+                                              "byRef": false,
+                                              "unpack": false
+                                            }
+                                          ]
+                                        },
+                                        "else": {
+                                          "nodeType": "Expr_ArrayDimFetch",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 523,
+                                            "startFilePos": 1271,
+                                            "endLine": 36,
+                                            "endTokenPos": 529,
+                                            "endFilePos": 1289
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 523,
+                                              "startFilePos": 1271,
+                                              "endLine": 36,
+                                              "endTokenPos": 526,
+                                              "endFilePos": 1283
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 36,
+                                                "startTokenPos": 523,
+                                                "startFilePos": 1271,
+                                                "endLine": 36,
+                                                "endTokenPos": 523,
+                                                "endFilePos": 1274
+                                              },
+                                              "name": "row"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 36,
+                                                "startTokenPos": 525,
+                                                "startFilePos": 1276,
+                                                "endLine": 36,
+                                                "endTokenPos": 525,
+                                                "endFilePos": 1282,
+                                                "kind": 2,
+                                                "rawValue": "\"order\""
+                                              },
+                                              "value": "order"
+                                            }
+                                          },
+                                          "dim": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 528,
+                                              "startFilePos": 1285,
+                                              "endLine": 36,
+                                              "endTokenPos": 528,
+                                              "endFilePos": 1288,
+                                              "kind": 2,
+                                              "rawValue": "\"id\""
+                                            },
+                                            "value": "id"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "right": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 534,
+                                        "startFilePos": 1294,
+                                        "endLine": 36,
+                                        "endTokenPos": 534,
+                                        "endFilePos": 1296,
+                                        "kind": 2,
+                                        "rawValue": "\" \""
+                                      },
+                                      "value": " "
+                                    }
+                                  },
+                                  "right": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 538,
+                                      "startFilePos": 1300,
+                                      "endLine": 36,
+                                      "endTokenPos": 538,
+                                      "endFilePos": 1303,
+                                      "kind": 2,
+                                      "rawValue": "\"by\""
+                                    },
+                                    "value": "by"
+                                  }
+                                },
+                                "right": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 542,
+                                    "startFilePos": 1307,
+                                    "endLine": 36,
+                                    "endTokenPos": 542,
+                                    "endFilePos": 1309,
+                                    "kind": 2,
+                                    "rawValue": "\" \""
+                                  },
+                                  "value": " "
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Expr_Ternary",
+                                "attributes": {
+                                  "startLine": 36,
+                                  "startTokenPos": 547,
+                                  "startFilePos": 1314,
+                                  "endLine": 36,
+                                  "endTokenPos": 582,
+                                  "endFilePos": 1420
+                                },
+                                "cond": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 547,
+                                    "startFilePos": 1314,
+                                    "endLine": 36,
+                                    "endTokenPos": 556,
+                                    "endFilePos": 1347
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 547,
+                                      "startFilePos": 1314,
+                                      "endLine": 36,
+                                      "endTokenPos": 547,
+                                      "endFilePos": 1321
+                                    },
+                                    "name": "is_float"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 549,
+                                        "startFilePos": 1323,
+                                        "endLine": 36,
+                                        "endTokenPos": 555,
+                                        "endFilePos": 1346
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 36,
+                                          "startTokenPos": 549,
+                                          "startFilePos": 1323,
+                                          "endLine": 36,
+                                          "endTokenPos": 555,
+                                          "endFilePos": 1346
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_ArrayDimFetch",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 549,
+                                            "startFilePos": 1323,
+                                            "endLine": 36,
+                                            "endTokenPos": 552,
+                                            "endFilePos": 1338
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 549,
+                                              "startFilePos": 1323,
+                                              "endLine": 36,
+                                              "endTokenPos": 549,
+                                              "endFilePos": 1326
+                                            },
+                                            "name": "row"
+                                          },
+                                          "dim": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 551,
+                                              "startFilePos": 1328,
+                                              "endLine": 36,
+                                              "endTokenPos": 551,
+                                              "endFilePos": 1337,
+                                              "kind": 2,
+                                              "rawValue": "\"customer\""
+                                            },
+                                            "value": "customer"
+                                          }
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 554,
+                                            "startFilePos": 1340,
+                                            "endLine": 36,
+                                            "endTokenPos": 554,
+                                            "endFilePos": 1345,
+                                            "kind": 2,
+                                            "rawValue": "\"name\""
+                                          },
+                                          "value": "name"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "if": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 560,
+                                    "startFilePos": 1351,
+                                    "endLine": 36,
+                                    "endTokenPos": 572,
+                                    "endFilePos": 1393
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 560,
+                                      "startFilePos": 1351,
+                                      "endLine": 36,
+                                      "endTokenPos": 560,
+                                      "endFilePos": 1361
+                                    },
+                                    "name": "json_encode"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 562,
+                                        "startFilePos": 1363,
+                                        "endLine": 36,
+                                        "endTokenPos": 568,
+                                        "endFilePos": 1386
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_ArrayDimFetch",
+                                        "attributes": {
+                                          "startLine": 36,
+                                          "startTokenPos": 562,
+                                          "startFilePos": 1363,
+                                          "endLine": 36,
+                                          "endTokenPos": 568,
+                                          "endFilePos": 1386
+                                        },
+                                        "var": {
+                                          "nodeType": "Expr_ArrayDimFetch",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 562,
+                                            "startFilePos": 1363,
+                                            "endLine": 36,
+                                            "endTokenPos": 565,
+                                            "endFilePos": 1378
+                                          },
+                                          "var": {
+                                            "nodeType": "Expr_Variable",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 562,
+                                              "startFilePos": 1363,
+                                              "endLine": 36,
+                                              "endTokenPos": 562,
+                                              "endFilePos": 1366
+                                            },
+                                            "name": "row"
+                                          },
+                                          "dim": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 36,
+                                              "startTokenPos": 564,
+                                              "startFilePos": 1368,
+                                              "endLine": 36,
+                                              "endTokenPos": 564,
+                                              "endFilePos": 1377,
+                                              "kind": 2,
+                                              "rawValue": "\"customer\""
+                                            },
+                                            "value": "customer"
+                                          }
+                                        },
+                                        "dim": {
+                                          "nodeType": "Scalar_String",
+                                          "attributes": {
+                                            "startLine": 36,
+                                            "startTokenPos": 567,
+                                            "startFilePos": 1380,
+                                            "endLine": 36,
+                                            "endTokenPos": 567,
+                                            "endFilePos": 1385,
+                                            "kind": 2,
+                                            "rawValue": "\"name\""
+                                          },
+                                          "value": "name"
+                                        }
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 571,
+                                        "startFilePos": 1389,
+                                        "endLine": 36,
+                                        "endTokenPos": 571,
+                                        "endFilePos": 1392
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_Int",
+                                        "attributes": {
+                                          "startLine": 36,
+                                          "startTokenPos": 571,
+                                          "startFilePos": 1389,
+                                          "endLine": 36,
+                                          "endTokenPos": 571,
+                                          "endFilePos": 1392,
+                                          "rawValue": "1344",
+                                          "kind": 10
+                                        },
+                                        "value": 1344
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "else": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 576,
+                                    "startFilePos": 1397,
+                                    "endLine": 36,
+                                    "endTokenPos": 582,
+                                    "endFilePos": 1420
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 576,
+                                      "startFilePos": 1397,
+                                      "endLine": 36,
+                                      "endTokenPos": 579,
+                                      "endFilePos": 1412
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 576,
+                                        "startFilePos": 1397,
+                                        "endLine": 36,
+                                        "endTokenPos": 576,
+                                        "endFilePos": 1400
+                                      },
+                                      "name": "row"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 36,
+                                        "startTokenPos": 578,
+                                        "startFilePos": 1402,
+                                        "endLine": 36,
+                                        "endTokenPos": 578,
+                                        "endFilePos": 1411,
+                                        "kind": 2,
+                                        "rawValue": "\"customer\""
+                                      },
+                                      "value": "customer"
+                                    }
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 581,
+                                      "startFilePos": 1414,
+                                      "endLine": 36,
+                                      "endTokenPos": 581,
+                                      "endFilePos": 1419,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                }
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 587,
+                                "startFilePos": 1425,
+                                "endLine": 36,
+                                "endTokenPos": 587,
+                                "endFilePos": 1427,
+                                "kind": 2,
+                                "rawValue": "\" \""
+                              },
+                              "value": " "
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 36,
+                              "startTokenPos": 591,
+                              "startFilePos": 1431,
+                              "endLine": 36,
+                              "endTokenPos": 591,
+                              "endFilePos": 1435,
+                              "kind": 2,
+                              "rawValue": "\"- $\""
+                            },
+                            "value": "- $"
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 36,
+                            "startTokenPos": 595,
+                            "startFilePos": 1439,
+                            "endLine": 36,
+                            "endTokenPos": 595,
+                            "endFilePos": 1441,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_Ternary",
+                        "attributes": {
+                          "startLine": 36,
+                          "startTokenPos": 600,
+                          "startFilePos": 1446,
+                          "endLine": 36,
+                          "endTokenPos": 635,
+                          "endFilePos": 1546
+                        },
+                        "cond": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 36,
+                            "startTokenPos": 600,
+                            "startFilePos": 1446,
+                            "endLine": 36,
+                            "endTokenPos": 609,
+                            "endFilePos": 1477
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 36,
+                              "startTokenPos": 600,
+                              "startFilePos": 1446,
+                              "endLine": 36,
+                              "endTokenPos": 600,
+                              "endFilePos": 1453
+                            },
+                            "name": "is_float"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 602,
+                                "startFilePos": 1455,
+                                "endLine": 36,
+                                "endTokenPos": 608,
+                                "endFilePos": 1476
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 36,
+                                  "startTokenPos": 602,
+                                  "startFilePos": 1455,
+                                  "endLine": 36,
+                                  "endTokenPos": 608,
+                                  "endFilePos": 1476
+                                },
+                                "var": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 602,
+                                    "startFilePos": 1455,
+                                    "endLine": 36,
+                                    "endTokenPos": 605,
+                                    "endFilePos": 1467
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 602,
+                                      "startFilePos": 1455,
+                                      "endLine": 36,
+                                      "endTokenPos": 602,
+                                      "endFilePos": 1458
+                                    },
+                                    "name": "row"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 604,
+                                      "startFilePos": 1460,
+                                      "endLine": 36,
+                                      "endTokenPos": 604,
+                                      "endFilePos": 1466,
+                                      "kind": 2,
+                                      "rawValue": "\"order\""
+                                    },
+                                    "value": "order"
+                                  }
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 607,
+                                    "startFilePos": 1469,
+                                    "endLine": 36,
+                                    "endTokenPos": 607,
+                                    "endFilePos": 1475,
+                                    "kind": 2,
+                                    "rawValue": "\"total\""
+                                  },
+                                  "value": "total"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "if": {
+                          "nodeType": "Expr_FuncCall",
+                          "attributes": {
+                            "startLine": 36,
+                            "startTokenPos": 613,
+                            "startFilePos": 1481,
+                            "endLine": 36,
+                            "endTokenPos": 625,
+                            "endFilePos": 1521
+                          },
+                          "name": {
+                            "nodeType": "Name",
+                            "attributes": {
+                              "startLine": 36,
+                              "startTokenPos": 613,
+                              "startFilePos": 1481,
+                              "endLine": 36,
+                              "endTokenPos": 613,
+                              "endFilePos": 1491
+                            },
+                            "name": "json_encode"
+                          },
+                          "args": [
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 615,
+                                "startFilePos": 1493,
+                                "endLine": 36,
+                                "endTokenPos": 621,
+                                "endFilePos": 1514
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 36,
+                                  "startTokenPos": 615,
+                                  "startFilePos": 1493,
+                                  "endLine": 36,
+                                  "endTokenPos": 621,
+                                  "endFilePos": 1514
+                                },
+                                "var": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 615,
+                                    "startFilePos": 1493,
+                                    "endLine": 36,
+                                    "endTokenPos": 618,
+                                    "endFilePos": 1505
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 615,
+                                      "startFilePos": 1493,
+                                      "endLine": 36,
+                                      "endTokenPos": 615,
+                                      "endFilePos": 1496
+                                    },
+                                    "name": "row"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 36,
+                                      "startTokenPos": 617,
+                                      "startFilePos": 1498,
+                                      "endLine": 36,
+                                      "endTokenPos": 617,
+                                      "endFilePos": 1504,
+                                      "kind": 2,
+                                      "rawValue": "\"order\""
+                                    },
+                                    "value": "order"
+                                  }
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 36,
+                                    "startTokenPos": 620,
+                                    "startFilePos": 1507,
+                                    "endLine": 36,
+                                    "endTokenPos": 620,
+                                    "endFilePos": 1513,
+                                    "kind": 2,
+                                    "rawValue": "\"total\""
+                                  },
+                                  "value": "total"
+                                }
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            },
+                            {
+                              "nodeType": "Arg",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 624,
+                                "startFilePos": 1517,
+                                "endLine": 36,
+                                "endTokenPos": 624,
+                                "endFilePos": 1520
+                              },
+                              "name": null,
+                              "value": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 36,
+                                  "startTokenPos": 624,
+                                  "startFilePos": 1517,
+                                  "endLine": 36,
+                                  "endTokenPos": 624,
+                                  "endFilePos": 1520,
+                                  "rawValue": "1344",
+                                  "kind": 10
+                                },
+                                "value": 1344
+                              },
+                              "byRef": false,
+                              "unpack": false
+                            }
+                          ]
+                        },
+                        "else": {
+                          "nodeType": "Expr_ArrayDimFetch",
+                          "attributes": {
+                            "startLine": 36,
+                            "startTokenPos": 629,
+                            "startFilePos": 1525,
+                            "endLine": 36,
+                            "endTokenPos": 635,
+                            "endFilePos": 1546
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 36,
+                              "startTokenPos": 629,
+                              "startFilePos": 1525,
+                              "endLine": 36,
+                              "endTokenPos": 632,
+                              "endFilePos": 1537
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 629,
+                                "startFilePos": 1525,
+                                "endLine": 36,
+                                "endTokenPos": 629,
+                                "endFilePos": 1528
+                              },
+                              "name": "row"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 36,
+                                "startTokenPos": 631,
+                                "startFilePos": 1530,
+                                "endLine": 36,
+                                "endTokenPos": 631,
+                                "endFilePos": 1536,
+                                "kind": 2,
+                                "rawValue": "\"order\""
+                              },
+                              "value": "order"
+                            }
+                          },
+                          "dim": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 36,
+                              "startTokenPos": 634,
+                              "startFilePos": 1539,
+                              "endLine": 36,
+                              "endTokenPos": 634,
+                              "endFilePos": 1545,
+                              "kind": 2,
+                              "rawValue": "\"total\""
+                            },
+                            "value": "total"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "nodeType": "Expr_ConstFetch",
+                      "attributes": {
+                        "startLine": 36,
+                        "startTokenPos": 639,
+                        "startFilePos": 1550,
+                        "endLine": 36,
+                        "endTokenPos": 639,
+                        "endFilePos": 1556
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 36,
+                          "startTokenPos": 639,
+                          "startFilePos": 1550,
+                          "endLine": 36,
+                          "endTokenPos": 639,
+                          "endFilePos": 1556
+                        },
+                        "name": "PHP_EOL"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "elseifs": [],
+              "else": {
+                "nodeType": "Stmt_Else",
+                "attributes": {
+                  "startLine": 37,
+                  "startTokenPos": 644,
+                  "startFilePos": 1561,
+                  "endLine": 39,
+                  "endTokenPos": 770,
+                  "endFilePos": 1853
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Echo",
+                    "attributes": {
+                      "startLine": 38,
+                      "startTokenPos": 648,
+                      "startFilePos": 1570,
+                      "endLine": 38,
+                      "endTokenPos": 768,
+                      "endFilePos": 1851
+                    },
+                    "exprs": [
+                      {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 38,
+                          "startTokenPos": 650,
+                          "startFilePos": 1575,
+                          "endLine": 38,
+                          "endTokenPos": 764,
+                          "endFilePos": 1841
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 38,
+                            "startTokenPos": 650,
+                            "startFilePos": 1575,
+                            "endLine": 38,
+                            "endTokenPos": 723,
+                            "endFilePos": 1735
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 650,
+                              "startFilePos": 1575,
+                              "endLine": 38,
+                              "endTokenPos": 719,
+                              "endFilePos": 1729
+                            },
+                            "left": {
+                              "nodeType": "Expr_BinaryOp_Concat",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 650,
+                                "startFilePos": 1575,
+                                "endLine": 38,
+                                "endTokenPos": 715,
+                                "endFilePos": 1721
+                              },
+                              "left": {
+                                "nodeType": "Expr_BinaryOp_Concat",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 650,
+                                  "startFilePos": 1575,
+                                  "endLine": 38,
+                                  "endTokenPos": 711,
+                                  "endFilePos": 1715
+                                },
+                                "left": {
+                                  "nodeType": "Expr_BinaryOp_Concat",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 650,
+                                    "startFilePos": 1575,
+                                    "endLine": 38,
+                                    "endTokenPos": 707,
+                                    "endFilePos": 1703
+                                  },
+                                  "left": {
+                                    "nodeType": "Expr_BinaryOp_Concat",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 650,
+                                      "startFilePos": 1575,
+                                      "endLine": 38,
+                                      "endTokenPos": 703,
+                                      "endFilePos": 1697
+                                    },
+                                    "left": {
+                                      "nodeType": "Expr_BinaryOp_Concat",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 650,
+                                        "startFilePos": 1575,
+                                        "endLine": 38,
+                                        "endTokenPos": 699,
+                                        "endFilePos": 1690
+                                      },
+                                      "left": {
+                                        "nodeType": "Expr_BinaryOp_Concat",
+                                        "attributes": {
+                                          "startLine": 38,
+                                          "startTokenPos": 650,
+                                          "startFilePos": 1575,
+                                          "endLine": 38,
+                                          "endTokenPos": 695,
+                                          "endFilePos": 1684
+                                        },
+                                        "left": {
+                                          "nodeType": "Expr_BinaryOp_Concat",
+                                          "attributes": {
+                                            "startLine": 38,
+                                            "startTokenPos": 650,
+                                            "startFilePos": 1575,
+                                            "endLine": 38,
+                                            "endTokenPos": 654,
+                                            "endFilePos": 1587
+                                          },
+                                          "left": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 650,
+                                              "startFilePos": 1575,
+                                              "endLine": 38,
+                                              "endTokenPos": 650,
+                                              "endFilePos": 1581,
+                                              "kind": 2,
+                                              "rawValue": "\"Order\""
+                                            },
+                                            "value": "Order"
+                                          },
+                                          "right": {
+                                            "nodeType": "Scalar_String",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 654,
+                                              "startFilePos": 1585,
+                                              "endLine": 38,
+                                              "endTokenPos": 654,
+                                              "endFilePos": 1587,
+                                              "kind": 2,
+                                              "rawValue": "\" \""
+                                            },
+                                            "value": " "
+                                          }
+                                        },
+                                        "right": {
+                                          "nodeType": "Expr_Ternary",
+                                          "attributes": {
+                                            "startLine": 38,
+                                            "startTokenPos": 659,
+                                            "startFilePos": 1592,
+                                            "endLine": 38,
+                                            "endTokenPos": 694,
+                                            "endFilePos": 1683
+                                          },
+                                          "cond": {
+                                            "nodeType": "Expr_FuncCall",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 659,
+                                              "startFilePos": 1592,
+                                              "endLine": 38,
+                                              "endTokenPos": 668,
+                                              "endFilePos": 1620
+                                            },
+                                            "name": {
+                                              "nodeType": "Name",
+                                              "attributes": {
+                                                "startLine": 38,
+                                                "startTokenPos": 659,
+                                                "startFilePos": 1592,
+                                                "endLine": 38,
+                                                "endTokenPos": 659,
+                                                "endFilePos": 1599
+                                              },
+                                              "name": "is_float"
+                                            },
+                                            "args": [
+                                              {
+                                                "nodeType": "Arg",
+                                                "attributes": {
+                                                  "startLine": 38,
+                                                  "startTokenPos": 661,
+                                                  "startFilePos": 1601,
+                                                  "endLine": 38,
+                                                  "endTokenPos": 667,
+                                                  "endFilePos": 1619
+                                                },
+                                                "name": null,
+                                                "value": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 38,
+                                                    "startTokenPos": 661,
+                                                    "startFilePos": 1601,
+                                                    "endLine": 38,
+                                                    "endTokenPos": 667,
+                                                    "endFilePos": 1619
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 38,
+                                                      "startTokenPos": 661,
+                                                      "startFilePos": 1601,
+                                                      "endLine": 38,
+                                                      "endTokenPos": 664,
+                                                      "endFilePos": 1613
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 38,
+                                                        "startTokenPos": 661,
+                                                        "startFilePos": 1601,
+                                                        "endLine": 38,
+                                                        "endTokenPos": 661,
+                                                        "endFilePos": 1604
+                                                      },
+                                                      "name": "row"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 38,
+                                                        "startTokenPos": 663,
+                                                        "startFilePos": 1606,
+                                                        "endLine": 38,
+                                                        "endTokenPos": 663,
+                                                        "endFilePos": 1612,
+                                                        "kind": 2,
+                                                        "rawValue": "\"order\""
+                                                      },
+                                                      "value": "order"
+                                                    }
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 38,
+                                                      "startTokenPos": 666,
+                                                      "startFilePos": 1615,
+                                                      "endLine": 38,
+                                                      "endTokenPos": 666,
+                                                      "endFilePos": 1618,
+                                                      "kind": 2,
+                                                      "rawValue": "\"id\""
+                                                    },
+                                                    "value": "id"
+                                                  }
+                                                },
+                                                "byRef": false,
+                                                "unpack": false
+                                              }
+                                            ]
+                                          },
+                                          "if": {
+                                            "nodeType": "Expr_FuncCall",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 672,
+                                              "startFilePos": 1624,
+                                              "endLine": 38,
+                                              "endTokenPos": 684,
+                                              "endFilePos": 1661
+                                            },
+                                            "name": {
+                                              "nodeType": "Name",
+                                              "attributes": {
+                                                "startLine": 38,
+                                                "startTokenPos": 672,
+                                                "startFilePos": 1624,
+                                                "endLine": 38,
+                                                "endTokenPos": 672,
+                                                "endFilePos": 1634
+                                              },
+                                              "name": "json_encode"
+                                            },
+                                            "args": [
+                                              {
+                                                "nodeType": "Arg",
+                                                "attributes": {
+                                                  "startLine": 38,
+                                                  "startTokenPos": 674,
+                                                  "startFilePos": 1636,
+                                                  "endLine": 38,
+                                                  "endTokenPos": 680,
+                                                  "endFilePos": 1654
+                                                },
+                                                "name": null,
+                                                "value": {
+                                                  "nodeType": "Expr_ArrayDimFetch",
+                                                  "attributes": {
+                                                    "startLine": 38,
+                                                    "startTokenPos": 674,
+                                                    "startFilePos": 1636,
+                                                    "endLine": 38,
+                                                    "endTokenPos": 680,
+                                                    "endFilePos": 1654
+                                                  },
+                                                  "var": {
+                                                    "nodeType": "Expr_ArrayDimFetch",
+                                                    "attributes": {
+                                                      "startLine": 38,
+                                                      "startTokenPos": 674,
+                                                      "startFilePos": 1636,
+                                                      "endLine": 38,
+                                                      "endTokenPos": 677,
+                                                      "endFilePos": 1648
+                                                    },
+                                                    "var": {
+                                                      "nodeType": "Expr_Variable",
+                                                      "attributes": {
+                                                        "startLine": 38,
+                                                        "startTokenPos": 674,
+                                                        "startFilePos": 1636,
+                                                        "endLine": 38,
+                                                        "endTokenPos": 674,
+                                                        "endFilePos": 1639
+                                                      },
+                                                      "name": "row"
+                                                    },
+                                                    "dim": {
+                                                      "nodeType": "Scalar_String",
+                                                      "attributes": {
+                                                        "startLine": 38,
+                                                        "startTokenPos": 676,
+                                                        "startFilePos": 1641,
+                                                        "endLine": 38,
+                                                        "endTokenPos": 676,
+                                                        "endFilePos": 1647,
+                                                        "kind": 2,
+                                                        "rawValue": "\"order\""
+                                                      },
+                                                      "value": "order"
+                                                    }
+                                                  },
+                                                  "dim": {
+                                                    "nodeType": "Scalar_String",
+                                                    "attributes": {
+                                                      "startLine": 38,
+                                                      "startTokenPos": 679,
+                                                      "startFilePos": 1650,
+                                                      "endLine": 38,
+                                                      "endTokenPos": 679,
+                                                      "endFilePos": 1653,
+                                                      "kind": 2,
+                                                      "rawValue": "\"id\""
+                                                    },
+                                                    "value": "id"
+                                                  }
+                                                },
+                                                "byRef": false,
+                                                "unpack": false
+                                              },
+                                              {
+                                                "nodeType": "Arg",
+                                                "attributes": {
+                                                  "startLine": 38,
+                                                  "startTokenPos": 683,
+                                                  "startFilePos": 1657,
+                                                  "endLine": 38,
+                                                  "endTokenPos": 683,
+                                                  "endFilePos": 1660
+                                                },
+                                                "name": null,
+                                                "value": {
+                                                  "nodeType": "Scalar_Int",
+                                                  "attributes": {
+                                                    "startLine": 38,
+                                                    "startTokenPos": 683,
+                                                    "startFilePos": 1657,
+                                                    "endLine": 38,
+                                                    "endTokenPos": 683,
+                                                    "endFilePos": 1660,
+                                                    "rawValue": "1344",
+                                                    "kind": 10
+                                                  },
+                                                  "value": 1344
+                                                },
+                                                "byRef": false,
+                                                "unpack": false
+                                              }
+                                            ]
+                                          },
+                                          "else": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 38,
+                                              "startTokenPos": 688,
+                                              "startFilePos": 1665,
+                                              "endLine": 38,
+                                              "endTokenPos": 694,
+                                              "endFilePos": 1683
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_ArrayDimFetch",
+                                              "attributes": {
+                                                "startLine": 38,
+                                                "startTokenPos": 688,
+                                                "startFilePos": 1665,
+                                                "endLine": 38,
+                                                "endTokenPos": 691,
+                                                "endFilePos": 1677
+                                              },
+                                              "var": {
+                                                "nodeType": "Expr_Variable",
+                                                "attributes": {
+                                                  "startLine": 38,
+                                                  "startTokenPos": 688,
+                                                  "startFilePos": 1665,
+                                                  "endLine": 38,
+                                                  "endTokenPos": 688,
+                                                  "endFilePos": 1668
+                                                },
+                                                "name": "row"
+                                              },
+                                              "dim": {
+                                                "nodeType": "Scalar_String",
+                                                "attributes": {
+                                                  "startLine": 38,
+                                                  "startTokenPos": 690,
+                                                  "startFilePos": 1670,
+                                                  "endLine": 38,
+                                                  "endTokenPos": 690,
+                                                  "endFilePos": 1676,
+                                                  "kind": 2,
+                                                  "rawValue": "\"order\""
+                                                },
+                                                "value": "order"
+                                              }
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 38,
+                                                "startTokenPos": 693,
+                                                "startFilePos": 1679,
+                                                "endLine": 38,
+                                                "endTokenPos": 693,
+                                                "endFilePos": 1682,
+                                                "kind": 2,
+                                                "rawValue": "\"id\""
+                                              },
+                                              "value": "id"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "right": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 38,
+                                          "startTokenPos": 699,
+                                          "startFilePos": 1688,
+                                          "endLine": 38,
+                                          "endTokenPos": 699,
+                                          "endFilePos": 1690,
+                                          "kind": 2,
+                                          "rawValue": "\" \""
+                                        },
+                                        "value": " "
+                                      }
+                                    },
+                                    "right": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 703,
+                                        "startFilePos": 1694,
+                                        "endLine": 38,
+                                        "endTokenPos": 703,
+                                        "endFilePos": 1697,
+                                        "kind": 2,
+                                        "rawValue": "\"by\""
+                                      },
+                                      "value": "by"
+                                    }
+                                  },
+                                  "right": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 707,
+                                      "startFilePos": 1701,
+                                      "endLine": 38,
+                                      "endTokenPos": 707,
+                                      "endFilePos": 1703,
+                                      "kind": 2,
+                                      "rawValue": "\" \""
+                                    },
+                                    "value": " "
+                                  }
+                                },
+                                "right": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 711,
+                                    "startFilePos": 1707,
+                                    "endLine": 38,
+                                    "endTokenPos": 711,
+                                    "endFilePos": 1715,
+                                    "kind": 2,
+                                    "rawValue": "\"Unknown\""
+                                  },
+                                  "value": "Unknown"
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 715,
+                                  "startFilePos": 1719,
+                                  "endLine": 38,
+                                  "endTokenPos": 715,
+                                  "endFilePos": 1721,
+                                  "kind": 2,
+                                  "rawValue": "\" \""
+                                },
+                                "value": " "
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 719,
+                                "startFilePos": 1725,
+                                "endLine": 38,
+                                "endTokenPos": 719,
+                                "endFilePos": 1729,
+                                "kind": 2,
+                                "rawValue": "\"- $\""
+                              },
+                              "value": "- $"
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 723,
+                              "startFilePos": 1733,
+                              "endLine": 38,
+                              "endTokenPos": 723,
+                              "endFilePos": 1735,
+                              "kind": 2,
+                              "rawValue": "\" \""
+                            },
+                            "value": " "
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Expr_Ternary",
+                          "attributes": {
+                            "startLine": 38,
+                            "startTokenPos": 728,
+                            "startFilePos": 1740,
+                            "endLine": 38,
+                            "endTokenPos": 763,
+                            "endFilePos": 1840
+                          },
+                          "cond": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 728,
+                              "startFilePos": 1740,
+                              "endLine": 38,
+                              "endTokenPos": 737,
+                              "endFilePos": 1771
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 728,
+                                "startFilePos": 1740,
+                                "endLine": 38,
+                                "endTokenPos": 728,
+                                "endFilePos": 1747
+                              },
+                              "name": "is_float"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 730,
+                                  "startFilePos": 1749,
+                                  "endLine": 38,
+                                  "endTokenPos": 736,
+                                  "endFilePos": 1770
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 730,
+                                    "startFilePos": 1749,
+                                    "endLine": 38,
+                                    "endTokenPos": 736,
+                                    "endFilePos": 1770
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 730,
+                                      "startFilePos": 1749,
+                                      "endLine": 38,
+                                      "endTokenPos": 733,
+                                      "endFilePos": 1761
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 730,
+                                        "startFilePos": 1749,
+                                        "endLine": 38,
+                                        "endTokenPos": 730,
+                                        "endFilePos": 1752
+                                      },
+                                      "name": "row"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 732,
+                                        "startFilePos": 1754,
+                                        "endLine": 38,
+                                        "endTokenPos": 732,
+                                        "endFilePos": 1760,
+                                        "kind": 2,
+                                        "rawValue": "\"order\""
+                                      },
+                                      "value": "order"
+                                    }
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 735,
+                                      "startFilePos": 1763,
+                                      "endLine": 38,
+                                      "endTokenPos": 735,
+                                      "endFilePos": 1769,
+                                      "kind": 2,
+                                      "rawValue": "\"total\""
+                                    },
+                                    "value": "total"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "if": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 741,
+                              "startFilePos": 1775,
+                              "endLine": 38,
+                              "endTokenPos": 753,
+                              "endFilePos": 1815
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 741,
+                                "startFilePos": 1775,
+                                "endLine": 38,
+                                "endTokenPos": 741,
+                                "endFilePos": 1785
+                              },
+                              "name": "json_encode"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 743,
+                                  "startFilePos": 1787,
+                                  "endLine": 38,
+                                  "endTokenPos": 749,
+                                  "endFilePos": 1808
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 743,
+                                    "startFilePos": 1787,
+                                    "endLine": 38,
+                                    "endTokenPos": 749,
+                                    "endFilePos": 1808
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 743,
+                                      "startFilePos": 1787,
+                                      "endLine": 38,
+                                      "endTokenPos": 746,
+                                      "endFilePos": 1799
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 743,
+                                        "startFilePos": 1787,
+                                        "endLine": 38,
+                                        "endTokenPos": 743,
+                                        "endFilePos": 1790
+                                      },
+                                      "name": "row"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 38,
+                                        "startTokenPos": 745,
+                                        "startFilePos": 1792,
+                                        "endLine": 38,
+                                        "endTokenPos": 745,
+                                        "endFilePos": 1798,
+                                        "kind": 2,
+                                        "rawValue": "\"order\""
+                                      },
+                                      "value": "order"
+                                    }
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 38,
+                                      "startTokenPos": 748,
+                                      "startFilePos": 1801,
+                                      "endLine": 38,
+                                      "endTokenPos": 748,
+                                      "endFilePos": 1807,
+                                      "kind": 2,
+                                      "rawValue": "\"total\""
+                                    },
+                                    "value": "total"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 752,
+                                  "startFilePos": 1811,
+                                  "endLine": 38,
+                                  "endTokenPos": 752,
+                                  "endFilePos": 1814
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 38,
+                                    "startTokenPos": 752,
+                                    "startFilePos": 1811,
+                                    "endLine": 38,
+                                    "endTokenPos": 752,
+                                    "endFilePos": 1814,
+                                    "rawValue": "1344",
+                                    "kind": 10
+                                  },
+                                  "value": 1344
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "else": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 38,
+                              "startTokenPos": 757,
+                              "startFilePos": 1819,
+                              "endLine": 38,
+                              "endTokenPos": 763,
+                              "endFilePos": 1840
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 757,
+                                "startFilePos": 1819,
+                                "endLine": 38,
+                                "endTokenPos": 760,
+                                "endFilePos": 1831
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 757,
+                                  "startFilePos": 1819,
+                                  "endLine": 38,
+                                  "endTokenPos": 757,
+                                  "endFilePos": 1822
+                                },
+                                "name": "row"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 38,
+                                  "startTokenPos": 759,
+                                  "startFilePos": 1824,
+                                  "endLine": 38,
+                                  "endTokenPos": 759,
+                                  "endFilePos": 1830,
+                                  "kind": 2,
+                                  "rawValue": "\"order\""
+                                },
+                                "value": "order"
+                              }
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 38,
+                                "startTokenPos": 762,
+                                "startFilePos": 1833,
+                                "endLine": 38,
+                                "endTokenPos": 762,
+                                "endFilePos": 1839,
+                                "kind": 2,
+                                "rawValue": "\"total\""
+                              },
+                              "value": "total"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Expr_ConstFetch",
+                        "attributes": {
+                          "startLine": 38,
+                          "startTokenPos": 767,
+                          "startFilePos": 1844,
+                          "endLine": 38,
+                          "endTokenPos": 767,
+                          "endFilePos": 1850
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 38,
+                            "startTokenPos": 767,
+                            "startFilePos": 1844,
+                            "endLine": 38,
+                            "endTokenPos": 767,
+                            "endFilePos": 1850
+                          },
+                          "name": "PHP_EOL"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": {
+            "nodeType": "Stmt_Else",
+            "attributes": {
+              "startLine": 40,
+              "startTokenPos": 775,
+              "startFilePos": 1858,
+              "endLine": 42,
+              "endTokenPos": 840,
+              "endFilePos": 2035
+            },
+            "stmts": [
+              {
+                "nodeType": "Stmt_Echo",
+                "attributes": {
+                  "startLine": 41,
+                  "startTokenPos": 779,
+                  "startFilePos": 1867,
+                  "endLine": 41,
+                  "endTokenPos": 838,
+                  "endFilePos": 2033
+                },
+                "exprs": [
+                  {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 41,
+                      "startTokenPos": 781,
+                      "startFilePos": 1872,
+                      "endLine": 41,
+                      "endTokenPos": 834,
+                      "endFilePos": 2023
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 41,
+                        "startTokenPos": 781,
+                        "startFilePos": 1872,
+                        "endLine": 41,
+                        "endTokenPos": 830,
+                        "endFilePos": 2005
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 41,
+                          "startTokenPos": 781,
+                          "startFilePos": 1872,
+                          "endLine": 41,
+                          "endTokenPos": 826,
+                          "endFilePos": 1999
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 41,
+                            "startTokenPos": 781,
+                            "startFilePos": 1872,
+                            "endLine": 41,
+                            "endTokenPos": 785,
+                            "endFilePos": 1887
+                          },
+                          "left": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 41,
+                              "startTokenPos": 781,
+                              "startFilePos": 1872,
+                              "endLine": 41,
+                              "endTokenPos": 781,
+                              "endFilePos": 1881,
+                              "kind": 2,
+                              "rawValue": "\"Customer\""
+                            },
+                            "value": "Customer"
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 41,
+                              "startTokenPos": 785,
+                              "startFilePos": 1885,
+                              "endLine": 41,
+                              "endTokenPos": 785,
+                              "endFilePos": 1887,
+                              "kind": 2,
+                              "rawValue": "\" \""
+                            },
+                            "value": " "
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Expr_Ternary",
+                          "attributes": {
+                            "startLine": 41,
+                            "startTokenPos": 790,
+                            "startFilePos": 1892,
+                            "endLine": 41,
+                            "endTokenPos": 825,
+                            "endFilePos": 1998
+                          },
+                          "cond": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 41,
+                              "startTokenPos": 790,
+                              "startFilePos": 1892,
+                              "endLine": 41,
+                              "endTokenPos": 799,
+                              "endFilePos": 1925
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 41,
+                                "startTokenPos": 790,
+                                "startFilePos": 1892,
+                                "endLine": 41,
+                                "endTokenPos": 790,
+                                "endFilePos": 1899
+                              },
+                              "name": "is_float"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 41,
+                                  "startTokenPos": 792,
+                                  "startFilePos": 1901,
+                                  "endLine": 41,
+                                  "endTokenPos": 798,
+                                  "endFilePos": 1924
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 41,
+                                    "startTokenPos": 792,
+                                    "startFilePos": 1901,
+                                    "endLine": 41,
+                                    "endTokenPos": 798,
+                                    "endFilePos": 1924
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 41,
+                                      "startTokenPos": 792,
+                                      "startFilePos": 1901,
+                                      "endLine": 41,
+                                      "endTokenPos": 795,
+                                      "endFilePos": 1916
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 41,
+                                        "startTokenPos": 792,
+                                        "startFilePos": 1901,
+                                        "endLine": 41,
+                                        "endTokenPos": 792,
+                                        "endFilePos": 1904
+                                      },
+                                      "name": "row"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 41,
+                                        "startTokenPos": 794,
+                                        "startFilePos": 1906,
+                                        "endLine": 41,
+                                        "endTokenPos": 794,
+                                        "endFilePos": 1915,
+                                        "kind": 2,
+                                        "rawValue": "\"customer\""
+                                      },
+                                      "value": "customer"
+                                    }
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 41,
+                                      "startTokenPos": 797,
+                                      "startFilePos": 1918,
+                                      "endLine": 41,
+                                      "endTokenPos": 797,
+                                      "endFilePos": 1923,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "if": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 41,
+                              "startTokenPos": 803,
+                              "startFilePos": 1929,
+                              "endLine": 41,
+                              "endTokenPos": 815,
+                              "endFilePos": 1971
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 41,
+                                "startTokenPos": 803,
+                                "startFilePos": 1929,
+                                "endLine": 41,
+                                "endTokenPos": 803,
+                                "endFilePos": 1939
+                              },
+                              "name": "json_encode"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 41,
+                                  "startTokenPos": 805,
+                                  "startFilePos": 1941,
+                                  "endLine": 41,
+                                  "endTokenPos": 811,
+                                  "endFilePos": 1964
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 41,
+                                    "startTokenPos": 805,
+                                    "startFilePos": 1941,
+                                    "endLine": 41,
+                                    "endTokenPos": 811,
+                                    "endFilePos": 1964
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 41,
+                                      "startTokenPos": 805,
+                                      "startFilePos": 1941,
+                                      "endLine": 41,
+                                      "endTokenPos": 808,
+                                      "endFilePos": 1956
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 41,
+                                        "startTokenPos": 805,
+                                        "startFilePos": 1941,
+                                        "endLine": 41,
+                                        "endTokenPos": 805,
+                                        "endFilePos": 1944
+                                      },
+                                      "name": "row"
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 41,
+                                        "startTokenPos": 807,
+                                        "startFilePos": 1946,
+                                        "endLine": 41,
+                                        "endTokenPos": 807,
+                                        "endFilePos": 1955,
+                                        "kind": 2,
+                                        "rawValue": "\"customer\""
+                                      },
+                                      "value": "customer"
+                                    }
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 41,
+                                      "startTokenPos": 810,
+                                      "startFilePos": 1958,
+                                      "endLine": 41,
+                                      "endTokenPos": 810,
+                                      "endFilePos": 1963,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 41,
+                                  "startTokenPos": 814,
+                                  "startFilePos": 1967,
+                                  "endLine": 41,
+                                  "endTokenPos": 814,
+                                  "endFilePos": 1970
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 41,
+                                    "startTokenPos": 814,
+                                    "startFilePos": 1967,
+                                    "endLine": 41,
+                                    "endTokenPos": 814,
+                                    "endFilePos": 1970,
+                                    "rawValue": "1344",
+                                    "kind": 10
+                                  },
+                                  "value": 1344
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "else": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 41,
+                              "startTokenPos": 819,
+                              "startFilePos": 1975,
+                              "endLine": 41,
+                              "endTokenPos": 825,
+                              "endFilePos": 1998
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 41,
+                                "startTokenPos": 819,
+                                "startFilePos": 1975,
+                                "endLine": 41,
+                                "endTokenPos": 822,
+                                "endFilePos": 1990
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 41,
+                                  "startTokenPos": 819,
+                                  "startFilePos": 1975,
+                                  "endLine": 41,
+                                  "endTokenPos": 819,
+                                  "endFilePos": 1978
+                                },
+                                "name": "row"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 41,
+                                  "startTokenPos": 821,
+                                  "startFilePos": 1980,
+                                  "endLine": 41,
+                                  "endTokenPos": 821,
+                                  "endFilePos": 1989,
+                                  "kind": 2,
+                                  "rawValue": "\"customer\""
+                                },
+                                "value": "customer"
+                              }
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 41,
+                                "startTokenPos": 824,
+                                "startFilePos": 1992,
+                                "endLine": 41,
+                                "endTokenPos": 824,
+                                "endFilePos": 1997,
+                                "kind": 2,
+                                "rawValue": "\"name\""
+                              },
+                              "value": "name"
+                            }
+                          }
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 41,
+                          "startTokenPos": 830,
+                          "startFilePos": 2003,
+                          "endLine": 41,
+                          "endTokenPos": 830,
+                          "endFilePos": 2005,
+                          "kind": 2,
+                          "rawValue": "\" \""
+                        },
+                        "value": " "
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 41,
+                        "startTokenPos": 834,
+                        "startFilePos": 2009,
+                        "endLine": 41,
+                        "endTokenPos": 834,
+                        "endFilePos": 2023,
+                        "kind": 2,
+                        "rawValue": "\"has no orders\""
+                      },
+                      "value": "has no orders"
+                    }
+                  },
+                  {
+                    "nodeType": "Expr_ConstFetch",
+                    "attributes": {
+                      "startLine": 41,
+                      "startTokenPos": 837,
+                      "startFilePos": 2026,
+                      "endLine": 41,
+                      "endTokenPos": 837,
+                      "endFilePos": 2032
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 41,
+                        "startTokenPos": 837,
+                        "startFilePos": 2026,
+                        "endLine": 41,
+                        "endTokenPos": 837,
+                        "endFilePos": 2032
+                      },
+                      "name": "PHP_EOL"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/partial_application.php.json
+++ b/tests/json-ast/x/php/partial_application.php.json
@@ -1,0 +1,626 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 22,
+        "endFilePos": 47
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 17
+        },
+        "name": "add"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 20
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 19,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 20
+            },
+            "name": "a"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 8,
+            "startFilePos": 23,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 24
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 23,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 24
+            },
+            "name": "b"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 31,
+            "endLine": 3,
+            "endTokenPos": 20,
+            "endFilePos": 45
+          },
+          "expr": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 15,
+              "startFilePos": 38,
+              "endLine": 3,
+              "endTokenPos": 19,
+              "endFilePos": 44
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 15,
+                "startFilePos": 38,
+                "endLine": 3,
+                "endTokenPos": 15,
+                "endFilePos": 39
+              },
+              "name": "a"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 19,
+                "startFilePos": 43,
+                "endLine": 3,
+                "endTokenPos": 19,
+                "endFilePos": 44
+              },
+              "name": "b"
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 24,
+        "startFilePos": 49,
+        "endLine": 7,
+        "endTokenPos": 47,
+        "endFilePos": 96
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 24,
+          "startFilePos": 49,
+          "endLine": 7,
+          "endTokenPos": 46,
+          "endFilePos": 95
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 24,
+            "startFilePos": 49,
+            "endLine": 5,
+            "endTokenPos": 24,
+            "endFilePos": 53
+          },
+          "name": "add5"
+        },
+        "expr": {
+          "nodeType": "Expr_Closure",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 28,
+            "startFilePos": 57,
+            "endLine": 7,
+            "endTokenPos": 46,
+            "endFilePos": 95
+          },
+          "static": false,
+          "byRef": false,
+          "params": [
+            {
+              "nodeType": "Param",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 30,
+                "startFilePos": 66,
+                "endLine": 5,
+                "endTokenPos": 30,
+                "endFilePos": 68
+              },
+              "type": null,
+              "byRef": false,
+              "variadic": false,
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 30,
+                  "startFilePos": 66,
+                  "endLine": 5,
+                  "endTokenPos": 30,
+                  "endFilePos": 68
+                },
+                "name": "a0"
+              },
+              "default": null,
+              "flags": 0,
+              "attrGroups": [],
+              "hooks": []
+            }
+          ],
+          "uses": [],
+          "returnType": null,
+          "stmts": [
+            {
+              "nodeType": "Stmt_Return",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 35,
+                "startFilePos": 75,
+                "endLine": 6,
+                "endTokenPos": 44,
+                "endFilePos": 93
+              },
+              "expr": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 37,
+                  "startFilePos": 82,
+                  "endLine": 6,
+                  "endTokenPos": 43,
+                  "endFilePos": 92
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 37,
+                    "startFilePos": 82,
+                    "endLine": 6,
+                    "endTokenPos": 37,
+                    "endFilePos": 84
+                  },
+                  "name": "add"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 39,
+                      "startFilePos": 86,
+                      "endLine": 6,
+                      "endTokenPos": 39,
+                      "endFilePos": 86
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 39,
+                        "startFilePos": 86,
+                        "endLine": 6,
+                        "endTokenPos": 39,
+                        "endFilePos": 86,
+                        "rawValue": "5",
+                        "kind": 10
+                      },
+                      "value": 5
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 42,
+                      "startFilePos": 89,
+                      "endLine": 6,
+                      "endTokenPos": 42,
+                      "endFilePos": 91
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 42,
+                        "startFilePos": 89,
+                        "endLine": 6,
+                        "endTokenPos": 42,
+                        "endFilePos": 91
+                      },
+                      "name": "a0"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              }
+            }
+          ],
+          "attrGroups": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 49,
+        "startFilePos": 98,
+        "endLine": 8,
+        "endTokenPos": 83,
+        "endFilePos": 173
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 52,
+            "startFilePos": 104,
+            "endLine": 8,
+            "endTokenPos": 78,
+            "endFilePos": 162
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 52,
+              "startFilePos": 104,
+              "endLine": 8,
+              "endTokenPos": 58,
+              "endFilePos": 121
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 52,
+                "startFilePos": 104,
+                "endLine": 8,
+                "endTokenPos": 52,
+                "endFilePos": 111
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 54,
+                  "startFilePos": 113,
+                  "endLine": 8,
+                  "endTokenPos": 57,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 54,
+                    "startFilePos": 113,
+                    "endLine": 8,
+                    "endTokenPos": 57,
+                    "endFilePos": 120
+                  },
+                  "name": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 54,
+                      "startFilePos": 113,
+                      "endLine": 8,
+                      "endTokenPos": 54,
+                      "endFilePos": 117
+                    },
+                    "name": "add5"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 56,
+                        "startFilePos": 119,
+                        "endLine": 8,
+                        "endTokenPos": 56,
+                        "endFilePos": 119
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 56,
+                          "startFilePos": 119,
+                          "endLine": 8,
+                          "endTokenPos": 56,
+                          "endFilePos": 119,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 62,
+              "startFilePos": 125,
+              "endLine": 8,
+              "endTokenPos": 71,
+              "endFilePos": 151
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 62,
+                "startFilePos": 125,
+                "endLine": 8,
+                "endTokenPos": 62,
+                "endFilePos": 135
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 64,
+                  "startFilePos": 137,
+                  "endLine": 8,
+                  "endTokenPos": 67,
+                  "endFilePos": 144
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 64,
+                    "startFilePos": 137,
+                    "endLine": 8,
+                    "endTokenPos": 67,
+                    "endFilePos": 144
+                  },
+                  "name": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 64,
+                      "startFilePos": 137,
+                      "endLine": 8,
+                      "endTokenPos": 64,
+                      "endFilePos": 141
+                    },
+                    "name": "add5"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 66,
+                        "startFilePos": 143,
+                        "endLine": 8,
+                        "endTokenPos": 66,
+                        "endFilePos": 143
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 66,
+                          "startFilePos": 143,
+                          "endLine": 8,
+                          "endTokenPos": 66,
+                          "endFilePos": 143,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 70,
+                  "startFilePos": 147,
+                  "endLine": 8,
+                  "endTokenPos": 70,
+                  "endFilePos": 150
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 70,
+                    "startFilePos": 147,
+                    "endLine": 8,
+                    "endTokenPos": 70,
+                    "endFilePos": 150,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 75,
+              "startFilePos": 155,
+              "endLine": 8,
+              "endTokenPos": 78,
+              "endFilePos": 162
+            },
+            "name": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 75,
+                "startFilePos": 155,
+                "endLine": 8,
+                "endTokenPos": 75,
+                "endFilePos": 159
+              },
+              "name": "add5"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 77,
+                  "startFilePos": 161,
+                  "endLine": 8,
+                  "endTokenPos": 77,
+                  "endFilePos": 161
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 77,
+                    "startFilePos": 161,
+                    "endLine": 8,
+                    "endTokenPos": 77,
+                    "endFilePos": 161,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 82,
+            "startFilePos": 166,
+            "endLine": 8,
+            "endTokenPos": 82,
+            "endFilePos": 172
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 82,
+              "startFilePos": 166,
+              "endLine": 8,
+              "endTokenPos": 82,
+              "endFilePos": 172
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/print_hello.php.json
+++ b/tests/json-ast/x/php/print_hello.php.json
@@ -1,0 +1,54 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 7,
+        "endFilePos": 27
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 3,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 3,
+            "endFilePos": 17,
+            "kind": 2,
+            "rawValue": "\"hello\""
+          },
+          "value": "hello"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 6,
+            "startFilePos": 20,
+            "endLine": 2,
+            "endTokenPos": 6,
+            "endFilePos": 26
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 6,
+              "startFilePos": 20,
+              "endLine": 2,
+              "endTokenPos": 6,
+              "endFilePos": 26
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/pure_fold.php.json
+++ b/tests/json-ast/x/php/pure_fold.php.json
@@ -1,0 +1,499 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 19,
+        "endFilePos": 45
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 20
+        },
+        "name": "triple"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 22,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 23
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 22,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 23
+            },
+            "name": "x"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 10,
+            "startFilePos": 30,
+            "endLine": 3,
+            "endTokenPos": 17,
+            "endFilePos": 43
+          },
+          "expr": {
+            "nodeType": "Expr_BinaryOp_Mul",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 12,
+              "startFilePos": 37,
+              "endLine": 3,
+              "endTokenPos": 16,
+              "endFilePos": 42
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 12,
+                "startFilePos": 37,
+                "endLine": 3,
+                "endTokenPos": 12,
+                "endFilePos": 38
+              },
+              "name": "x"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 16,
+                "startFilePos": 42,
+                "endLine": 3,
+                "endTokenPos": 16,
+                "endFilePos": 42,
+                "rawValue": "3",
+                "kind": 10
+              },
+              "value": 3
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 21,
+        "startFilePos": 47,
+        "endLine": 5,
+        "endTokenPos": 67,
+        "endFilePos": 137
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 24,
+            "startFilePos": 53,
+            "endLine": 5,
+            "endTokenPos": 62,
+            "endFilePos": 126
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 24,
+              "startFilePos": 53,
+              "endLine": 5,
+              "endTokenPos": 34,
+              "endFilePos": 75
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 24,
+                "startFilePos": 53,
+                "endLine": 5,
+                "endTokenPos": 24,
+                "endFilePos": 60
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 26,
+                  "startFilePos": 62,
+                  "endLine": 5,
+                  "endTokenPos": 33,
+                  "endFilePos": 74
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 26,
+                    "startFilePos": 62,
+                    "endLine": 5,
+                    "endTokenPos": 33,
+                    "endFilePos": 74
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 26,
+                      "startFilePos": 62,
+                      "endLine": 5,
+                      "endTokenPos": 26,
+                      "endFilePos": 67
+                    },
+                    "name": "triple"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 28,
+                        "startFilePos": 69,
+                        "endLine": 5,
+                        "endTokenPos": 32,
+                        "endFilePos": 73
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Plus",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 28,
+                          "startFilePos": 69,
+                          "endLine": 5,
+                          "endTokenPos": 32,
+                          "endFilePos": 73
+                        },
+                        "left": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 28,
+                            "startFilePos": 69,
+                            "endLine": 5,
+                            "endTokenPos": 28,
+                            "endFilePos": 69,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 32,
+                            "startFilePos": 73,
+                            "endLine": 5,
+                            "endTokenPos": 32,
+                            "endFilePos": 73,
+                            "rawValue": "2",
+                            "kind": 10
+                          },
+                          "value": 2
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 38,
+              "startFilePos": 79,
+              "endLine": 5,
+              "endTokenPos": 51,
+              "endFilePos": 110
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 38,
+                "startFilePos": 79,
+                "endLine": 5,
+                "endTokenPos": 38,
+                "endFilePos": 89
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 40,
+                  "startFilePos": 91,
+                  "endLine": 5,
+                  "endTokenPos": 47,
+                  "endFilePos": 103
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 40,
+                    "startFilePos": 91,
+                    "endLine": 5,
+                    "endTokenPos": 47,
+                    "endFilePos": 103
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 40,
+                      "startFilePos": 91,
+                      "endLine": 5,
+                      "endTokenPos": 40,
+                      "endFilePos": 96
+                    },
+                    "name": "triple"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 42,
+                        "startFilePos": 98,
+                        "endLine": 5,
+                        "endTokenPos": 46,
+                        "endFilePos": 102
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Plus",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 42,
+                          "startFilePos": 98,
+                          "endLine": 5,
+                          "endTokenPos": 46,
+                          "endFilePos": 102
+                        },
+                        "left": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 42,
+                            "startFilePos": 98,
+                            "endLine": 5,
+                            "endTokenPos": 42,
+                            "endFilePos": 98,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 46,
+                            "startFilePos": 102,
+                            "endLine": 5,
+                            "endTokenPos": 46,
+                            "endFilePos": 102,
+                            "rawValue": "2",
+                            "kind": 10
+                          },
+                          "value": 2
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 50,
+                  "startFilePos": 106,
+                  "endLine": 5,
+                  "endTokenPos": 50,
+                  "endFilePos": 109
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 50,
+                    "startFilePos": 106,
+                    "endLine": 5,
+                    "endTokenPos": 50,
+                    "endFilePos": 109,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 55,
+              "startFilePos": 114,
+              "endLine": 5,
+              "endTokenPos": 62,
+              "endFilePos": 126
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 55,
+                "startFilePos": 114,
+                "endLine": 5,
+                "endTokenPos": 55,
+                "endFilePos": 119
+              },
+              "name": "triple"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 57,
+                  "startFilePos": 121,
+                  "endLine": 5,
+                  "endTokenPos": 61,
+                  "endFilePos": 125
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 57,
+                    "startFilePos": 121,
+                    "endLine": 5,
+                    "endTokenPos": 61,
+                    "endFilePos": 125
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 57,
+                      "startFilePos": 121,
+                      "endLine": 5,
+                      "endTokenPos": 57,
+                      "endFilePos": 121,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 61,
+                      "startFilePos": 125,
+                      "endLine": 5,
+                      "endTokenPos": 61,
+                      "endFilePos": 125,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 66,
+            "startFilePos": 130,
+            "endLine": 5,
+            "endTokenPos": 66,
+            "endFilePos": 136
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 66,
+              "startFilePos": 130,
+              "endLine": 5,
+              "endTokenPos": 66,
+              "endFilePos": 136
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/pure_global_fold.php.json
+++ b/tests/json-ast/x/php/pure_global_fold.php.json
@@ -1,0 +1,470 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "k"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "2",
+            "kind": 10
+          },
+          "value": 2
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 5,
+        "endTokenPos": 26,
+        "endFilePos": 51
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 10,
+          "startFilePos": 23,
+          "endLine": 3,
+          "endTokenPos": 10,
+          "endFilePos": 25
+        },
+        "name": "inc"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 27,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 28
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 12,
+              "startFilePos": 27,
+              "endLine": 3,
+              "endTokenPos": 12,
+              "endFilePos": 28
+            },
+            "name": "x"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 17,
+            "startFilePos": 35,
+            "endLine": 4,
+            "endTokenPos": 24,
+            "endFilePos": 49
+          },
+          "expr": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 19,
+              "startFilePos": 42,
+              "endLine": 4,
+              "endTokenPos": 23,
+              "endFilePos": 48
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 19,
+                "startFilePos": 42,
+                "endLine": 4,
+                "endTokenPos": 19,
+                "endFilePos": 43
+              },
+              "name": "x"
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 23,
+                "startFilePos": 47,
+                "endLine": 4,
+                "endTokenPos": 23,
+                "endFilePos": 48
+              },
+              "name": "k"
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 28,
+        "startFilePos": 53,
+        "endLine": 6,
+        "endTokenPos": 62,
+        "endFilePos": 122
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 31,
+            "startFilePos": 59,
+            "endLine": 6,
+            "endTokenPos": 57,
+            "endFilePos": 111
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 31,
+              "startFilePos": 59,
+              "endLine": 6,
+              "endTokenPos": 37,
+              "endFilePos": 74
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 31,
+                "startFilePos": 59,
+                "endLine": 6,
+                "endTokenPos": 31,
+                "endFilePos": 66
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 33,
+                  "startFilePos": 68,
+                  "endLine": 6,
+                  "endTokenPos": 36,
+                  "endFilePos": 73
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 33,
+                    "startFilePos": 68,
+                    "endLine": 6,
+                    "endTokenPos": 36,
+                    "endFilePos": 73
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 33,
+                      "startFilePos": 68,
+                      "endLine": 6,
+                      "endTokenPos": 33,
+                      "endFilePos": 70
+                    },
+                    "name": "inc"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 35,
+                        "startFilePos": 72,
+                        "endLine": 6,
+                        "endTokenPos": 35,
+                        "endFilePos": 72
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 35,
+                          "startFilePos": 72,
+                          "endLine": 6,
+                          "endTokenPos": 35,
+                          "endFilePos": 72,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 41,
+              "startFilePos": 78,
+              "endLine": 6,
+              "endTokenPos": 50,
+              "endFilePos": 102
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 41,
+                "startFilePos": 78,
+                "endLine": 6,
+                "endTokenPos": 41,
+                "endFilePos": 88
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 43,
+                  "startFilePos": 90,
+                  "endLine": 6,
+                  "endTokenPos": 46,
+                  "endFilePos": 95
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 43,
+                    "startFilePos": 90,
+                    "endLine": 6,
+                    "endTokenPos": 46,
+                    "endFilePos": 95
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 43,
+                      "startFilePos": 90,
+                      "endLine": 6,
+                      "endTokenPos": 43,
+                      "endFilePos": 92
+                    },
+                    "name": "inc"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 45,
+                        "startFilePos": 94,
+                        "endLine": 6,
+                        "endTokenPos": 45,
+                        "endFilePos": 94
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 45,
+                          "startFilePos": 94,
+                          "endLine": 6,
+                          "endTokenPos": 45,
+                          "endFilePos": 94,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 49,
+                  "startFilePos": 98,
+                  "endLine": 6,
+                  "endTokenPos": 49,
+                  "endFilePos": 101
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 49,
+                    "startFilePos": 98,
+                    "endLine": 6,
+                    "endTokenPos": 49,
+                    "endFilePos": 101,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 54,
+              "startFilePos": 106,
+              "endLine": 6,
+              "endTokenPos": 57,
+              "endFilePos": 111
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 54,
+                "startFilePos": 106,
+                "endLine": 6,
+                "endTokenPos": 54,
+                "endFilePos": 108
+              },
+              "name": "inc"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 56,
+                  "startFilePos": 110,
+                  "endLine": 6,
+                  "endTokenPos": 56,
+                  "endFilePos": 110
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 56,
+                    "startFilePos": 110,
+                    "endLine": 6,
+                    "endTokenPos": 56,
+                    "endFilePos": 110,
+                    "rawValue": "3",
+                    "kind": 10
+                  },
+                  "value": 3
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 61,
+            "startFilePos": 115,
+            "endLine": 6,
+            "endTokenPos": 61,
+            "endFilePos": 121
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 61,
+              "startFilePos": 115,
+              "endLine": 6,
+              "endTokenPos": 61,
+              "endFilePos": 121
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/python_auto.php.json
+++ b/tests/json-ast/x/php/python_auto.php.json
@@ -1,0 +1,1412 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 10,
+        "endTokenPos": 113,
+        "endFilePos": 230
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 10,
+          "endTokenPos": 112,
+          "endFilePos": 229
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "math"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 10,
+            "endTokenPos": 112,
+            "endFilePos": 229,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 4,
+                "endTokenPos": 25,
+                "endFilePos": 59
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 20,
+                  "kind": 2,
+                  "rawValue": "\"sqrt\""
+                },
+                "value": "sqrt"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 25,
+                  "endLine": 4,
+                  "endTokenPos": 25,
+                  "endFilePos": 59
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 12,
+                      "startFilePos": 34,
+                      "endLine": 2,
+                      "endTokenPos": 12,
+                      "endFilePos": 35
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 12,
+                        "startFilePos": 34,
+                        "endLine": 2,
+                        "endTokenPos": 12,
+                        "endFilePos": 35
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 17,
+                      "startFilePos": 42,
+                      "endLine": 3,
+                      "endTokenPos": 23,
+                      "endFilePos": 57
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 19,
+                        "startFilePos": 49,
+                        "endLine": 3,
+                        "endTokenPos": 22,
+                        "endFilePos": 56
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 19,
+                          "startFilePos": 49,
+                          "endLine": 3,
+                          "endTokenPos": 19,
+                          "endFilePos": 52
+                        },
+                        "name": "sqrt"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 21,
+                            "startFilePos": 54,
+                            "endLine": 3,
+                            "endTokenPos": 21,
+                            "endFilePos": 55
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 21,
+                              "startFilePos": 54,
+                              "endLine": 3,
+                              "endTokenPos": 21,
+                              "endFilePos": 55
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 28,
+                "startFilePos": 62,
+                "endLine": 6,
+                "endTokenPos": 53,
+                "endFilePos": 112
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 28,
+                  "startFilePos": 62,
+                  "endLine": 4,
+                  "endTokenPos": 28,
+                  "endFilePos": 66,
+                  "kind": 2,
+                  "rawValue": "\"pow\""
+                },
+                "value": "pow"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 32,
+                  "startFilePos": 71,
+                  "endLine": 6,
+                  "endTokenPos": 53,
+                  "endFilePos": 112
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 34,
+                      "startFilePos": 80,
+                      "endLine": 4,
+                      "endTokenPos": 34,
+                      "endFilePos": 81
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 34,
+                        "startFilePos": 80,
+                        "endLine": 4,
+                        "endTokenPos": 34,
+                        "endFilePos": 81
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  },
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 37,
+                      "startFilePos": 84,
+                      "endLine": 4,
+                      "endTokenPos": 37,
+                      "endFilePos": 85
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 37,
+                        "startFilePos": 84,
+                        "endLine": 4,
+                        "endTokenPos": 37,
+                        "endFilePos": 85
+                      },
+                      "name": "y"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 42,
+                      "startFilePos": 92,
+                      "endLine": 5,
+                      "endTokenPos": 51,
+                      "endFilePos": 110
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 44,
+                        "startFilePos": 99,
+                        "endLine": 5,
+                        "endTokenPos": 50,
+                        "endFilePos": 109
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 44,
+                          "startFilePos": 99,
+                          "endLine": 5,
+                          "endTokenPos": 44,
+                          "endFilePos": 101
+                        },
+                        "name": "pow"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 46,
+                            "startFilePos": 103,
+                            "endLine": 5,
+                            "endTokenPos": 46,
+                            "endFilePos": 104
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 46,
+                              "startFilePos": 103,
+                              "endLine": 5,
+                              "endTokenPos": 46,
+                              "endFilePos": 104
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 49,
+                            "startFilePos": 107,
+                            "endLine": 5,
+                            "endTokenPos": 49,
+                            "endFilePos": 108
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 49,
+                              "startFilePos": 107,
+                              "endLine": 5,
+                              "endTokenPos": 49,
+                              "endFilePos": 108
+                            },
+                            "name": "y"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 56,
+                "startFilePos": 115,
+                "endLine": 8,
+                "endTokenPos": 75,
+                "endFilePos": 157
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 56,
+                  "startFilePos": 115,
+                  "endLine": 6,
+                  "endTokenPos": 56,
+                  "endFilePos": 119,
+                  "kind": 2,
+                  "rawValue": "\"sin\""
+                },
+                "value": "sin"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 60,
+                  "startFilePos": 124,
+                  "endLine": 8,
+                  "endTokenPos": 75,
+                  "endFilePos": 157
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 62,
+                      "startFilePos": 133,
+                      "endLine": 6,
+                      "endTokenPos": 62,
+                      "endFilePos": 134
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 62,
+                        "startFilePos": 133,
+                        "endLine": 6,
+                        "endTokenPos": 62,
+                        "endFilePos": 134
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 67,
+                      "startFilePos": 141,
+                      "endLine": 7,
+                      "endTokenPos": 73,
+                      "endFilePos": 155
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 69,
+                        "startFilePos": 148,
+                        "endLine": 7,
+                        "endTokenPos": 72,
+                        "endFilePos": 154
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 69,
+                          "startFilePos": 148,
+                          "endLine": 7,
+                          "endTokenPos": 69,
+                          "endFilePos": 150
+                        },
+                        "name": "sin"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 71,
+                            "startFilePos": 152,
+                            "endLine": 7,
+                            "endTokenPos": 71,
+                            "endFilePos": 153
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 71,
+                              "startFilePos": 152,
+                              "endLine": 7,
+                              "endTokenPos": 71,
+                              "endFilePos": 153
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 78,
+                "startFilePos": 160,
+                "endLine": 10,
+                "endTokenPos": 97,
+                "endFilePos": 202
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 78,
+                  "startFilePos": 160,
+                  "endLine": 8,
+                  "endTokenPos": 78,
+                  "endFilePos": 164,
+                  "kind": 2,
+                  "rawValue": "\"log\""
+                },
+                "value": "log"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 82,
+                  "startFilePos": 169,
+                  "endLine": 10,
+                  "endTokenPos": 97,
+                  "endFilePos": 202
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 84,
+                      "startFilePos": 178,
+                      "endLine": 8,
+                      "endTokenPos": 84,
+                      "endFilePos": 179
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 84,
+                        "startFilePos": 178,
+                        "endLine": 8,
+                        "endTokenPos": 84,
+                        "endFilePos": 179
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 89,
+                      "startFilePos": 186,
+                      "endLine": 9,
+                      "endTokenPos": 95,
+                      "endFilePos": 200
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 91,
+                        "startFilePos": 193,
+                        "endLine": 9,
+                        "endTokenPos": 94,
+                        "endFilePos": 199
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 91,
+                          "startFilePos": 193,
+                          "endLine": 9,
+                          "endTokenPos": 91,
+                          "endFilePos": 195
+                        },
+                        "name": "log"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 93,
+                            "startFilePos": 197,
+                            "endLine": 9,
+                            "endTokenPos": 93,
+                            "endFilePos": 198
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 93,
+                              "startFilePos": 197,
+                              "endLine": 9,
+                              "endTokenPos": 93,
+                              "endFilePos": 198
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 100,
+                "startFilePos": 205,
+                "endLine": 10,
+                "endTokenPos": 104,
+                "endFilePos": 216
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 100,
+                  "startFilePos": 205,
+                  "endLine": 10,
+                  "endTokenPos": 100,
+                  "endFilePos": 208,
+                  "kind": 2,
+                  "rawValue": "\"pi\""
+                },
+                "value": "pi"
+              },
+              "value": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 104,
+                  "startFilePos": 213,
+                  "endLine": 10,
+                  "endTokenPos": 104,
+                  "endFilePos": 216
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 104,
+                    "startFilePos": 213,
+                    "endLine": 10,
+                    "endTokenPos": 104,
+                    "endFilePos": 216
+                  },
+                  "name": "M_PI"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 107,
+                "startFilePos": 219,
+                "endLine": 10,
+                "endTokenPos": 111,
+                "endFilePos": 228
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 107,
+                  "startFilePos": 219,
+                  "endLine": 10,
+                  "endTokenPos": 107,
+                  "endFilePos": 221,
+                  "kind": 2,
+                  "rawValue": "\"e\""
+                },
+                "value": "e"
+              },
+              "value": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 111,
+                  "startFilePos": 226,
+                  "endLine": 10,
+                  "endTokenPos": 111,
+                  "endFilePos": 228
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 111,
+                    "startFilePos": 226,
+                    "endLine": 10,
+                    "endTokenPos": 111,
+                    "endFilePos": 228
+                  },
+                  "name": "M_E"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 11,
+        "startTokenPos": 115,
+        "startFilePos": 232,
+        "endLine": 11,
+        "endTokenPos": 158,
+        "endFilePos": 340
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 118,
+            "startFilePos": 238,
+            "endLine": 11,
+            "endTokenPos": 153,
+            "endFilePos": 329
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 118,
+              "startFilePos": 238,
+              "endLine": 11,
+              "endTokenPos": 127,
+              "endFilePos": 266
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 118,
+                "startFilePos": 238,
+                "endLine": 11,
+                "endTokenPos": 118,
+                "endFilePos": 245
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 120,
+                  "startFilePos": 247,
+                  "endLine": 11,
+                  "endTokenPos": 126,
+                  "endFilePos": 265
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 120,
+                    "startFilePos": 247,
+                    "endLine": 11,
+                    "endTokenPos": 126,
+                    "endFilePos": 265
+                  },
+                  "name": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 120,
+                      "startFilePos": 247,
+                      "endLine": 11,
+                      "endTokenPos": 123,
+                      "endFilePos": 259
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 120,
+                        "startFilePos": 247,
+                        "endLine": 11,
+                        "endTokenPos": 120,
+                        "endFilePos": 251
+                      },
+                      "name": "math"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 122,
+                        "startFilePos": 253,
+                        "endLine": 11,
+                        "endTokenPos": 122,
+                        "endFilePos": 258,
+                        "kind": 1,
+                        "rawValue": "'sqrt'"
+                      },
+                      "value": "sqrt"
+                    }
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 125,
+                        "startFilePos": 261,
+                        "endLine": 11,
+                        "endTokenPos": 125,
+                        "endFilePos": 264
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Float",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 125,
+                          "startFilePos": 261,
+                          "endLine": 11,
+                          "endTokenPos": 125,
+                          "endFilePos": 264,
+                          "rawValue": "16.0"
+                        },
+                        "value": 16
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 131,
+              "startFilePos": 270,
+              "endLine": 11,
+              "endTokenPos": 143,
+              "endFilePos": 307
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 131,
+                "startFilePos": 270,
+                "endLine": 11,
+                "endTokenPos": 131,
+                "endFilePos": 280
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 133,
+                  "startFilePos": 282,
+                  "endLine": 11,
+                  "endTokenPos": 139,
+                  "endFilePos": 300
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 133,
+                    "startFilePos": 282,
+                    "endLine": 11,
+                    "endTokenPos": 139,
+                    "endFilePos": 300
+                  },
+                  "name": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 133,
+                      "startFilePos": 282,
+                      "endLine": 11,
+                      "endTokenPos": 136,
+                      "endFilePos": 294
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 133,
+                        "startFilePos": 282,
+                        "endLine": 11,
+                        "endTokenPos": 133,
+                        "endFilePos": 286
+                      },
+                      "name": "math"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 135,
+                        "startFilePos": 288,
+                        "endLine": 11,
+                        "endTokenPos": 135,
+                        "endFilePos": 293,
+                        "kind": 1,
+                        "rawValue": "'sqrt'"
+                      },
+                      "value": "sqrt"
+                    }
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 138,
+                        "startFilePos": 296,
+                        "endLine": 11,
+                        "endTokenPos": 138,
+                        "endFilePos": 299
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Float",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 138,
+                          "startFilePos": 296,
+                          "endLine": 11,
+                          "endTokenPos": 138,
+                          "endFilePos": 299,
+                          "rawValue": "16.0"
+                        },
+                        "value": 16
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 142,
+                  "startFilePos": 303,
+                  "endLine": 11,
+                  "endTokenPos": 142,
+                  "endFilePos": 306
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 142,
+                    "startFilePos": 303,
+                    "endLine": 11,
+                    "endTokenPos": 142,
+                    "endFilePos": 306,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 147,
+              "startFilePos": 311,
+              "endLine": 11,
+              "endTokenPos": 153,
+              "endFilePos": 329
+            },
+            "name": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 11,
+                "startTokenPos": 147,
+                "startFilePos": 311,
+                "endLine": 11,
+                "endTokenPos": 150,
+                "endFilePos": 323
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 147,
+                  "startFilePos": 311,
+                  "endLine": 11,
+                  "endTokenPos": 147,
+                  "endFilePos": 315
+                },
+                "name": "math"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 149,
+                  "startFilePos": 317,
+                  "endLine": 11,
+                  "endTokenPos": 149,
+                  "endFilePos": 322,
+                  "kind": 1,
+                  "rawValue": "'sqrt'"
+                },
+                "value": "sqrt"
+              }
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 152,
+                  "startFilePos": 325,
+                  "endLine": 11,
+                  "endTokenPos": 152,
+                  "endFilePos": 328
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Float",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 152,
+                    "startFilePos": 325,
+                    "endLine": 11,
+                    "endTokenPos": 152,
+                    "endFilePos": 328,
+                    "rawValue": "16.0"
+                  },
+                  "value": 16
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 157,
+            "startFilePos": 333,
+            "endLine": 11,
+            "endTokenPos": 157,
+            "endFilePos": 339
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 157,
+              "startFilePos": 333,
+              "endLine": 11,
+              "endTokenPos": 157,
+              "endFilePos": 339
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 12,
+        "startTokenPos": 160,
+        "startFilePos": 342,
+        "endLine": 12,
+        "endTokenPos": 194,
+        "endFilePos": 426
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 163,
+            "startFilePos": 348,
+            "endLine": 12,
+            "endTokenPos": 189,
+            "endFilePos": 415
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 163,
+              "startFilePos": 348,
+              "endLine": 12,
+              "endTokenPos": 169,
+              "endFilePos": 368
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 163,
+                "startFilePos": 348,
+                "endLine": 12,
+                "endTokenPos": 163,
+                "endFilePos": 355
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 165,
+                  "startFilePos": 357,
+                  "endLine": 12,
+                  "endTokenPos": 168,
+                  "endFilePos": 367
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 165,
+                    "startFilePos": 357,
+                    "endLine": 12,
+                    "endTokenPos": 168,
+                    "endFilePos": 367
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 165,
+                      "startFilePos": 357,
+                      "endLine": 12,
+                      "endTokenPos": 165,
+                      "endFilePos": 361
+                    },
+                    "name": "math"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 167,
+                      "startFilePos": 363,
+                      "endLine": 12,
+                      "endTokenPos": 167,
+                      "endFilePos": 366,
+                      "kind": 2,
+                      "rawValue": "\"pi\""
+                    },
+                    "value": "pi"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 173,
+              "startFilePos": 372,
+              "endLine": 12,
+              "endTokenPos": 182,
+              "endFilePos": 401
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 173,
+                "startFilePos": 372,
+                "endLine": 12,
+                "endTokenPos": 173,
+                "endFilePos": 382
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 175,
+                  "startFilePos": 384,
+                  "endLine": 12,
+                  "endTokenPos": 178,
+                  "endFilePos": 394
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 175,
+                    "startFilePos": 384,
+                    "endLine": 12,
+                    "endTokenPos": 178,
+                    "endFilePos": 394
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 175,
+                      "startFilePos": 384,
+                      "endLine": 12,
+                      "endTokenPos": 175,
+                      "endFilePos": 388
+                    },
+                    "name": "math"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 177,
+                      "startFilePos": 390,
+                      "endLine": 12,
+                      "endTokenPos": 177,
+                      "endFilePos": 393,
+                      "kind": 2,
+                      "rawValue": "\"pi\""
+                    },
+                    "value": "pi"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 181,
+                  "startFilePos": 397,
+                  "endLine": 12,
+                  "endTokenPos": 181,
+                  "endFilePos": 400
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 181,
+                    "startFilePos": 397,
+                    "endLine": 12,
+                    "endTokenPos": 181,
+                    "endFilePos": 400,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 186,
+              "startFilePos": 405,
+              "endLine": 12,
+              "endTokenPos": 189,
+              "endFilePos": 415
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 186,
+                "startFilePos": 405,
+                "endLine": 12,
+                "endTokenPos": 186,
+                "endFilePos": 409
+              },
+              "name": "math"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 188,
+                "startFilePos": 411,
+                "endLine": 12,
+                "endTokenPos": 188,
+                "endFilePos": 414,
+                "kind": 2,
+                "rawValue": "\"pi\""
+              },
+              "value": "pi"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 193,
+            "startFilePos": 419,
+            "endLine": 12,
+            "endTokenPos": 193,
+            "endFilePos": 425
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 193,
+              "startFilePos": 419,
+              "endLine": 12,
+              "endTokenPos": 193,
+              "endFilePos": 425
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/python_math.php.json
+++ b/tests/json-ast/x/php/python_math.php.json
@@ -1,0 +1,2596 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 10,
+        "endTokenPos": 113,
+        "endFilePos": 230
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 10,
+          "endTokenPos": 112,
+          "endFilePos": 229
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "math"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 10,
+            "endTokenPos": 112,
+            "endFilePos": 229,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 4,
+                "endTokenPos": 25,
+                "endFilePos": 59
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 20,
+                  "kind": 2,
+                  "rawValue": "\"sqrt\""
+                },
+                "value": "sqrt"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 25,
+                  "endLine": 4,
+                  "endTokenPos": 25,
+                  "endFilePos": 59
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 12,
+                      "startFilePos": 34,
+                      "endLine": 2,
+                      "endTokenPos": 12,
+                      "endFilePos": 35
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 12,
+                        "startFilePos": 34,
+                        "endLine": 2,
+                        "endTokenPos": 12,
+                        "endFilePos": 35
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 17,
+                      "startFilePos": 42,
+                      "endLine": 3,
+                      "endTokenPos": 23,
+                      "endFilePos": 57
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 19,
+                        "startFilePos": 49,
+                        "endLine": 3,
+                        "endTokenPos": 22,
+                        "endFilePos": 56
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 19,
+                          "startFilePos": 49,
+                          "endLine": 3,
+                          "endTokenPos": 19,
+                          "endFilePos": 52
+                        },
+                        "name": "sqrt"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 21,
+                            "startFilePos": 54,
+                            "endLine": 3,
+                            "endTokenPos": 21,
+                            "endFilePos": 55
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 21,
+                              "startFilePos": 54,
+                              "endLine": 3,
+                              "endTokenPos": 21,
+                              "endFilePos": 55
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 28,
+                "startFilePos": 62,
+                "endLine": 6,
+                "endTokenPos": 53,
+                "endFilePos": 112
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 28,
+                  "startFilePos": 62,
+                  "endLine": 4,
+                  "endTokenPos": 28,
+                  "endFilePos": 66,
+                  "kind": 2,
+                  "rawValue": "\"pow\""
+                },
+                "value": "pow"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 32,
+                  "startFilePos": 71,
+                  "endLine": 6,
+                  "endTokenPos": 53,
+                  "endFilePos": 112
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 34,
+                      "startFilePos": 80,
+                      "endLine": 4,
+                      "endTokenPos": 34,
+                      "endFilePos": 81
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 34,
+                        "startFilePos": 80,
+                        "endLine": 4,
+                        "endTokenPos": 34,
+                        "endFilePos": 81
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  },
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 37,
+                      "startFilePos": 84,
+                      "endLine": 4,
+                      "endTokenPos": 37,
+                      "endFilePos": 85
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 37,
+                        "startFilePos": 84,
+                        "endLine": 4,
+                        "endTokenPos": 37,
+                        "endFilePos": 85
+                      },
+                      "name": "y"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 42,
+                      "startFilePos": 92,
+                      "endLine": 5,
+                      "endTokenPos": 51,
+                      "endFilePos": 110
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 44,
+                        "startFilePos": 99,
+                        "endLine": 5,
+                        "endTokenPos": 50,
+                        "endFilePos": 109
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 44,
+                          "startFilePos": 99,
+                          "endLine": 5,
+                          "endTokenPos": 44,
+                          "endFilePos": 101
+                        },
+                        "name": "pow"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 46,
+                            "startFilePos": 103,
+                            "endLine": 5,
+                            "endTokenPos": 46,
+                            "endFilePos": 104
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 46,
+                              "startFilePos": 103,
+                              "endLine": 5,
+                              "endTokenPos": 46,
+                              "endFilePos": 104
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 49,
+                            "startFilePos": 107,
+                            "endLine": 5,
+                            "endTokenPos": 49,
+                            "endFilePos": 108
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 49,
+                              "startFilePos": 107,
+                              "endLine": 5,
+                              "endTokenPos": 49,
+                              "endFilePos": 108
+                            },
+                            "name": "y"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 56,
+                "startFilePos": 115,
+                "endLine": 8,
+                "endTokenPos": 75,
+                "endFilePos": 157
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 56,
+                  "startFilePos": 115,
+                  "endLine": 6,
+                  "endTokenPos": 56,
+                  "endFilePos": 119,
+                  "kind": 2,
+                  "rawValue": "\"sin\""
+                },
+                "value": "sin"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 60,
+                  "startFilePos": 124,
+                  "endLine": 8,
+                  "endTokenPos": 75,
+                  "endFilePos": 157
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 62,
+                      "startFilePos": 133,
+                      "endLine": 6,
+                      "endTokenPos": 62,
+                      "endFilePos": 134
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 62,
+                        "startFilePos": 133,
+                        "endLine": 6,
+                        "endTokenPos": 62,
+                        "endFilePos": 134
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 67,
+                      "startFilePos": 141,
+                      "endLine": 7,
+                      "endTokenPos": 73,
+                      "endFilePos": 155
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 69,
+                        "startFilePos": 148,
+                        "endLine": 7,
+                        "endTokenPos": 72,
+                        "endFilePos": 154
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 69,
+                          "startFilePos": 148,
+                          "endLine": 7,
+                          "endTokenPos": 69,
+                          "endFilePos": 150
+                        },
+                        "name": "sin"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 71,
+                            "startFilePos": 152,
+                            "endLine": 7,
+                            "endTokenPos": 71,
+                            "endFilePos": 153
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 71,
+                              "startFilePos": 152,
+                              "endLine": 7,
+                              "endTokenPos": 71,
+                              "endFilePos": 153
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 78,
+                "startFilePos": 160,
+                "endLine": 10,
+                "endTokenPos": 97,
+                "endFilePos": 202
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 78,
+                  "startFilePos": 160,
+                  "endLine": 8,
+                  "endTokenPos": 78,
+                  "endFilePos": 164,
+                  "kind": 2,
+                  "rawValue": "\"log\""
+                },
+                "value": "log"
+              },
+              "value": {
+                "nodeType": "Expr_Closure",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 82,
+                  "startFilePos": 169,
+                  "endLine": 10,
+                  "endTokenPos": 97,
+                  "endFilePos": 202
+                },
+                "static": false,
+                "byRef": false,
+                "params": [
+                  {
+                    "nodeType": "Param",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 84,
+                      "startFilePos": 178,
+                      "endLine": 8,
+                      "endTokenPos": 84,
+                      "endFilePos": 179
+                    },
+                    "type": null,
+                    "byRef": false,
+                    "variadic": false,
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 84,
+                        "startFilePos": 178,
+                        "endLine": 8,
+                        "endTokenPos": 84,
+                        "endFilePos": 179
+                      },
+                      "name": "x"
+                    },
+                    "default": null,
+                    "flags": 0,
+                    "attrGroups": [],
+                    "hooks": []
+                  }
+                ],
+                "uses": [],
+                "returnType": null,
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Return",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 89,
+                      "startFilePos": 186,
+                      "endLine": 9,
+                      "endTokenPos": 95,
+                      "endFilePos": 200
+                    },
+                    "expr": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 91,
+                        "startFilePos": 193,
+                        "endLine": 9,
+                        "endTokenPos": 94,
+                        "endFilePos": 199
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 91,
+                          "startFilePos": 193,
+                          "endLine": 9,
+                          "endTokenPos": 91,
+                          "endFilePos": 195
+                        },
+                        "name": "log"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 93,
+                            "startFilePos": 197,
+                            "endLine": 9,
+                            "endTokenPos": 93,
+                            "endFilePos": 198
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 93,
+                              "startFilePos": 197,
+                              "endLine": 9,
+                              "endTokenPos": 93,
+                              "endFilePos": 198
+                            },
+                            "name": "x"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "attrGroups": []
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 100,
+                "startFilePos": 205,
+                "endLine": 10,
+                "endTokenPos": 104,
+                "endFilePos": 216
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 100,
+                  "startFilePos": 205,
+                  "endLine": 10,
+                  "endTokenPos": 100,
+                  "endFilePos": 208,
+                  "kind": 2,
+                  "rawValue": "\"pi\""
+                },
+                "value": "pi"
+              },
+              "value": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 104,
+                  "startFilePos": 213,
+                  "endLine": 10,
+                  "endTokenPos": 104,
+                  "endFilePos": 216
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 104,
+                    "startFilePos": 213,
+                    "endLine": 10,
+                    "endTokenPos": 104,
+                    "endFilePos": 216
+                  },
+                  "name": "M_PI"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 10,
+                "startTokenPos": 107,
+                "startFilePos": 219,
+                "endLine": 10,
+                "endTokenPos": 111,
+                "endFilePos": 228
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 107,
+                  "startFilePos": 219,
+                  "endLine": 10,
+                  "endTokenPos": 107,
+                  "endFilePos": 221,
+                  "kind": 2,
+                  "rawValue": "\"e\""
+                },
+                "value": "e"
+              },
+              "value": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 10,
+                  "startTokenPos": 111,
+                  "startFilePos": 226,
+                  "endLine": 10,
+                  "endTokenPos": 111,
+                  "endFilePos": 228
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 10,
+                    "startTokenPos": 111,
+                    "startFilePos": 226,
+                    "endLine": 10,
+                    "endTokenPos": 111,
+                    "endFilePos": 228
+                  },
+                  "name": "M_E"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 11,
+        "startTokenPos": 115,
+        "startFilePos": 232,
+        "endLine": 11,
+        "endTokenPos": 120,
+        "endFilePos": 240
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 11,
+          "startTokenPos": 115,
+          "startFilePos": 232,
+          "endLine": 11,
+          "endTokenPos": 119,
+          "endFilePos": 239
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 115,
+            "startFilePos": 232,
+            "endLine": 11,
+            "endTokenPos": 115,
+            "endFilePos": 233
+          },
+          "name": "r"
+        },
+        "expr": {
+          "nodeType": "Scalar_Float",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 119,
+            "startFilePos": 237,
+            "endLine": 11,
+            "endTokenPos": 119,
+            "endFilePos": 239,
+            "rawValue": "3.0"
+          },
+          "value": 3
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 12,
+        "startTokenPos": 122,
+        "startFilePos": 242,
+        "endLine": 12,
+        "endTokenPos": 143,
+        "endFilePos": 285
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 12,
+          "startTokenPos": 122,
+          "startFilePos": 242,
+          "endLine": 12,
+          "endTokenPos": 142,
+          "endFilePos": 284
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 122,
+            "startFilePos": 242,
+            "endLine": 12,
+            "endTokenPos": 122,
+            "endFilePos": 246
+          },
+          "name": "area"
+        },
+        "expr": {
+          "nodeType": "Expr_BinaryOp_Mul",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 126,
+            "startFilePos": 250,
+            "endLine": 12,
+            "endTokenPos": 142,
+            "endFilePos": 284
+          },
+          "left": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 126,
+              "startFilePos": 250,
+              "endLine": 12,
+              "endTokenPos": 129,
+              "endFilePos": 260
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 126,
+                "startFilePos": 250,
+                "endLine": 12,
+                "endTokenPos": 126,
+                "endFilePos": 254
+              },
+              "name": "math"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 128,
+                "startFilePos": 256,
+                "endLine": 12,
+                "endTokenPos": 128,
+                "endFilePos": 259,
+                "kind": 2,
+                "rawValue": "\"pi\""
+              },
+              "value": "pi"
+            }
+          },
+          "right": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 133,
+              "startFilePos": 264,
+              "endLine": 12,
+              "endTokenPos": 142,
+              "endFilePos": 284
+            },
+            "name": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 133,
+                "startFilePos": 264,
+                "endLine": 12,
+                "endTokenPos": 136,
+                "endFilePos": 275
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 133,
+                  "startFilePos": 264,
+                  "endLine": 12,
+                  "endTokenPos": 133,
+                  "endFilePos": 268
+                },
+                "name": "math"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 135,
+                  "startFilePos": 270,
+                  "endLine": 12,
+                  "endTokenPos": 135,
+                  "endFilePos": 274,
+                  "kind": 1,
+                  "rawValue": "'pow'"
+                },
+                "value": "pow"
+              }
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 138,
+                  "startFilePos": 277,
+                  "endLine": 12,
+                  "endTokenPos": 138,
+                  "endFilePos": 278
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 138,
+                    "startFilePos": 277,
+                    "endLine": 12,
+                    "endTokenPos": 138,
+                    "endFilePos": 278
+                  },
+                  "name": "r"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 141,
+                  "startFilePos": 281,
+                  "endLine": 12,
+                  "endTokenPos": 141,
+                  "endFilePos": 283
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Float",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 141,
+                    "startFilePos": 281,
+                    "endLine": 12,
+                    "endTokenPos": 141,
+                    "endFilePos": 283,
+                    "rawValue": "2.0"
+                  },
+                  "value": 2
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 13,
+        "startTokenPos": 145,
+        "startFilePos": 287,
+        "endLine": 13,
+        "endTokenPos": 156,
+        "endFilePos": 314
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 13,
+          "startTokenPos": 145,
+          "startFilePos": 287,
+          "endLine": 13,
+          "endTokenPos": 155,
+          "endFilePos": 313
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 145,
+            "startFilePos": 287,
+            "endLine": 13,
+            "endTokenPos": 145,
+            "endFilePos": 291
+          },
+          "name": "root"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 149,
+            "startFilePos": 295,
+            "endLine": 13,
+            "endTokenPos": 155,
+            "endFilePos": 313
+          },
+          "name": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 149,
+              "startFilePos": 295,
+              "endLine": 13,
+              "endTokenPos": 152,
+              "endFilePos": 307
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 149,
+                "startFilePos": 295,
+                "endLine": 13,
+                "endTokenPos": 149,
+                "endFilePos": 299
+              },
+              "name": "math"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 151,
+                "startFilePos": 301,
+                "endLine": 13,
+                "endTokenPos": 151,
+                "endFilePos": 306,
+                "kind": 1,
+                "rawValue": "'sqrt'"
+              },
+              "value": "sqrt"
+            }
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 154,
+                "startFilePos": 309,
+                "endLine": 13,
+                "endTokenPos": 154,
+                "endFilePos": 312
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_Float",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 154,
+                  "startFilePos": 309,
+                  "endLine": 13,
+                  "endTokenPos": 154,
+                  "endFilePos": 312,
+                  "rawValue": "49.0"
+                },
+                "value": 49
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 14,
+        "startTokenPos": 158,
+        "startFilePos": 316,
+        "endLine": 14,
+        "endTokenPos": 176,
+        "endFilePos": 356
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 14,
+          "startTokenPos": 158,
+          "startFilePos": 316,
+          "endLine": 14,
+          "endTokenPos": 175,
+          "endFilePos": 355
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 158,
+            "startFilePos": 316,
+            "endLine": 14,
+            "endTokenPos": 158,
+            "endFilePos": 321
+          },
+          "name": "sin45"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 162,
+            "startFilePos": 325,
+            "endLine": 14,
+            "endTokenPos": 175,
+            "endFilePos": 355
+          },
+          "name": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 162,
+              "startFilePos": 325,
+              "endLine": 14,
+              "endTokenPos": 165,
+              "endFilePos": 336
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 162,
+                "startFilePos": 325,
+                "endLine": 14,
+                "endTokenPos": 162,
+                "endFilePos": 329
+              },
+              "name": "math"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 164,
+                "startFilePos": 331,
+                "endLine": 14,
+                "endTokenPos": 164,
+                "endFilePos": 335,
+                "kind": 1,
+                "rawValue": "'sin'"
+              },
+              "value": "sin"
+            }
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 167,
+                "startFilePos": 338,
+                "endLine": 14,
+                "endTokenPos": 174,
+                "endFilePos": 354
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_BinaryOp_Div",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 167,
+                  "startFilePos": 338,
+                  "endLine": 14,
+                  "endTokenPos": 174,
+                  "endFilePos": 354
+                },
+                "left": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 167,
+                    "startFilePos": 338,
+                    "endLine": 14,
+                    "endTokenPos": 170,
+                    "endFilePos": 348
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 167,
+                      "startFilePos": 338,
+                      "endLine": 14,
+                      "endTokenPos": 167,
+                      "endFilePos": 342
+                    },
+                    "name": "math"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 169,
+                      "startFilePos": 344,
+                      "endLine": 14,
+                      "endTokenPos": 169,
+                      "endFilePos": 347,
+                      "kind": 2,
+                      "rawValue": "\"pi\""
+                    },
+                    "value": "pi"
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_Float",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 174,
+                    "startFilePos": 352,
+                    "endLine": 14,
+                    "endTokenPos": 174,
+                    "endFilePos": 354,
+                    "rawValue": "4.0"
+                  },
+                  "value": 4
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 15,
+        "startTokenPos": 178,
+        "startFilePos": 358,
+        "endLine": 15,
+        "endTokenPos": 192,
+        "endFilePos": 391
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 15,
+          "startTokenPos": 178,
+          "startFilePos": 358,
+          "endLine": 15,
+          "endTokenPos": 191,
+          "endFilePos": 390
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 178,
+            "startFilePos": 358,
+            "endLine": 15,
+            "endTokenPos": 178,
+            "endFilePos": 363
+          },
+          "name": "log_e"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 182,
+            "startFilePos": 367,
+            "endLine": 15,
+            "endTokenPos": 191,
+            "endFilePos": 390
+          },
+          "name": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 15,
+              "startTokenPos": 182,
+              "startFilePos": 367,
+              "endLine": 15,
+              "endTokenPos": 185,
+              "endFilePos": 378
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 182,
+                "startFilePos": 367,
+                "endLine": 15,
+                "endTokenPos": 182,
+                "endFilePos": 371
+              },
+              "name": "math"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 184,
+                "startFilePos": 373,
+                "endLine": 15,
+                "endTokenPos": 184,
+                "endFilePos": 377,
+                "kind": 1,
+                "rawValue": "'log'"
+              },
+              "value": "log"
+            }
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 187,
+                "startFilePos": 380,
+                "endLine": 15,
+                "endTokenPos": 190,
+                "endFilePos": 389
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_ArrayDimFetch",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 187,
+                  "startFilePos": 380,
+                  "endLine": 15,
+                  "endTokenPos": 190,
+                  "endFilePos": 389
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 187,
+                    "startFilePos": 380,
+                    "endLine": 15,
+                    "endTokenPos": 187,
+                    "endFilePos": 384
+                  },
+                  "name": "math"
+                },
+                "dim": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 189,
+                    "startFilePos": 386,
+                    "endLine": 15,
+                    "endTokenPos": 189,
+                    "endFilePos": 388,
+                    "kind": 2,
+                    "rawValue": "\"e\""
+                  },
+                  "value": "e"
+                }
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 16,
+        "startTokenPos": 194,
+        "startFilePos": 393,
+        "endLine": 16,
+        "endTokenPos": 262,
+        "endFilePos": 555
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_BinaryOp_Concat",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 196,
+            "startFilePos": 398,
+            "endLine": 16,
+            "endTokenPos": 258,
+            "endFilePos": 545
+          },
+          "left": {
+            "nodeType": "Expr_BinaryOp_Concat",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 196,
+              "startFilePos": 398,
+              "endLine": 16,
+              "endTokenPos": 235,
+              "endFilePos": 490
+            },
+            "left": {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 196,
+                "startFilePos": 398,
+                "endLine": 16,
+                "endTokenPos": 231,
+                "endFilePos": 484
+              },
+              "left": {
+                "nodeType": "Expr_BinaryOp_Concat",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 196,
+                  "startFilePos": 398,
+                  "endLine": 16,
+                  "endTokenPos": 227,
+                  "endFilePos": 477
+                },
+                "left": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 196,
+                    "startFilePos": 398,
+                    "endLine": 16,
+                    "endTokenPos": 223,
+                    "endFilePos": 471
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 196,
+                      "startFilePos": 398,
+                      "endLine": 16,
+                      "endTokenPos": 200,
+                      "endFilePos": 425
+                    },
+                    "left": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 196,
+                        "startFilePos": 398,
+                        "endLine": 16,
+                        "endTokenPos": 196,
+                        "endFilePos": 419,
+                        "kind": 2,
+                        "rawValue": "\"Circle area with r =\""
+                      },
+                      "value": "Circle area with r ="
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 200,
+                        "startFilePos": 423,
+                        "endLine": 16,
+                        "endTokenPos": 200,
+                        "endFilePos": 425,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Expr_Ternary",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 205,
+                      "startFilePos": 430,
+                      "endLine": 16,
+                      "endTokenPos": 222,
+                      "endFilePos": 470
+                    },
+                    "cond": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 205,
+                        "startFilePos": 430,
+                        "endLine": 16,
+                        "endTokenPos": 208,
+                        "endFilePos": 441
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 205,
+                          "startFilePos": 430,
+                          "endLine": 16,
+                          "endTokenPos": 205,
+                          "endFilePos": 437
+                        },
+                        "name": "is_float"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 207,
+                            "startFilePos": 439,
+                            "endLine": 16,
+                            "endTokenPos": 207,
+                            "endFilePos": 440
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 207,
+                              "startFilePos": 439,
+                              "endLine": 16,
+                              "endTokenPos": 207,
+                              "endFilePos": 440
+                            },
+                            "name": "r"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "if": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 212,
+                        "startFilePos": 445,
+                        "endLine": 16,
+                        "endTokenPos": 218,
+                        "endFilePos": 465
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 16,
+                          "startTokenPos": 212,
+                          "startFilePos": 445,
+                          "endLine": 16,
+                          "endTokenPos": 212,
+                          "endFilePos": 455
+                        },
+                        "name": "json_encode"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 214,
+                            "startFilePos": 457,
+                            "endLine": 16,
+                            "endTokenPos": 214,
+                            "endFilePos": 458
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 214,
+                              "startFilePos": 457,
+                              "endLine": 16,
+                              "endTokenPos": 214,
+                              "endFilePos": 458
+                            },
+                            "name": "r"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 16,
+                            "startTokenPos": 217,
+                            "startFilePos": 461,
+                            "endLine": 16,
+                            "endTokenPos": 217,
+                            "endFilePos": 464
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 16,
+                              "startTokenPos": 217,
+                              "startFilePos": 461,
+                              "endLine": 16,
+                              "endTokenPos": 217,
+                              "endFilePos": 464,
+                              "rawValue": "1344",
+                              "kind": 10
+                            },
+                            "value": 1344
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "else": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 16,
+                        "startTokenPos": 222,
+                        "startFilePos": 469,
+                        "endLine": 16,
+                        "endTokenPos": 222,
+                        "endFilePos": 470
+                      },
+                      "name": "r"
+                    }
+                  }
+                },
+                "right": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 227,
+                    "startFilePos": 475,
+                    "endLine": 16,
+                    "endTokenPos": 227,
+                    "endFilePos": 477,
+                    "kind": 2,
+                    "rawValue": "\" \""
+                  },
+                  "value": " "
+                }
+              },
+              "right": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 231,
+                  "startFilePos": 481,
+                  "endLine": 16,
+                  "endTokenPos": 231,
+                  "endFilePos": 484,
+                  "kind": 2,
+                  "rawValue": "\"=\u003e\""
+                },
+                "value": "=\u003e"
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 235,
+                "startFilePos": 488,
+                "endLine": 16,
+                "endTokenPos": 235,
+                "endFilePos": 490,
+                "kind": 2,
+                "rawValue": "\" \""
+              },
+              "value": " "
+            }
+          },
+          "right": {
+            "nodeType": "Expr_Ternary",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 240,
+              "startFilePos": 495,
+              "endLine": 16,
+              "endTokenPos": 257,
+              "endFilePos": 544
+            },
+            "cond": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 240,
+                "startFilePos": 495,
+                "endLine": 16,
+                "endTokenPos": 243,
+                "endFilePos": 509
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 240,
+                  "startFilePos": 495,
+                  "endLine": 16,
+                  "endTokenPos": 240,
+                  "endFilePos": 502
+                },
+                "name": "is_float"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 242,
+                    "startFilePos": 504,
+                    "endLine": 16,
+                    "endTokenPos": 242,
+                    "endFilePos": 508
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 242,
+                      "startFilePos": 504,
+                      "endLine": 16,
+                      "endTokenPos": 242,
+                      "endFilePos": 508
+                    },
+                    "name": "area"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "if": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 247,
+                "startFilePos": 513,
+                "endLine": 16,
+                "endTokenPos": 253,
+                "endFilePos": 536
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 16,
+                  "startTokenPos": 247,
+                  "startFilePos": 513,
+                  "endLine": 16,
+                  "endTokenPos": 247,
+                  "endFilePos": 523
+                },
+                "name": "json_encode"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 249,
+                    "startFilePos": 525,
+                    "endLine": 16,
+                    "endTokenPos": 249,
+                    "endFilePos": 529
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 249,
+                      "startFilePos": 525,
+                      "endLine": 16,
+                      "endTokenPos": 249,
+                      "endFilePos": 529
+                    },
+                    "name": "area"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 16,
+                    "startTokenPos": 252,
+                    "startFilePos": 532,
+                    "endLine": 16,
+                    "endTokenPos": 252,
+                    "endFilePos": 535
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 16,
+                      "startTokenPos": 252,
+                      "startFilePos": 532,
+                      "endLine": 16,
+                      "endTokenPos": 252,
+                      "endFilePos": 535,
+                      "rawValue": "1344",
+                      "kind": 10
+                    },
+                    "value": 1344
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "else": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 16,
+                "startTokenPos": 257,
+                "startFilePos": 540,
+                "endLine": 16,
+                "endTokenPos": 257,
+                "endFilePos": 544
+              },
+              "name": "area"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 16,
+            "startTokenPos": 261,
+            "startFilePos": 548,
+            "endLine": 16,
+            "endTokenPos": 261,
+            "endFilePos": 554
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 16,
+              "startTokenPos": 261,
+              "startFilePos": 548,
+              "endLine": 16,
+              "endTokenPos": 261,
+              "endFilePos": 554
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 17,
+        "startTokenPos": 264,
+        "startFilePos": 557,
+        "endLine": 17,
+        "endTokenPos": 297,
+        "endFilePos": 652
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_BinaryOp_Concat",
+          "attributes": {
+            "startLine": 17,
+            "startTokenPos": 266,
+            "startFilePos": 562,
+            "endLine": 17,
+            "endTokenPos": 293,
+            "endFilePos": 642
+          },
+          "left": {
+            "nodeType": "Expr_BinaryOp_Concat",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 266,
+              "startFilePos": 562,
+              "endLine": 17,
+              "endTokenPos": 270,
+              "endFilePos": 587
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 17,
+                "startTokenPos": 266,
+                "startFilePos": 562,
+                "endLine": 17,
+                "endTokenPos": 266,
+                "endFilePos": 581,
+                "kind": 2,
+                "rawValue": "\"Square root of 49:\""
+              },
+              "value": "Square root of 49:"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 17,
+                "startTokenPos": 270,
+                "startFilePos": 585,
+                "endLine": 17,
+                "endTokenPos": 270,
+                "endFilePos": 587,
+                "kind": 2,
+                "rawValue": "\" \""
+              },
+              "value": " "
+            }
+          },
+          "right": {
+            "nodeType": "Expr_Ternary",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 275,
+              "startFilePos": 592,
+              "endLine": 17,
+              "endTokenPos": 292,
+              "endFilePos": 641
+            },
+            "cond": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 17,
+                "startTokenPos": 275,
+                "startFilePos": 592,
+                "endLine": 17,
+                "endTokenPos": 278,
+                "endFilePos": 606
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 17,
+                  "startTokenPos": 275,
+                  "startFilePos": 592,
+                  "endLine": 17,
+                  "endTokenPos": 275,
+                  "endFilePos": 599
+                },
+                "name": "is_float"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 277,
+                    "startFilePos": 601,
+                    "endLine": 17,
+                    "endTokenPos": 277,
+                    "endFilePos": 605
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 17,
+                      "startTokenPos": 277,
+                      "startFilePos": 601,
+                      "endLine": 17,
+                      "endTokenPos": 277,
+                      "endFilePos": 605
+                    },
+                    "name": "root"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "if": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 17,
+                "startTokenPos": 282,
+                "startFilePos": 610,
+                "endLine": 17,
+                "endTokenPos": 288,
+                "endFilePos": 633
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 17,
+                  "startTokenPos": 282,
+                  "startFilePos": 610,
+                  "endLine": 17,
+                  "endTokenPos": 282,
+                  "endFilePos": 620
+                },
+                "name": "json_encode"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 284,
+                    "startFilePos": 622,
+                    "endLine": 17,
+                    "endTokenPos": 284,
+                    "endFilePos": 626
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 17,
+                      "startTokenPos": 284,
+                      "startFilePos": 622,
+                      "endLine": 17,
+                      "endTokenPos": 284,
+                      "endFilePos": 626
+                    },
+                    "name": "root"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 17,
+                    "startTokenPos": 287,
+                    "startFilePos": 629,
+                    "endLine": 17,
+                    "endTokenPos": 287,
+                    "endFilePos": 632
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 17,
+                      "startTokenPos": 287,
+                      "startFilePos": 629,
+                      "endLine": 17,
+                      "endTokenPos": 287,
+                      "endFilePos": 632,
+                      "rawValue": "1344",
+                      "kind": 10
+                    },
+                    "value": 1344
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "else": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 17,
+                "startTokenPos": 292,
+                "startFilePos": 637,
+                "endLine": 17,
+                "endTokenPos": 292,
+                "endFilePos": 641
+              },
+              "name": "root"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 17,
+            "startTokenPos": 296,
+            "startFilePos": 645,
+            "endLine": 17,
+            "endTokenPos": 296,
+            "endFilePos": 651
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 17,
+              "startTokenPos": 296,
+              "startFilePos": 645,
+              "endLine": 17,
+              "endTokenPos": 296,
+              "endFilePos": 651
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 18,
+        "startTokenPos": 299,
+        "startFilePos": 654,
+        "endLine": 18,
+        "endTokenPos": 332,
+        "endFilePos": 744
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_BinaryOp_Concat",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 301,
+            "startFilePos": 659,
+            "endLine": 18,
+            "endTokenPos": 328,
+            "endFilePos": 734
+          },
+          "left": {
+            "nodeType": "Expr_BinaryOp_Concat",
+            "attributes": {
+              "startLine": 18,
+              "startTokenPos": 301,
+              "startFilePos": 659,
+              "endLine": 18,
+              "endTokenPos": 305,
+              "endFilePos": 676
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 301,
+                "startFilePos": 659,
+                "endLine": 18,
+                "endTokenPos": 301,
+                "endFilePos": 670,
+                "kind": 2,
+                "rawValue": "\"sin(\u03c0\/4):\""
+              },
+              "value": "sin(\u03c0\/4):"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 305,
+                "startFilePos": 674,
+                "endLine": 18,
+                "endTokenPos": 305,
+                "endFilePos": 676,
+                "kind": 2,
+                "rawValue": "\" \""
+              },
+              "value": " "
+            }
+          },
+          "right": {
+            "nodeType": "Expr_Ternary",
+            "attributes": {
+              "startLine": 18,
+              "startTokenPos": 310,
+              "startFilePos": 681,
+              "endLine": 18,
+              "endTokenPos": 327,
+              "endFilePos": 733
+            },
+            "cond": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 310,
+                "startFilePos": 681,
+                "endLine": 18,
+                "endTokenPos": 313,
+                "endFilePos": 696
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 310,
+                  "startFilePos": 681,
+                  "endLine": 18,
+                  "endTokenPos": 310,
+                  "endFilePos": 688
+                },
+                "name": "is_float"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 312,
+                    "startFilePos": 690,
+                    "endLine": 18,
+                    "endTokenPos": 312,
+                    "endFilePos": 695
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 312,
+                      "startFilePos": 690,
+                      "endLine": 18,
+                      "endTokenPos": 312,
+                      "endFilePos": 695
+                    },
+                    "name": "sin45"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "if": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 317,
+                "startFilePos": 700,
+                "endLine": 18,
+                "endTokenPos": 323,
+                "endFilePos": 724
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 317,
+                  "startFilePos": 700,
+                  "endLine": 18,
+                  "endTokenPos": 317,
+                  "endFilePos": 710
+                },
+                "name": "json_encode"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 319,
+                    "startFilePos": 712,
+                    "endLine": 18,
+                    "endTokenPos": 319,
+                    "endFilePos": 717
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 319,
+                      "startFilePos": 712,
+                      "endLine": 18,
+                      "endTokenPos": 319,
+                      "endFilePos": 717
+                    },
+                    "name": "sin45"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 322,
+                    "startFilePos": 720,
+                    "endLine": 18,
+                    "endTokenPos": 322,
+                    "endFilePos": 723
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 18,
+                      "startTokenPos": 322,
+                      "startFilePos": 720,
+                      "endLine": 18,
+                      "endTokenPos": 322,
+                      "endFilePos": 723,
+                      "rawValue": "1344",
+                      "kind": 10
+                    },
+                    "value": 1344
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "else": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 18,
+                "startTokenPos": 327,
+                "startFilePos": 728,
+                "endLine": 18,
+                "endTokenPos": 327,
+                "endFilePos": 733
+              },
+              "name": "sin45"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 18,
+            "startTokenPos": 331,
+            "startFilePos": 737,
+            "endLine": 18,
+            "endTokenPos": 331,
+            "endFilePos": 743
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 18,
+              "startTokenPos": 331,
+              "startFilePos": 737,
+              "endLine": 18,
+              "endTokenPos": 331,
+              "endFilePos": 743
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 19,
+        "startTokenPos": 334,
+        "startFilePos": 746,
+        "endLine": 19,
+        "endTokenPos": 367,
+        "endFilePos": 833
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_BinaryOp_Concat",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 336,
+            "startFilePos": 751,
+            "endLine": 19,
+            "endTokenPos": 363,
+            "endFilePos": 823
+          },
+          "left": {
+            "nodeType": "Expr_BinaryOp_Concat",
+            "attributes": {
+              "startLine": 19,
+              "startTokenPos": 336,
+              "startFilePos": 751,
+              "endLine": 19,
+              "endTokenPos": 340,
+              "endFilePos": 765
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 19,
+                "startTokenPos": 336,
+                "startFilePos": 751,
+                "endLine": 19,
+                "endTokenPos": 336,
+                "endFilePos": 759,
+                "kind": 2,
+                "rawValue": "\"log(e):\""
+              },
+              "value": "log(e):"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 19,
+                "startTokenPos": 340,
+                "startFilePos": 763,
+                "endLine": 19,
+                "endTokenPos": 340,
+                "endFilePos": 765,
+                "kind": 2,
+                "rawValue": "\" \""
+              },
+              "value": " "
+            }
+          },
+          "right": {
+            "nodeType": "Expr_Ternary",
+            "attributes": {
+              "startLine": 19,
+              "startTokenPos": 345,
+              "startFilePos": 770,
+              "endLine": 19,
+              "endTokenPos": 362,
+              "endFilePos": 822
+            },
+            "cond": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 19,
+                "startTokenPos": 345,
+                "startFilePos": 770,
+                "endLine": 19,
+                "endTokenPos": 348,
+                "endFilePos": 785
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 19,
+                  "startTokenPos": 345,
+                  "startFilePos": 770,
+                  "endLine": 19,
+                  "endTokenPos": 345,
+                  "endFilePos": 777
+                },
+                "name": "is_float"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 19,
+                    "startTokenPos": 347,
+                    "startFilePos": 779,
+                    "endLine": 19,
+                    "endTokenPos": 347,
+                    "endFilePos": 784
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 19,
+                      "startTokenPos": 347,
+                      "startFilePos": 779,
+                      "endLine": 19,
+                      "endTokenPos": 347,
+                      "endFilePos": 784
+                    },
+                    "name": "log_e"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "if": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 19,
+                "startTokenPos": 352,
+                "startFilePos": 789,
+                "endLine": 19,
+                "endTokenPos": 358,
+                "endFilePos": 813
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 19,
+                  "startTokenPos": 352,
+                  "startFilePos": 789,
+                  "endLine": 19,
+                  "endTokenPos": 352,
+                  "endFilePos": 799
+                },
+                "name": "json_encode"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 19,
+                    "startTokenPos": 354,
+                    "startFilePos": 801,
+                    "endLine": 19,
+                    "endTokenPos": 354,
+                    "endFilePos": 806
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 19,
+                      "startTokenPos": 354,
+                      "startFilePos": 801,
+                      "endLine": 19,
+                      "endTokenPos": 354,
+                      "endFilePos": 806
+                    },
+                    "name": "log_e"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 19,
+                    "startTokenPos": 357,
+                    "startFilePos": 809,
+                    "endLine": 19,
+                    "endTokenPos": 357,
+                    "endFilePos": 812
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 19,
+                      "startTokenPos": 357,
+                      "startFilePos": 809,
+                      "endLine": 19,
+                      "endTokenPos": 357,
+                      "endFilePos": 812,
+                      "rawValue": "1344",
+                      "kind": 10
+                    },
+                    "value": 1344
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "else": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 19,
+                "startTokenPos": 362,
+                "startFilePos": 817,
+                "endLine": 19,
+                "endTokenPos": 362,
+                "endFilePos": 822
+              },
+              "name": "log_e"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 19,
+            "startTokenPos": 366,
+            "startFilePos": 826,
+            "endLine": 19,
+            "endTokenPos": 366,
+            "endFilePos": 832
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 19,
+              "startTokenPos": 366,
+              "startFilePos": 826,
+              "endLine": 19,
+              "endTokenPos": 366,
+              "endFilePos": 832
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/query_sum_select.php.json
+++ b/tests/json-ast/x/php/query_sum_select.php.json
@@ -1,0 +1,1235 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 14,
+        "endFilePos": 23
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 13,
+          "endFilePos": 22
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "nums"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 13,
+            "endFilePos": 22,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 6,
+                "endFilePos": 15
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 15,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 9,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 9,
+                "endFilePos": 18
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 9,
+                  "startFilePos": 18,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 18,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 21,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 21
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 12,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 12,
+                  "endFilePos": 21,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 16,
+        "startFilePos": 25,
+        "endLine": 11,
+        "endTokenPos": 136,
+        "endFilePos": 257
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 16,
+          "startFilePos": 25,
+          "endLine": 11,
+          "endTokenPos": 135,
+          "endFilePos": 256
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 16,
+            "startFilePos": 25,
+            "endLine": 3,
+            "endTokenPos": 16,
+            "endFilePos": 31
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 20,
+            "startFilePos": 35,
+            "endLine": 11,
+            "endTokenPos": 135,
+            "endFilePos": 256
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 21,
+              "startFilePos": 36,
+              "endLine": 11,
+              "endTokenPos": 132,
+              "endFilePos": 253
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 28,
+                  "startFilePos": 52,
+                  "endLine": 3,
+                  "endTokenPos": 28,
+                  "endFilePos": 56
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 28,
+                    "startFilePos": 52,
+                    "endLine": 3,
+                    "endTokenPos": 28,
+                    "endFilePos": 56
+                  },
+                  "name": "nums"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 33,
+                  "startFilePos": 61,
+                  "endLine": 3,
+                  "endTokenPos": 38,
+                  "endFilePos": 67
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 33,
+                    "startFilePos": 61,
+                    "endLine": 3,
+                    "endTokenPos": 37,
+                    "endFilePos": 66
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 33,
+                      "startFilePos": 61,
+                      "endLine": 3,
+                      "endTokenPos": 33,
+                      "endFilePos": 62
+                    },
+                    "name": "s"
+                  },
+                  "expr": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 37,
+                      "startFilePos": 66,
+                      "endLine": 3,
+                      "endTokenPos": 37,
+                      "endFilePos": 66,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 40,
+                  "startFilePos": 69,
+                  "endLine": 11,
+                  "endTokenPos": 125,
+                  "endFilePos": 240
+                },
+                "expr": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 43,
+                    "startFilePos": 78,
+                    "endLine": 11,
+                    "endTokenPos": 109,
+                    "endFilePos": 217
+                  },
+                  "name": {
+                    "nodeType": "Expr_Closure",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 44,
+                      "startFilePos": 79,
+                      "endLine": 11,
+                      "endTokenPos": 106,
+                      "endFilePos": 214
+                    },
+                    "static": false,
+                    "byRef": false,
+                    "params": [],
+                    "uses": [
+                      {
+                        "nodeType": "ClosureUse",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 51,
+                          "startFilePos": 95,
+                          "endLine": 3,
+                          "endTokenPos": 51,
+                          "endFilePos": 99
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 51,
+                            "startFilePos": 95,
+                            "endLine": 3,
+                            "endTokenPos": 51,
+                            "endFilePos": 99
+                          },
+                          "name": "nums"
+                        },
+                        "byRef": false
+                      }
+                    ],
+                    "returnType": null,
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 56,
+                          "startFilePos": 106,
+                          "endLine": 4,
+                          "endTokenPos": 62,
+                          "endFilePos": 118
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 56,
+                            "startFilePos": 106,
+                            "endLine": 4,
+                            "endTokenPos": 61,
+                            "endFilePos": 117
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 56,
+                              "startFilePos": 106,
+                              "endLine": 4,
+                              "endTokenPos": 56,
+                              "endFilePos": 112
+                            },
+                            "name": "result"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 60,
+                              "startFilePos": 116,
+                              "endLine": 4,
+                              "endTokenPos": 61,
+                              "endFilePos": 117,
+                              "kind": 2
+                            },
+                            "items": []
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Foreach",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 64,
+                          "startFilePos": 122,
+                          "endLine": 9,
+                          "endTokenPos": 99,
+                          "endFilePos": 194
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 67,
+                            "startFilePos": 131,
+                            "endLine": 5,
+                            "endTokenPos": 67,
+                            "endFilePos": 135
+                          },
+                          "name": "nums"
+                        },
+                        "keyVar": null,
+                        "byRef": false,
+                        "valueVar": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 71,
+                            "startFilePos": 140,
+                            "endLine": 5,
+                            "endTokenPos": 71,
+                            "endFilePos": 141
+                          },
+                          "name": "n"
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_If",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 76,
+                              "startFilePos": 150,
+                              "endLine": 8,
+                              "endTokenPos": 97,
+                              "endFilePos": 190
+                            },
+                            "cond": {
+                              "nodeType": "Expr_BinaryOp_Greater",
+                              "attributes": {
+                                "startLine": 6,
+                                "startTokenPos": 79,
+                                "startFilePos": 154,
+                                "endLine": 6,
+                                "endTokenPos": 83,
+                                "endFilePos": 159
+                              },
+                              "left": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 79,
+                                  "startFilePos": 154,
+                                  "endLine": 6,
+                                  "endTokenPos": 79,
+                                  "endFilePos": 155
+                                },
+                                "name": "n"
+                              },
+                              "right": {
+                                "nodeType": "Scalar_Int",
+                                "attributes": {
+                                  "startLine": 6,
+                                  "startTokenPos": 83,
+                                  "startFilePos": 159,
+                                  "endLine": 6,
+                                  "endTokenPos": 83,
+                                  "endFilePos": 159,
+                                  "rawValue": "1",
+                                  "kind": 10
+                                },
+                                "value": 1
+                              }
+                            },
+                            "stmts": [
+                              {
+                                "nodeType": "Stmt_Expression",
+                                "attributes": {
+                                  "startLine": 7,
+                                  "startTokenPos": 88,
+                                  "startFilePos": 170,
+                                  "endLine": 7,
+                                  "endTokenPos": 95,
+                                  "endFilePos": 184
+                                },
+                                "expr": {
+                                  "nodeType": "Expr_Assign",
+                                  "attributes": {
+                                    "startLine": 7,
+                                    "startTokenPos": 88,
+                                    "startFilePos": 170,
+                                    "endLine": 7,
+                                    "endTokenPos": 94,
+                                    "endFilePos": 183
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 7,
+                                      "startTokenPos": 88,
+                                      "startFilePos": 170,
+                                      "endLine": 7,
+                                      "endTokenPos": 90,
+                                      "endFilePos": 178
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_Variable",
+                                      "attributes": {
+                                        "startLine": 7,
+                                        "startTokenPos": 88,
+                                        "startFilePos": 170,
+                                        "endLine": 7,
+                                        "endTokenPos": 88,
+                                        "endFilePos": 176
+                                      },
+                                      "name": "result"
+                                    },
+                                    "dim": null
+                                  },
+                                  "expr": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 7,
+                                      "startTokenPos": 94,
+                                      "startFilePos": 182,
+                                      "endLine": 7,
+                                      "endTokenPos": 94,
+                                      "endFilePos": 183
+                                    },
+                                    "name": "n"
+                                  }
+                                }
+                              }
+                            ],
+                            "elseifs": [],
+                            "else": null
+                          }
+                        ]
+                      },
+                      {
+                        "nodeType": "Stmt_Return",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 101,
+                          "startFilePos": 198,
+                          "endLine": 10,
+                          "endTokenPos": 104,
+                          "endFilePos": 212
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 103,
+                            "startFilePos": 205,
+                            "endLine": 10,
+                            "endTokenPos": 103,
+                            "endFilePos": 211
+                          },
+                          "name": "result"
+                        }
+                      }
+                    ],
+                    "attrGroups": []
+                  },
+                  "args": []
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 113,
+                    "startFilePos": 222,
+                    "endLine": 11,
+                    "endTokenPos": 113,
+                    "endFilePos": 224
+                  },
+                  "name": "_v"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 118,
+                      "startFilePos": 229,
+                      "endLine": 11,
+                      "endTokenPos": 123,
+                      "endFilePos": 238
+                    },
+                    "expr": {
+                      "nodeType": "Expr_AssignOp_Plus",
+                      "attributes": {
+                        "startLine": 11,
+                        "startTokenPos": 118,
+                        "startFilePos": 229,
+                        "endLine": 11,
+                        "endTokenPos": 122,
+                        "endFilePos": 237
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 118,
+                          "startFilePos": 229,
+                          "endLine": 11,
+                          "endTokenPos": 118,
+                          "endFilePos": 230
+                        },
+                        "name": "s"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 122,
+                          "startFilePos": 235,
+                          "endLine": 11,
+                          "endTokenPos": 122,
+                          "endFilePos": 237
+                        },
+                        "name": "_v"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 127,
+                  "startFilePos": 242,
+                  "endLine": 11,
+                  "endTokenPos": 130,
+                  "endFilePos": 251
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 129,
+                    "startFilePos": 249,
+                    "endLine": 11,
+                    "endTokenPos": 129,
+                    "endFilePos": 250
+                  },
+                  "name": "s"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 12,
+        "startTokenPos": 138,
+        "startFilePos": 259,
+        "endLine": 12,
+        "endTokenPos": 195,
+        "endFilePos": 431
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 140,
+            "startFilePos": 264,
+            "endLine": 12,
+            "endTokenPos": 191,
+            "endFilePos": 421
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 140,
+              "startFilePos": 264,
+              "endLine": 12,
+              "endTokenPos": 140,
+              "endFilePos": 274
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 142,
+                "startFilePos": 276,
+                "endLine": 12,
+                "endTokenPos": 142,
+                "endFilePos": 282
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 142,
+                  "startFilePos": 276,
+                  "endLine": 12,
+                  "endTokenPos": 142,
+                  "endFilePos": 282,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 145,
+                "startFilePos": 285,
+                "endLine": 12,
+                "endTokenPos": 145,
+                "endFilePos": 291
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 145,
+                  "startFilePos": 285,
+                  "endLine": 12,
+                  "endTokenPos": 145,
+                  "endFilePos": 291,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 12,
+                "startTokenPos": 148,
+                "startFilePos": 294,
+                "endLine": 12,
+                "endTokenPos": 190,
+                "endFilePos": 420
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 12,
+                  "startTokenPos": 148,
+                  "startFilePos": 294,
+                  "endLine": 12,
+                  "endTokenPos": 190,
+                  "endFilePos": 420
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 12,
+                    "startTokenPos": 148,
+                    "startFilePos": 294,
+                    "endLine": 12,
+                    "endTokenPos": 148,
+                    "endFilePos": 304
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 150,
+                      "startFilePos": 306,
+                      "endLine": 12,
+                      "endTokenPos": 150,
+                      "endFilePos": 311
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 150,
+                        "startFilePos": 306,
+                        "endLine": 12,
+                        "endTokenPos": 150,
+                        "endFilePos": 311,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 153,
+                      "startFilePos": 314,
+                      "endLine": 12,
+                      "endTokenPos": 153,
+                      "endFilePos": 319
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 153,
+                        "startFilePos": 314,
+                        "endLine": 12,
+                        "endTokenPos": 153,
+                        "endFilePos": 319,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 12,
+                      "startTokenPos": 156,
+                      "startFilePos": 322,
+                      "endLine": 12,
+                      "endTokenPos": 189,
+                      "endFilePos": 419
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 12,
+                        "startTokenPos": 156,
+                        "startFilePos": 322,
+                        "endLine": 12,
+                        "endTokenPos": 189,
+                        "endFilePos": 419
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 12,
+                          "startTokenPos": 156,
+                          "startFilePos": 322,
+                          "endLine": 12,
+                          "endTokenPos": 156,
+                          "endFilePos": 332
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 158,
+                            "startFilePos": 334,
+                            "endLine": 12,
+                            "endTokenPos": 158,
+                            "endFilePos": 337
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 158,
+                              "startFilePos": 334,
+                              "endLine": 12,
+                              "endTokenPos": 158,
+                              "endFilePos": 337,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 161,
+                            "startFilePos": 340,
+                            "endLine": 12,
+                            "endTokenPos": 161,
+                            "endFilePos": 342
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 161,
+                              "startFilePos": 340,
+                              "endLine": 12,
+                              "endTokenPos": 161,
+                              "endFilePos": 342,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 12,
+                            "startTokenPos": 164,
+                            "startFilePos": 345,
+                            "endLine": 12,
+                            "endTokenPos": 188,
+                            "endFilePos": 418
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 12,
+                              "startTokenPos": 164,
+                              "startFilePos": 345,
+                              "endLine": 12,
+                              "endTokenPos": 188,
+                              "endFilePos": 418
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 12,
+                                "startTokenPos": 164,
+                                "startFilePos": 345,
+                                "endLine": 12,
+                                "endTokenPos": 164,
+                                "endFilePos": 355
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 166,
+                                  "startFilePos": 357,
+                                  "endLine": 12,
+                                  "endTokenPos": 166,
+                                  "endFilePos": 359
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 166,
+                                    "startFilePos": 357,
+                                    "endLine": 12,
+                                    "endTokenPos": 166,
+                                    "endFilePos": 359,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 169,
+                                  "startFilePos": 362,
+                                  "endLine": 12,
+                                  "endTokenPos": 169,
+                                  "endFilePos": 365
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 169,
+                                    "startFilePos": 362,
+                                    "endLine": 12,
+                                    "endTokenPos": 169,
+                                    "endFilePos": 365,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 12,
+                                  "startTokenPos": 172,
+                                  "startFilePos": 368,
+                                  "endLine": 12,
+                                  "endTokenPos": 187,
+                                  "endFilePos": 417
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 12,
+                                    "startTokenPos": 172,
+                                    "startFilePos": 368,
+                                    "endLine": 12,
+                                    "endTokenPos": 187,
+                                    "endFilePos": 417
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 12,
+                                      "startTokenPos": 172,
+                                      "startFilePos": 368,
+                                      "endLine": 12,
+                                      "endTokenPos": 172,
+                                      "endFilePos": 378
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 12,
+                                        "startTokenPos": 174,
+                                        "startFilePos": 380,
+                                        "endLine": 12,
+                                        "endTokenPos": 174,
+                                        "endFilePos": 382
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 12,
+                                          "startTokenPos": 174,
+                                          "startFilePos": 380,
+                                          "endLine": 12,
+                                          "endTokenPos": 174,
+                                          "endFilePos": 382,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 12,
+                                        "startTokenPos": 177,
+                                        "startFilePos": 385,
+                                        "endLine": 12,
+                                        "endTokenPos": 177,
+                                        "endFilePos": 388
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 12,
+                                          "startTokenPos": 177,
+                                          "startFilePos": 385,
+                                          "endLine": 12,
+                                          "endTokenPos": 177,
+                                          "endFilePos": 388,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 12,
+                                        "startTokenPos": 180,
+                                        "startFilePos": 391,
+                                        "endLine": 12,
+                                        "endTokenPos": 186,
+                                        "endFilePos": 416
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 12,
+                                          "startTokenPos": 180,
+                                          "startFilePos": 391,
+                                          "endLine": 12,
+                                          "endTokenPos": 186,
+                                          "endFilePos": 416
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 12,
+                                            "startTokenPos": 180,
+                                            "startFilePos": 391,
+                                            "endLine": 12,
+                                            "endTokenPos": 180,
+                                            "endFilePos": 401
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 12,
+                                              "startTokenPos": 182,
+                                              "startFilePos": 403,
+                                              "endLine": 12,
+                                              "endTokenPos": 182,
+                                              "endFilePos": 409
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 12,
+                                                "startTokenPos": 182,
+                                                "startFilePos": 403,
+                                                "endLine": 12,
+                                                "endTokenPos": 182,
+                                                "endFilePos": 409
+                                              },
+                                              "name": "result"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 12,
+                                              "startTokenPos": 185,
+                                              "startFilePos": 412,
+                                              "endLine": 12,
+                                              "endTokenPos": 185,
+                                              "endFilePos": 415
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 12,
+                                                "startTokenPos": 185,
+                                                "startFilePos": 412,
+                                                "endLine": 12,
+                                                "endTokenPos": 185,
+                                                "endFilePos": 415,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 12,
+            "startTokenPos": 194,
+            "startFilePos": 424,
+            "endLine": 12,
+            "endTokenPos": 194,
+            "endFilePos": 430
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 12,
+              "startTokenPos": 194,
+              "startFilePos": 424,
+              "endLine": 12,
+              "endTokenPos": 194,
+              "endFilePos": 430
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/record_assign.php.json
+++ b/tests/json-ast/x/php/record_assign.php.json
@@ -1,0 +1,600 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 4,
+        "endTokenPos": 27,
+        "endFilePos": 50
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 17
+        },
+        "name": "inc"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 20
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 19,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 20
+            },
+            "name": "c"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 10,
+            "startFilePos": 27,
+            "endLine": 3,
+            "endTokenPos": 25,
+            "endFilePos": 48
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 10,
+              "startFilePos": 27,
+              "endLine": 3,
+              "endTokenPos": 24,
+              "endFilePos": 47
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 10,
+                "startFilePos": 27,
+                "endLine": 3,
+                "endTokenPos": 13,
+                "endFilePos": 33
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 10,
+                  "startFilePos": 27,
+                  "endLine": 3,
+                  "endTokenPos": 10,
+                  "endFilePos": 28
+                },
+                "name": "c"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 12,
+                  "startFilePos": 30,
+                  "endLine": 3,
+                  "endTokenPos": 12,
+                  "endFilePos": 32,
+                  "kind": 2,
+                  "rawValue": "\"n\""
+                },
+                "value": "n"
+              }
+            },
+            "expr": {
+              "nodeType": "Expr_BinaryOp_Plus",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 37,
+                "endLine": 3,
+                "endTokenPos": 24,
+                "endFilePos": 47
+              },
+              "left": {
+                "nodeType": "Expr_ArrayDimFetch",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 17,
+                  "startFilePos": 37,
+                  "endLine": 3,
+                  "endTokenPos": 20,
+                  "endFilePos": 43
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 17,
+                    "startFilePos": 37,
+                    "endLine": 3,
+                    "endTokenPos": 17,
+                    "endFilePos": 38
+                  },
+                  "name": "c"
+                },
+                "dim": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 19,
+                    "startFilePos": 40,
+                    "endLine": 3,
+                    "endTokenPos": 19,
+                    "endFilePos": 42,
+                    "kind": 2,
+                    "rawValue": "\"n\""
+                  },
+                  "value": "n"
+                }
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 24,
+                  "startFilePos": 47,
+                  "endLine": 3,
+                  "endTokenPos": 24,
+                  "endFilePos": 47,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              }
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 29,
+        "startFilePos": 52,
+        "endLine": 5,
+        "endTokenPos": 40,
+        "endFilePos": 67
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 29,
+          "startFilePos": 52,
+          "endLine": 5,
+          "endTokenPos": 39,
+          "endFilePos": 66
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 29,
+            "startFilePos": 52,
+            "endLine": 5,
+            "endTokenPos": 29,
+            "endFilePos": 53
+          },
+          "name": "c"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 33,
+            "startFilePos": 57,
+            "endLine": 5,
+            "endTokenPos": 39,
+            "endFilePos": 66,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 34,
+                "startFilePos": 58,
+                "endLine": 5,
+                "endTokenPos": 38,
+                "endFilePos": 65
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 34,
+                  "startFilePos": 58,
+                  "endLine": 5,
+                  "endTokenPos": 34,
+                  "endFilePos": 60,
+                  "kind": 2,
+                  "rawValue": "\"n\""
+                },
+                "value": "n"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 38,
+                  "startFilePos": 65,
+                  "endLine": 5,
+                  "endTokenPos": 38,
+                  "endFilePos": 65,
+                  "rawValue": "0",
+                  "kind": 10
+                },
+                "value": 0
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 42,
+        "startFilePos": 69,
+        "endLine": 6,
+        "endTokenPos": 46,
+        "endFilePos": 76
+      },
+      "expr": {
+        "nodeType": "Expr_FuncCall",
+        "attributes": {
+          "startLine": 6,
+          "startTokenPos": 42,
+          "startFilePos": 69,
+          "endLine": 6,
+          "endTokenPos": 45,
+          "endFilePos": 75
+        },
+        "name": {
+          "nodeType": "Name",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 42,
+            "startFilePos": 69,
+            "endLine": 6,
+            "endTokenPos": 42,
+            "endFilePos": 71
+          },
+          "name": "inc"
+        },
+        "args": [
+          {
+            "nodeType": "Arg",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 44,
+              "startFilePos": 73,
+              "endLine": 6,
+              "endTokenPos": 44,
+              "endFilePos": 74
+            },
+            "name": null,
+            "value": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 44,
+                "startFilePos": 73,
+                "endLine": 6,
+                "endTokenPos": 44,
+                "endFilePos": 74
+              },
+              "name": "c"
+            },
+            "byRef": false,
+            "unpack": false
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 48,
+        "startFilePos": 78,
+        "endLine": 7,
+        "endTokenPos": 82,
+        "endFilePos": 150
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 51,
+            "startFilePos": 84,
+            "endLine": 7,
+            "endTokenPos": 77,
+            "endFilePos": 139
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 51,
+              "startFilePos": 84,
+              "endLine": 7,
+              "endTokenPos": 57,
+              "endFilePos": 100
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 51,
+                "startFilePos": 84,
+                "endLine": 7,
+                "endTokenPos": 51,
+                "endFilePos": 91
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 53,
+                  "startFilePos": 93,
+                  "endLine": 7,
+                  "endTokenPos": 56,
+                  "endFilePos": 99
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 53,
+                    "startFilePos": 93,
+                    "endLine": 7,
+                    "endTokenPos": 56,
+                    "endFilePos": 99
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 53,
+                      "startFilePos": 93,
+                      "endLine": 7,
+                      "endTokenPos": 53,
+                      "endFilePos": 94
+                    },
+                    "name": "c"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 55,
+                      "startFilePos": 96,
+                      "endLine": 7,
+                      "endTokenPos": 55,
+                      "endFilePos": 98,
+                      "kind": 2,
+                      "rawValue": "\"n\""
+                    },
+                    "value": "n"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 61,
+              "startFilePos": 104,
+              "endLine": 7,
+              "endTokenPos": 70,
+              "endFilePos": 129
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 61,
+                "startFilePos": 104,
+                "endLine": 7,
+                "endTokenPos": 61,
+                "endFilePos": 114
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 63,
+                  "startFilePos": 116,
+                  "endLine": 7,
+                  "endTokenPos": 66,
+                  "endFilePos": 122
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 63,
+                    "startFilePos": 116,
+                    "endLine": 7,
+                    "endTokenPos": 66,
+                    "endFilePos": 122
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 63,
+                      "startFilePos": 116,
+                      "endLine": 7,
+                      "endTokenPos": 63,
+                      "endFilePos": 117
+                    },
+                    "name": "c"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 65,
+                      "startFilePos": 119,
+                      "endLine": 7,
+                      "endTokenPos": 65,
+                      "endFilePos": 121,
+                      "kind": 2,
+                      "rawValue": "\"n\""
+                    },
+                    "value": "n"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 69,
+                  "startFilePos": 125,
+                  "endLine": 7,
+                  "endTokenPos": 69,
+                  "endFilePos": 128
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 69,
+                    "startFilePos": 125,
+                    "endLine": 7,
+                    "endTokenPos": 69,
+                    "endFilePos": 128,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 74,
+              "startFilePos": 133,
+              "endLine": 7,
+              "endTokenPos": 77,
+              "endFilePos": 139
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 74,
+                "startFilePos": 133,
+                "endLine": 7,
+                "endTokenPos": 74,
+                "endFilePos": 134
+              },
+              "name": "c"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 76,
+                "startFilePos": 136,
+                "endLine": 7,
+                "endTokenPos": 76,
+                "endFilePos": 138,
+                "kind": 2,
+                "rawValue": "\"n\""
+              },
+              "value": "n"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 81,
+            "startFilePos": 143,
+            "endLine": 7,
+            "endTokenPos": 81,
+            "endFilePos": 149
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 81,
+              "startFilePos": 143,
+              "endLine": 7,
+              "endTokenPos": 81,
+              "endFilePos": 149
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/right_join.php.json
+++ b/tests/json-ast/x/php/right_join.php.json
@@ -1,0 +1,3522 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 69,
+        "endFilePos": 147
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 68,
+          "endFilePos": 146
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 15
+          },
+          "name": "customers"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 19,
+            "endLine": 2,
+            "endTokenPos": 68,
+            "endFilePos": 146,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 20,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 49
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 20,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 49,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 29
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 21,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 24,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 29,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 29,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 32,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 37,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 42,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 48,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 79
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 52,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 79,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 61
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 56,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 61,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 64,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 78
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 64,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 69,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 74,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 82,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 113
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 82,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 113,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 83,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 91
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 86,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 91,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 91,
+                        "rawValue": "3",
+                        "kind": 10
+                      },
+                      "value": 3
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 94,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 112
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 94,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 99,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 104,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 112,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 54,
+                "startFilePos": 116,
+                "endLine": 2,
+                "endTokenPos": 67,
+                "endFilePos": 145
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 54,
+                  "startFilePos": 116,
+                  "endLine": 2,
+                  "endTokenPos": 67,
+                  "endFilePos": 145,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 117,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 125
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 55,
+                        "startFilePos": 117,
+                        "endLine": 2,
+                        "endTokenPos": 55,
+                        "endFilePos": 120,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 59,
+                        "startFilePos": 125,
+                        "endLine": 2,
+                        "endTokenPos": 59,
+                        "endFilePos": 125,
+                        "rawValue": "4",
+                        "kind": 10
+                      },
+                      "value": 4
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 62,
+                      "startFilePos": 128,
+                      "endLine": 2,
+                      "endTokenPos": 66,
+                      "endFilePos": 144
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 62,
+                        "startFilePos": 128,
+                        "endLine": 2,
+                        "endTokenPos": 62,
+                        "endFilePos": 133,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 66,
+                        "startFilePos": 138,
+                        "endLine": 2,
+                        "endTokenPos": 66,
+                        "endFilePos": 144,
+                        "kind": 2,
+                        "rawValue": "\"Diana\""
+                      },
+                      "value": "Diana"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 71,
+        "startFilePos": 149,
+        "endLine": 3,
+        "endTokenPos": 144,
+        "endFilePos": 309
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 71,
+          "startFilePos": 149,
+          "endLine": 3,
+          "endTokenPos": 143,
+          "endFilePos": 308
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 71,
+            "startFilePos": 149,
+            "endLine": 3,
+            "endTokenPos": 71,
+            "endFilePos": 155
+          },
+          "name": "orders"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 75,
+            "startFilePos": 159,
+            "endLine": 3,
+            "endTokenPos": 143,
+            "endFilePos": 308,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 76,
+                "startFilePos": 160,
+                "endLine": 3,
+                "endTokenPos": 96,
+                "endFilePos": 207
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 76,
+                  "startFilePos": 160,
+                  "endLine": 3,
+                  "endTokenPos": 96,
+                  "endFilePos": 207,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 77,
+                      "startFilePos": 161,
+                      "endLine": 3,
+                      "endTokenPos": 81,
+                      "endFilePos": 171
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 77,
+                        "startFilePos": 161,
+                        "endLine": 3,
+                        "endTokenPos": 77,
+                        "endFilePos": 164,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 81,
+                        "startFilePos": 169,
+                        "endLine": 3,
+                        "endTokenPos": 81,
+                        "endFilePos": 171,
+                        "rawValue": "100",
+                        "kind": 10
+                      },
+                      "value": 100
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 84,
+                      "startFilePos": 174,
+                      "endLine": 3,
+                      "endTokenPos": 88,
+                      "endFilePos": 190
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 84,
+                        "startFilePos": 174,
+                        "endLine": 3,
+                        "endTokenPos": 84,
+                        "endFilePos": 185,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 88,
+                        "startFilePos": 190,
+                        "endLine": 3,
+                        "endTokenPos": 88,
+                        "endFilePos": 190,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 91,
+                      "startFilePos": 193,
+                      "endLine": 3,
+                      "endTokenPos": 95,
+                      "endFilePos": 206
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 91,
+                        "startFilePos": 193,
+                        "endLine": 3,
+                        "endTokenPos": 91,
+                        "endFilePos": 199,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 95,
+                        "startFilePos": 204,
+                        "endLine": 3,
+                        "endTokenPos": 95,
+                        "endFilePos": 206,
+                        "rawValue": "250",
+                        "kind": 10
+                      },
+                      "value": 250
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 99,
+                "startFilePos": 210,
+                "endLine": 3,
+                "endTokenPos": 119,
+                "endFilePos": 257
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 99,
+                  "startFilePos": 210,
+                  "endLine": 3,
+                  "endTokenPos": 119,
+                  "endFilePos": 257,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 100,
+                      "startFilePos": 211,
+                      "endLine": 3,
+                      "endTokenPos": 104,
+                      "endFilePos": 221
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 100,
+                        "startFilePos": 211,
+                        "endLine": 3,
+                        "endTokenPos": 100,
+                        "endFilePos": 214,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 104,
+                        "startFilePos": 219,
+                        "endLine": 3,
+                        "endTokenPos": 104,
+                        "endFilePos": 221,
+                        "rawValue": "101",
+                        "kind": 10
+                      },
+                      "value": 101
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 107,
+                      "startFilePos": 224,
+                      "endLine": 3,
+                      "endTokenPos": 111,
+                      "endFilePos": 240
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 107,
+                        "startFilePos": 224,
+                        "endLine": 3,
+                        "endTokenPos": 107,
+                        "endFilePos": 235,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 111,
+                        "startFilePos": 240,
+                        "endLine": 3,
+                        "endTokenPos": 111,
+                        "endFilePos": 240,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 114,
+                      "startFilePos": 243,
+                      "endLine": 3,
+                      "endTokenPos": 118,
+                      "endFilePos": 256
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 114,
+                        "startFilePos": 243,
+                        "endLine": 3,
+                        "endTokenPos": 114,
+                        "endFilePos": 249,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 118,
+                        "startFilePos": 254,
+                        "endLine": 3,
+                        "endTokenPos": 118,
+                        "endFilePos": 256,
+                        "rawValue": "125",
+                        "kind": 10
+                      },
+                      "value": 125
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 122,
+                "startFilePos": 260,
+                "endLine": 3,
+                "endTokenPos": 142,
+                "endFilePos": 307
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 122,
+                  "startFilePos": 260,
+                  "endLine": 3,
+                  "endTokenPos": 142,
+                  "endFilePos": 307,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 123,
+                      "startFilePos": 261,
+                      "endLine": 3,
+                      "endTokenPos": 127,
+                      "endFilePos": 271
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 123,
+                        "startFilePos": 261,
+                        "endLine": 3,
+                        "endTokenPos": 123,
+                        "endFilePos": 264,
+                        "kind": 2,
+                        "rawValue": "\"id\""
+                      },
+                      "value": "id"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 127,
+                        "startFilePos": 269,
+                        "endLine": 3,
+                        "endTokenPos": 127,
+                        "endFilePos": 271,
+                        "rawValue": "102",
+                        "kind": 10
+                      },
+                      "value": 102
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 130,
+                      "startFilePos": 274,
+                      "endLine": 3,
+                      "endTokenPos": 134,
+                      "endFilePos": 290
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 130,
+                        "startFilePos": 274,
+                        "endLine": 3,
+                        "endTokenPos": 130,
+                        "endFilePos": 285,
+                        "kind": 2,
+                        "rawValue": "\"customerId\""
+                      },
+                      "value": "customerId"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 134,
+                        "startFilePos": 290,
+                        "endLine": 3,
+                        "endTokenPos": 134,
+                        "endFilePos": 290,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 137,
+                      "startFilePos": 293,
+                      "endLine": 3,
+                      "endTokenPos": 141,
+                      "endFilePos": 306
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 137,
+                        "startFilePos": 293,
+                        "endLine": 3,
+                        "endTokenPos": 137,
+                        "endFilePos": 299,
+                        "kind": 2,
+                        "rawValue": "\"total\""
+                      },
+                      "value": "total"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 141,
+                        "startFilePos": 304,
+                        "endLine": 3,
+                        "endTokenPos": 141,
+                        "endFilePos": 306,
+                        "rawValue": "300",
+                        "kind": 10
+                      },
+                      "value": 300
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 146,
+        "startFilePos": 311,
+        "endLine": 19,
+        "endTokenPos": 315,
+        "endFilePos": 742
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 146,
+          "startFilePos": 311,
+          "endLine": 19,
+          "endTokenPos": 314,
+          "endFilePos": 741
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 146,
+            "startFilePos": 311,
+            "endLine": 4,
+            "endTokenPos": 146,
+            "endFilePos": 317
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 150,
+            "startFilePos": 321,
+            "endLine": 19,
+            "endTokenPos": 314,
+            "endFilePos": 741
+          },
+          "name": {
+            "nodeType": "Expr_Closure",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 151,
+              "startFilePos": 322,
+              "endLine": 19,
+              "endTokenPos": 311,
+              "endFilePos": 738
+            },
+            "static": false,
+            "byRef": false,
+            "params": [],
+            "uses": [
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 158,
+                  "startFilePos": 338,
+                  "endLine": 4,
+                  "endTokenPos": 158,
+                  "endFilePos": 347
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 158,
+                    "startFilePos": 338,
+                    "endLine": 4,
+                    "endTokenPos": 158,
+                    "endFilePos": 347
+                  },
+                  "name": "customers"
+                },
+                "byRef": false
+              },
+              {
+                "nodeType": "ClosureUse",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 161,
+                  "startFilePos": 350,
+                  "endLine": 4,
+                  "endTokenPos": 161,
+                  "endFilePos": 356
+                },
+                "var": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 161,
+                    "startFilePos": 350,
+                    "endLine": 4,
+                    "endTokenPos": 161,
+                    "endFilePos": 356
+                  },
+                  "name": "orders"
+                },
+                "byRef": false
+              }
+            ],
+            "returnType": null,
+            "stmts": [
+              {
+                "nodeType": "Stmt_Expression",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 166,
+                  "startFilePos": 363,
+                  "endLine": 5,
+                  "endTokenPos": 172,
+                  "endFilePos": 375
+                },
+                "expr": {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 166,
+                    "startFilePos": 363,
+                    "endLine": 5,
+                    "endTokenPos": 171,
+                    "endFilePos": 374
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 166,
+                      "startFilePos": 363,
+                      "endLine": 5,
+                      "endTokenPos": 166,
+                      "endFilePos": 369
+                    },
+                    "name": "result"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_Array",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 170,
+                      "startFilePos": 373,
+                      "endLine": 5,
+                      "endTokenPos": 171,
+                      "endFilePos": 374,
+                      "kind": 2
+                    },
+                    "items": []
+                  }
+                }
+              },
+              {
+                "nodeType": "Stmt_Foreach",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 174,
+                  "startFilePos": 379,
+                  "endLine": 17,
+                  "endTokenPos": 304,
+                  "endFilePos": 718
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 177,
+                    "startFilePos": 388,
+                    "endLine": 6,
+                    "endTokenPos": 177,
+                    "endFilePos": 394
+                  },
+                  "name": "orders"
+                },
+                "keyVar": null,
+                "byRef": false,
+                "valueVar": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 181,
+                    "startFilePos": 399,
+                    "endLine": 6,
+                    "endTokenPos": 181,
+                    "endFilePos": 400
+                  },
+                  "name": "o"
+                },
+                "stmts": [
+                  {
+                    "nodeType": "Stmt_Expression",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 186,
+                      "startFilePos": 409,
+                      "endLine": 7,
+                      "endTokenPos": 191,
+                      "endFilePos": 425
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Assign",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 186,
+                        "startFilePos": 409,
+                        "endLine": 7,
+                        "endTokenPos": 190,
+                        "endFilePos": 424
+                      },
+                      "var": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 186,
+                          "startFilePos": 409,
+                          "endLine": 7,
+                          "endTokenPos": 186,
+                          "endFilePos": 416
+                        },
+                        "name": "matched"
+                      },
+                      "expr": {
+                        "nodeType": "Expr_ConstFetch",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 190,
+                          "startFilePos": 420,
+                          "endLine": 7,
+                          "endTokenPos": 190,
+                          "endFilePos": 424
+                        },
+                        "name": {
+                          "nodeType": "Name",
+                          "attributes": {
+                            "startLine": 7,
+                            "startTokenPos": 190,
+                            "startFilePos": 420,
+                            "endLine": 7,
+                            "endTokenPos": 190,
+                            "endFilePos": 424
+                          },
+                          "name": "false"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Stmt_Foreach",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 193,
+                      "startFilePos": 431,
+                      "endLine": 12,
+                      "endTokenPos": 259,
+                      "endFilePos": 605
+                    },
+                    "expr": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 196,
+                        "startFilePos": 440,
+                        "endLine": 8,
+                        "endTokenPos": 196,
+                        "endFilePos": 449
+                      },
+                      "name": "customers"
+                    },
+                    "keyVar": null,
+                    "byRef": false,
+                    "valueVar": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 200,
+                        "startFilePos": 454,
+                        "endLine": 8,
+                        "endTokenPos": 200,
+                        "endFilePos": 455
+                      },
+                      "name": "c"
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_If",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 205,
+                          "startFilePos": 466,
+                          "endLine": 9,
+                          "endTokenPos": 225,
+                          "endFilePos": 511
+                        },
+                        "cond": {
+                          "nodeType": "Expr_BooleanNot",
+                          "attributes": {
+                            "startLine": 9,
+                            "startTokenPos": 208,
+                            "startFilePos": 470,
+                            "endLine": 9,
+                            "endTokenPos": 221,
+                            "endFilePos": 500
+                          },
+                          "expr": {
+                            "nodeType": "Expr_BinaryOp_Equal",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 210,
+                              "startFilePos": 472,
+                              "endLine": 9,
+                              "endTokenPos": 220,
+                              "endFilePos": 499
+                            },
+                            "left": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 210,
+                                "startFilePos": 472,
+                                "endLine": 9,
+                                "endTokenPos": 213,
+                                "endFilePos": 487
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 210,
+                                  "startFilePos": 472,
+                                  "endLine": 9,
+                                  "endTokenPos": 210,
+                                  "endFilePos": 473
+                                },
+                                "name": "o"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 212,
+                                  "startFilePos": 475,
+                                  "endLine": 9,
+                                  "endTokenPos": 212,
+                                  "endFilePos": 486,
+                                  "kind": 2,
+                                  "rawValue": "\"customerId\""
+                                },
+                                "value": "customerId"
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 9,
+                                "startTokenPos": 217,
+                                "startFilePos": 492,
+                                "endLine": 9,
+                                "endTokenPos": 220,
+                                "endFilePos": 499
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 217,
+                                  "startFilePos": 492,
+                                  "endLine": 9,
+                                  "endTokenPos": 217,
+                                  "endFilePos": 493
+                                },
+                                "name": "c"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 9,
+                                  "startTokenPos": 219,
+                                  "startFilePos": 495,
+                                  "endLine": 9,
+                                  "endTokenPos": 219,
+                                  "endFilePos": 498,
+                                  "kind": 2,
+                                  "rawValue": "\"id\""
+                                },
+                                "value": "id"
+                              }
+                            }
+                          }
+                        },
+                        "stmts": [
+                          {
+                            "nodeType": "Stmt_Continue",
+                            "attributes": {
+                              "startLine": 9,
+                              "startTokenPos": 224,
+                              "startFilePos": 503,
+                              "endLine": 9,
+                              "endTokenPos": 225,
+                              "endFilePos": 511
+                            },
+                            "num": null
+                          }
+                        ],
+                        "elseifs": [],
+                        "else": null
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 10,
+                          "startTokenPos": 227,
+                          "startFilePos": 519,
+                          "endLine": 10,
+                          "endTokenPos": 232,
+                          "endFilePos": 534
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 10,
+                            "startTokenPos": 227,
+                            "startFilePos": 519,
+                            "endLine": 10,
+                            "endTokenPos": 231,
+                            "endFilePos": 533
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 227,
+                              "startFilePos": 519,
+                              "endLine": 10,
+                              "endTokenPos": 227,
+                              "endFilePos": 526
+                            },
+                            "name": "matched"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 10,
+                              "startTokenPos": 231,
+                              "startFilePos": 530,
+                              "endLine": 10,
+                              "endTokenPos": 231,
+                              "endFilePos": 533
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 10,
+                                "startTokenPos": 231,
+                                "startFilePos": 530,
+                                "endLine": 10,
+                                "endTokenPos": 231,
+                                "endFilePos": 533
+                              },
+                              "name": "true"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 11,
+                          "startTokenPos": 234,
+                          "startFilePos": 542,
+                          "endLine": 11,
+                          "endTokenPos": 257,
+                          "endFilePos": 599
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 11,
+                            "startTokenPos": 234,
+                            "startFilePos": 542,
+                            "endLine": 11,
+                            "endTokenPos": 256,
+                            "endFilePos": 598
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 234,
+                              "startFilePos": 542,
+                              "endLine": 11,
+                              "endTokenPos": 236,
+                              "endFilePos": 550
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 11,
+                                "startTokenPos": 234,
+                                "startFilePos": 542,
+                                "endLine": 11,
+                                "endTokenPos": 234,
+                                "endFilePos": 548
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 11,
+                              "startTokenPos": 240,
+                              "startFilePos": 554,
+                              "endLine": 11,
+                              "endTokenPos": 256,
+                              "endFilePos": 598,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 241,
+                                  "startFilePos": 555,
+                                  "endLine": 11,
+                                  "endTokenPos": 248,
+                                  "endFilePos": 582
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 241,
+                                    "startFilePos": 555,
+                                    "endLine": 11,
+                                    "endTokenPos": 241,
+                                    "endFilePos": 568,
+                                    "kind": 2,
+                                    "rawValue": "\"customerName\""
+                                  },
+                                  "value": "customerName"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 245,
+                                    "startFilePos": 573,
+                                    "endLine": 11,
+                                    "endTokenPos": 248,
+                                    "endFilePos": 582
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 245,
+                                      "startFilePos": 573,
+                                      "endLine": 11,
+                                      "endTokenPos": 245,
+                                      "endFilePos": 574
+                                    },
+                                    "name": "c"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 11,
+                                      "startTokenPos": 247,
+                                      "startFilePos": 576,
+                                      "endLine": 11,
+                                      "endTokenPos": 247,
+                                      "endFilePos": 581,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 11,
+                                  "startTokenPos": 251,
+                                  "startFilePos": 585,
+                                  "endLine": 11,
+                                  "endTokenPos": 255,
+                                  "endFilePos": 597
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 251,
+                                    "startFilePos": 585,
+                                    "endLine": 11,
+                                    "endTokenPos": 251,
+                                    "endFilePos": 591,
+                                    "kind": 2,
+                                    "rawValue": "\"order\""
+                                  },
+                                  "value": "order"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 11,
+                                    "startTokenPos": 255,
+                                    "startFilePos": 596,
+                                    "endLine": 11,
+                                    "endTokenPos": 255,
+                                    "endFilePos": 597
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "nodeType": "Stmt_If",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 261,
+                      "startFilePos": 611,
+                      "endLine": 16,
+                      "endTokenPos": 302,
+                      "endFilePos": 714
+                    },
+                    "cond": {
+                      "nodeType": "Expr_BooleanNot",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 264,
+                        "startFilePos": 615,
+                        "endLine": 13,
+                        "endTokenPos": 265,
+                        "endFilePos": 623
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 13,
+                          "startTokenPos": 265,
+                          "startFilePos": 616,
+                          "endLine": 13,
+                          "endTokenPos": 265,
+                          "endFilePos": 623
+                        },
+                        "name": "matched"
+                      }
+                    },
+                    "stmts": [
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 14,
+                          "startTokenPos": 270,
+                          "startFilePos": 634,
+                          "endLine": 14,
+                          "endTokenPos": 275,
+                          "endFilePos": 643
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 14,
+                            "startTokenPos": 270,
+                            "startFilePos": 634,
+                            "endLine": 14,
+                            "endTokenPos": 274,
+                            "endFilePos": 642
+                          },
+                          "var": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 270,
+                              "startFilePos": 634,
+                              "endLine": 14,
+                              "endTokenPos": 270,
+                              "endFilePos": 635
+                            },
+                            "name": "c"
+                          },
+                          "expr": {
+                            "nodeType": "Expr_ConstFetch",
+                            "attributes": {
+                              "startLine": 14,
+                              "startTokenPos": 274,
+                              "startFilePos": 639,
+                              "endLine": 14,
+                              "endTokenPos": 274,
+                              "endFilePos": 642
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 14,
+                                "startTokenPos": 274,
+                                "startFilePos": 639,
+                                "endLine": 14,
+                                "endTokenPos": 274,
+                                "endFilePos": 642
+                              },
+                              "name": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "Stmt_Expression",
+                        "attributes": {
+                          "startLine": 15,
+                          "startTokenPos": 277,
+                          "startFilePos": 651,
+                          "endLine": 15,
+                          "endTokenPos": 300,
+                          "endFilePos": 708
+                        },
+                        "expr": {
+                          "nodeType": "Expr_Assign",
+                          "attributes": {
+                            "startLine": 15,
+                            "startTokenPos": 277,
+                            "startFilePos": 651,
+                            "endLine": 15,
+                            "endTokenPos": 299,
+                            "endFilePos": 707
+                          },
+                          "var": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 277,
+                              "startFilePos": 651,
+                              "endLine": 15,
+                              "endTokenPos": 279,
+                              "endFilePos": 659
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 15,
+                                "startTokenPos": 277,
+                                "startFilePos": 651,
+                                "endLine": 15,
+                                "endTokenPos": 277,
+                                "endFilePos": 657
+                              },
+                              "name": "result"
+                            },
+                            "dim": null
+                          },
+                          "expr": {
+                            "nodeType": "Expr_Array",
+                            "attributes": {
+                              "startLine": 15,
+                              "startTokenPos": 283,
+                              "startFilePos": 663,
+                              "endLine": 15,
+                              "endTokenPos": 299,
+                              "endFilePos": 707,
+                              "kind": 2
+                            },
+                            "items": [
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 284,
+                                  "startFilePos": 664,
+                                  "endLine": 15,
+                                  "endTokenPos": 291,
+                                  "endFilePos": 691
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 284,
+                                    "startFilePos": 664,
+                                    "endLine": 15,
+                                    "endTokenPos": 284,
+                                    "endFilePos": 677,
+                                    "kind": 2,
+                                    "rawValue": "\"customerName\""
+                                  },
+                                  "value": "customerName"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 288,
+                                    "startFilePos": 682,
+                                    "endLine": 15,
+                                    "endTokenPos": 291,
+                                    "endFilePos": 691
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 288,
+                                      "startFilePos": 682,
+                                      "endLine": 15,
+                                      "endTokenPos": 288,
+                                      "endFilePos": 683
+                                    },
+                                    "name": "c"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 15,
+                                      "startTokenPos": 290,
+                                      "startFilePos": 685,
+                                      "endLine": 15,
+                                      "endTokenPos": 290,
+                                      "endFilePos": 690,
+                                      "kind": 2,
+                                      "rawValue": "\"name\""
+                                    },
+                                    "value": "name"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "ArrayItem",
+                                "attributes": {
+                                  "startLine": 15,
+                                  "startTokenPos": 294,
+                                  "startFilePos": 694,
+                                  "endLine": 15,
+                                  "endTokenPos": 298,
+                                  "endFilePos": 706
+                                },
+                                "key": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 294,
+                                    "startFilePos": 694,
+                                    "endLine": 15,
+                                    "endTokenPos": 294,
+                                    "endFilePos": 700,
+                                    "kind": 2,
+                                    "rawValue": "\"order\""
+                                  },
+                                  "value": "order"
+                                },
+                                "value": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 15,
+                                    "startTokenPos": 298,
+                                    "startFilePos": 705,
+                                    "endLine": 15,
+                                    "endTokenPos": 298,
+                                    "endFilePos": 706
+                                  },
+                                  "name": "o"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ],
+                    "elseifs": [],
+                    "else": null
+                  }
+                ]
+              },
+              {
+                "nodeType": "Stmt_Return",
+                "attributes": {
+                  "startLine": 18,
+                  "startTokenPos": 306,
+                  "startFilePos": 722,
+                  "endLine": 18,
+                  "endTokenPos": 309,
+                  "endFilePos": 736
+                },
+                "expr": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 18,
+                    "startTokenPos": 308,
+                    "startFilePos": 729,
+                    "endLine": 18,
+                    "endTokenPos": 308,
+                    "endFilePos": 735
+                  },
+                  "name": "result"
+                }
+              }
+            ],
+            "attrGroups": []
+          },
+          "args": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 20,
+        "startTokenPos": 317,
+        "startFilePos": 744,
+        "endLine": 20,
+        "endTokenPos": 323,
+        "endFilePos": 791
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 20,
+            "startTokenPos": 319,
+            "startFilePos": 749,
+            "endLine": 20,
+            "endTokenPos": 319,
+            "endFilePos": 781,
+            "kind": 2,
+            "rawValue": "\"--- Right Join using syntax ---\""
+          },
+          "value": "--- Right Join using syntax ---"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 20,
+            "startTokenPos": 322,
+            "startFilePos": 784,
+            "endLine": 20,
+            "endTokenPos": 322,
+            "endFilePos": 790
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 20,
+              "startTokenPos": 322,
+              "startFilePos": 784,
+              "endLine": 20,
+              "endTokenPos": 322,
+              "endFilePos": 790
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 21,
+        "startTokenPos": 325,
+        "startFilePos": 793,
+        "endLine": 27,
+        "endTokenPos": 558,
+        "endFilePos": 1424
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 21,
+          "startTokenPos": 328,
+          "startFilePos": 802,
+          "endLine": 21,
+          "endTokenPos": 328,
+          "endFilePos": 808
+        },
+        "name": "result"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 21,
+          "startTokenPos": 332,
+          "startFilePos": 813,
+          "endLine": 21,
+          "endTokenPos": 332,
+          "endFilePos": 818
+        },
+        "name": "entry"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 22,
+            "startTokenPos": 337,
+            "startFilePos": 825,
+            "endLine": 26,
+            "endTokenPos": 556,
+            "endFilePos": 1422
+          },
+          "cond": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 22,
+              "startTokenPos": 340,
+              "startFilePos": 829,
+              "endLine": 22,
+              "endTokenPos": 343,
+              "endFilePos": 843
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 22,
+                "startTokenPos": 340,
+                "startFilePos": 829,
+                "endLine": 22,
+                "endTokenPos": 340,
+                "endFilePos": 834
+              },
+              "name": "entry"
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 22,
+                "startTokenPos": 342,
+                "startFilePos": 836,
+                "endLine": 22,
+                "endTokenPos": 342,
+                "endFilePos": 842,
+                "kind": 2,
+                "rawValue": "\"order\""
+              },
+              "value": "order"
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Echo",
+              "attributes": {
+                "startLine": 23,
+                "startTokenPos": 348,
+                "startFilePos": 850,
+                "endLine": 23,
+                "endTokenPos": 496,
+                "endFilePos": 1247
+              },
+              "exprs": [
+                {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 23,
+                    "startTokenPos": 350,
+                    "startFilePos": 855,
+                    "endLine": 23,
+                    "endTokenPos": 492,
+                    "endFilePos": 1237
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 23,
+                      "startTokenPos": 350,
+                      "startFilePos": 855,
+                      "endLine": 23,
+                      "endTokenPos": 451,
+                      "endFilePos": 1125
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 350,
+                        "startFilePos": 855,
+                        "endLine": 23,
+                        "endTokenPos": 447,
+                        "endFilePos": 1119
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 350,
+                          "startFilePos": 855,
+                          "endLine": 23,
+                          "endTokenPos": 443,
+                          "endFilePos": 1111
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 350,
+                            "startFilePos": 855,
+                            "endLine": 23,
+                            "endTokenPos": 439,
+                            "endFilePos": 1105
+                          },
+                          "left": {
+                            "nodeType": "Expr_BinaryOp_Concat",
+                            "attributes": {
+                              "startLine": 23,
+                              "startTokenPos": 350,
+                              "startFilePos": 855,
+                              "endLine": 23,
+                              "endTokenPos": 398,
+                              "endFilePos": 1002
+                            },
+                            "left": {
+                              "nodeType": "Expr_BinaryOp_Concat",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 350,
+                                "startFilePos": 855,
+                                "endLine": 23,
+                                "endTokenPos": 394,
+                                "endFilePos": 996
+                              },
+                              "left": {
+                                "nodeType": "Expr_BinaryOp_Concat",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 350,
+                                  "startFilePos": 855,
+                                  "endLine": 23,
+                                  "endTokenPos": 390,
+                                  "endFilePos": 982
+                                },
+                                "left": {
+                                  "nodeType": "Expr_BinaryOp_Concat",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 350,
+                                    "startFilePos": 855,
+                                    "endLine": 23,
+                                    "endTokenPos": 386,
+                                    "endFilePos": 976
+                                  },
+                                  "left": {
+                                    "nodeType": "Expr_BinaryOp_Concat",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 350,
+                                      "startFilePos": 855,
+                                      "endLine": 23,
+                                      "endTokenPos": 354,
+                                      "endFilePos": 870
+                                    },
+                                    "left": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 350,
+                                        "startFilePos": 855,
+                                        "endLine": 23,
+                                        "endTokenPos": 350,
+                                        "endFilePos": 864,
+                                        "kind": 2,
+                                        "rawValue": "\"Customer\""
+                                      },
+                                      "value": "Customer"
+                                    },
+                                    "right": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 354,
+                                        "startFilePos": 868,
+                                        "endLine": 23,
+                                        "endTokenPos": 354,
+                                        "endFilePos": 870,
+                                        "kind": 2,
+                                        "rawValue": "\" \""
+                                      },
+                                      "value": " "
+                                    }
+                                  },
+                                  "right": {
+                                    "nodeType": "Expr_Ternary",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 359,
+                                      "startFilePos": 875,
+                                      "endLine": 23,
+                                      "endTokenPos": 385,
+                                      "endFilePos": 975
+                                    },
+                                    "cond": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 359,
+                                        "startFilePos": 875,
+                                        "endLine": 23,
+                                        "endTokenPos": 365,
+                                        "endFilePos": 906
+                                      },
+                                      "name": {
+                                        "nodeType": "Name",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 359,
+                                          "startFilePos": 875,
+                                          "endLine": 23,
+                                          "endTokenPos": 359,
+                                          "endFilePos": 882
+                                        },
+                                        "name": "is_float"
+                                      },
+                                      "args": [
+                                        {
+                                          "nodeType": "Arg",
+                                          "attributes": {
+                                            "startLine": 23,
+                                            "startTokenPos": 361,
+                                            "startFilePos": 884,
+                                            "endLine": 23,
+                                            "endTokenPos": 364,
+                                            "endFilePos": 905
+                                          },
+                                          "name": null,
+                                          "value": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 23,
+                                              "startTokenPos": 361,
+                                              "startFilePos": 884,
+                                              "endLine": 23,
+                                              "endTokenPos": 364,
+                                              "endFilePos": 905
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 361,
+                                                "startFilePos": 884,
+                                                "endLine": 23,
+                                                "endTokenPos": 361,
+                                                "endFilePos": 889
+                                              },
+                                              "name": "entry"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 363,
+                                                "startFilePos": 891,
+                                                "endLine": 23,
+                                                "endTokenPos": 363,
+                                                "endFilePos": 904,
+                                                "kind": 2,
+                                                "rawValue": "\"customerName\""
+                                              },
+                                              "value": "customerName"
+                                            }
+                                          },
+                                          "byRef": false,
+                                          "unpack": false
+                                        }
+                                      ]
+                                    },
+                                    "if": {
+                                      "nodeType": "Expr_FuncCall",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 369,
+                                        "startFilePos": 910,
+                                        "endLine": 23,
+                                        "endTokenPos": 378,
+                                        "endFilePos": 950
+                                      },
+                                      "name": {
+                                        "nodeType": "Name",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 369,
+                                          "startFilePos": 910,
+                                          "endLine": 23,
+                                          "endTokenPos": 369,
+                                          "endFilePos": 920
+                                        },
+                                        "name": "json_encode"
+                                      },
+                                      "args": [
+                                        {
+                                          "nodeType": "Arg",
+                                          "attributes": {
+                                            "startLine": 23,
+                                            "startTokenPos": 371,
+                                            "startFilePos": 922,
+                                            "endLine": 23,
+                                            "endTokenPos": 374,
+                                            "endFilePos": 943
+                                          },
+                                          "name": null,
+                                          "value": {
+                                            "nodeType": "Expr_ArrayDimFetch",
+                                            "attributes": {
+                                              "startLine": 23,
+                                              "startTokenPos": 371,
+                                              "startFilePos": 922,
+                                              "endLine": 23,
+                                              "endTokenPos": 374,
+                                              "endFilePos": 943
+                                            },
+                                            "var": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 371,
+                                                "startFilePos": 922,
+                                                "endLine": 23,
+                                                "endTokenPos": 371,
+                                                "endFilePos": 927
+                                              },
+                                              "name": "entry"
+                                            },
+                                            "dim": {
+                                              "nodeType": "Scalar_String",
+                                              "attributes": {
+                                                "startLine": 23,
+                                                "startTokenPos": 373,
+                                                "startFilePos": 929,
+                                                "endLine": 23,
+                                                "endTokenPos": 373,
+                                                "endFilePos": 942,
+                                                "kind": 2,
+                                                "rawValue": "\"customerName\""
+                                              },
+                                              "value": "customerName"
+                                            }
+                                          },
+                                          "byRef": false,
+                                          "unpack": false
+                                        },
+                                        {
+                                          "nodeType": "Arg",
+                                          "attributes": {
+                                            "startLine": 23,
+                                            "startTokenPos": 377,
+                                            "startFilePos": 946,
+                                            "endLine": 23,
+                                            "endTokenPos": 377,
+                                            "endFilePos": 949
+                                          },
+                                          "name": null,
+                                          "value": {
+                                            "nodeType": "Scalar_Int",
+                                            "attributes": {
+                                              "startLine": 23,
+                                              "startTokenPos": 377,
+                                              "startFilePos": 946,
+                                              "endLine": 23,
+                                              "endTokenPos": 377,
+                                              "endFilePos": 949,
+                                              "rawValue": "1344",
+                                              "kind": 10
+                                            },
+                                            "value": 1344
+                                          },
+                                          "byRef": false,
+                                          "unpack": false
+                                        }
+                                      ]
+                                    },
+                                    "else": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 382,
+                                        "startFilePos": 954,
+                                        "endLine": 23,
+                                        "endTokenPos": 385,
+                                        "endFilePos": 975
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 382,
+                                          "startFilePos": 954,
+                                          "endLine": 23,
+                                          "endTokenPos": 382,
+                                          "endFilePos": 959
+                                        },
+                                        "name": "entry"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 384,
+                                          "startFilePos": 961,
+                                          "endLine": 23,
+                                          "endTokenPos": 384,
+                                          "endFilePos": 974,
+                                          "kind": 2,
+                                          "rawValue": "\"customerName\""
+                                        },
+                                        "value": "customerName"
+                                      }
+                                    }
+                                  }
+                                },
+                                "right": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 390,
+                                    "startFilePos": 980,
+                                    "endLine": 23,
+                                    "endTokenPos": 390,
+                                    "endFilePos": 982,
+                                    "kind": 2,
+                                    "rawValue": "\" \""
+                                  },
+                                  "value": " "
+                                }
+                              },
+                              "right": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 394,
+                                  "startFilePos": 986,
+                                  "endLine": 23,
+                                  "endTokenPos": 394,
+                                  "endFilePos": 996,
+                                  "kind": 2,
+                                  "rawValue": "\"has order\""
+                                },
+                                "value": "has order"
+                              }
+                            },
+                            "right": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 398,
+                                "startFilePos": 1000,
+                                "endLine": 23,
+                                "endTokenPos": 398,
+                                "endFilePos": 1002,
+                                "kind": 2,
+                                "rawValue": "\" \""
+                              },
+                              "value": " "
+                            }
+                          },
+                          "right": {
+                            "nodeType": "Expr_Ternary",
+                            "attributes": {
+                              "startLine": 23,
+                              "startTokenPos": 403,
+                              "startFilePos": 1007,
+                              "endLine": 23,
+                              "endTokenPos": 438,
+                              "endFilePos": 1104
+                            },
+                            "cond": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 403,
+                                "startFilePos": 1007,
+                                "endLine": 23,
+                                "endTokenPos": 412,
+                                "endFilePos": 1037
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 403,
+                                  "startFilePos": 1007,
+                                  "endLine": 23,
+                                  "endTokenPos": 403,
+                                  "endFilePos": 1014
+                                },
+                                "name": "is_float"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 405,
+                                    "startFilePos": 1016,
+                                    "endLine": 23,
+                                    "endTokenPos": 411,
+                                    "endFilePos": 1036
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 405,
+                                      "startFilePos": 1016,
+                                      "endLine": 23,
+                                      "endTokenPos": 411,
+                                      "endFilePos": 1036
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 405,
+                                        "startFilePos": 1016,
+                                        "endLine": 23,
+                                        "endTokenPos": 408,
+                                        "endFilePos": 1030
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 405,
+                                          "startFilePos": 1016,
+                                          "endLine": 23,
+                                          "endTokenPos": 405,
+                                          "endFilePos": 1021
+                                        },
+                                        "name": "entry"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 407,
+                                          "startFilePos": 1023,
+                                          "endLine": 23,
+                                          "endTokenPos": 407,
+                                          "endFilePos": 1029,
+                                          "kind": 2,
+                                          "rawValue": "\"order\""
+                                        },
+                                        "value": "order"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 410,
+                                        "startFilePos": 1032,
+                                        "endLine": 23,
+                                        "endTokenPos": 410,
+                                        "endFilePos": 1035,
+                                        "kind": 2,
+                                        "rawValue": "\"id\""
+                                      },
+                                      "value": "id"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "if": {
+                              "nodeType": "Expr_FuncCall",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 416,
+                                "startFilePos": 1041,
+                                "endLine": 23,
+                                "endTokenPos": 428,
+                                "endFilePos": 1080
+                              },
+                              "name": {
+                                "nodeType": "Name",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 416,
+                                  "startFilePos": 1041,
+                                  "endLine": 23,
+                                  "endTokenPos": 416,
+                                  "endFilePos": 1051
+                                },
+                                "name": "json_encode"
+                              },
+                              "args": [
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 418,
+                                    "startFilePos": 1053,
+                                    "endLine": 23,
+                                    "endTokenPos": 424,
+                                    "endFilePos": 1073
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Expr_ArrayDimFetch",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 418,
+                                      "startFilePos": 1053,
+                                      "endLine": 23,
+                                      "endTokenPos": 424,
+                                      "endFilePos": 1073
+                                    },
+                                    "var": {
+                                      "nodeType": "Expr_ArrayDimFetch",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 418,
+                                        "startFilePos": 1053,
+                                        "endLine": 23,
+                                        "endTokenPos": 421,
+                                        "endFilePos": 1067
+                                      },
+                                      "var": {
+                                        "nodeType": "Expr_Variable",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 418,
+                                          "startFilePos": 1053,
+                                          "endLine": 23,
+                                          "endTokenPos": 418,
+                                          "endFilePos": 1058
+                                        },
+                                        "name": "entry"
+                                      },
+                                      "dim": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 23,
+                                          "startTokenPos": 420,
+                                          "startFilePos": 1060,
+                                          "endLine": 23,
+                                          "endTokenPos": 420,
+                                          "endFilePos": 1066,
+                                          "kind": 2,
+                                          "rawValue": "\"order\""
+                                        },
+                                        "value": "order"
+                                      }
+                                    },
+                                    "dim": {
+                                      "nodeType": "Scalar_String",
+                                      "attributes": {
+                                        "startLine": 23,
+                                        "startTokenPos": 423,
+                                        "startFilePos": 1069,
+                                        "endLine": 23,
+                                        "endTokenPos": 423,
+                                        "endFilePos": 1072,
+                                        "kind": 2,
+                                        "rawValue": "\"id\""
+                                      },
+                                      "value": "id"
+                                    }
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                },
+                                {
+                                  "nodeType": "Arg",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 427,
+                                    "startFilePos": 1076,
+                                    "endLine": 23,
+                                    "endTokenPos": 427,
+                                    "endFilePos": 1079
+                                  },
+                                  "name": null,
+                                  "value": {
+                                    "nodeType": "Scalar_Int",
+                                    "attributes": {
+                                      "startLine": 23,
+                                      "startTokenPos": 427,
+                                      "startFilePos": 1076,
+                                      "endLine": 23,
+                                      "endTokenPos": 427,
+                                      "endFilePos": 1079,
+                                      "rawValue": "1344",
+                                      "kind": 10
+                                    },
+                                    "value": 1344
+                                  },
+                                  "byRef": false,
+                                  "unpack": false
+                                }
+                              ]
+                            },
+                            "else": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 432,
+                                "startFilePos": 1084,
+                                "endLine": 23,
+                                "endTokenPos": 438,
+                                "endFilePos": 1104
+                              },
+                              "var": {
+                                "nodeType": "Expr_ArrayDimFetch",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 432,
+                                  "startFilePos": 1084,
+                                  "endLine": 23,
+                                  "endTokenPos": 435,
+                                  "endFilePos": 1098
+                                },
+                                "var": {
+                                  "nodeType": "Expr_Variable",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 432,
+                                    "startFilePos": 1084,
+                                    "endLine": 23,
+                                    "endTokenPos": 432,
+                                    "endFilePos": 1089
+                                  },
+                                  "name": "entry"
+                                },
+                                "dim": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 23,
+                                    "startTokenPos": 434,
+                                    "startFilePos": 1091,
+                                    "endLine": 23,
+                                    "endTokenPos": 434,
+                                    "endFilePos": 1097,
+                                    "kind": 2,
+                                    "rawValue": "\"order\""
+                                  },
+                                  "value": "order"
+                                }
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 437,
+                                  "startFilePos": 1100,
+                                  "endLine": 23,
+                                  "endTokenPos": 437,
+                                  "endFilePos": 1103,
+                                  "kind": 2,
+                                  "rawValue": "\"id\""
+                                },
+                                "value": "id"
+                              }
+                            }
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 443,
+                            "startFilePos": 1109,
+                            "endLine": 23,
+                            "endTokenPos": 443,
+                            "endFilePos": 1111,
+                            "kind": 2,
+                            "rawValue": "\" \""
+                          },
+                          "value": " "
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 447,
+                          "startFilePos": 1115,
+                          "endLine": 23,
+                          "endTokenPos": 447,
+                          "endFilePos": 1119,
+                          "kind": 2,
+                          "rawValue": "\"- $\""
+                        },
+                        "value": "- $"
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 451,
+                        "startFilePos": 1123,
+                        "endLine": 23,
+                        "endTokenPos": 451,
+                        "endFilePos": 1125,
+                        "kind": 2,
+                        "rawValue": "\" \""
+                      },
+                      "value": " "
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Expr_Ternary",
+                    "attributes": {
+                      "startLine": 23,
+                      "startTokenPos": 456,
+                      "startFilePos": 1130,
+                      "endLine": 23,
+                      "endTokenPos": 491,
+                      "endFilePos": 1236
+                    },
+                    "cond": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 456,
+                        "startFilePos": 1130,
+                        "endLine": 23,
+                        "endTokenPos": 465,
+                        "endFilePos": 1163
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 456,
+                          "startFilePos": 1130,
+                          "endLine": 23,
+                          "endTokenPos": 456,
+                          "endFilePos": 1137
+                        },
+                        "name": "is_float"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 458,
+                            "startFilePos": 1139,
+                            "endLine": 23,
+                            "endTokenPos": 464,
+                            "endFilePos": 1162
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 23,
+                              "startTokenPos": 458,
+                              "startFilePos": 1139,
+                              "endLine": 23,
+                              "endTokenPos": 464,
+                              "endFilePos": 1162
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 458,
+                                "startFilePos": 1139,
+                                "endLine": 23,
+                                "endTokenPos": 461,
+                                "endFilePos": 1153
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 458,
+                                  "startFilePos": 1139,
+                                  "endLine": 23,
+                                  "endTokenPos": 458,
+                                  "endFilePos": 1144
+                                },
+                                "name": "entry"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 460,
+                                  "startFilePos": 1146,
+                                  "endLine": 23,
+                                  "endTokenPos": 460,
+                                  "endFilePos": 1152,
+                                  "kind": 2,
+                                  "rawValue": "\"order\""
+                                },
+                                "value": "order"
+                              }
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 463,
+                                "startFilePos": 1155,
+                                "endLine": 23,
+                                "endTokenPos": 463,
+                                "endFilePos": 1161,
+                                "kind": 2,
+                                "rawValue": "\"total\""
+                              },
+                              "value": "total"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "if": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 469,
+                        "startFilePos": 1167,
+                        "endLine": 23,
+                        "endTokenPos": 481,
+                        "endFilePos": 1209
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 469,
+                          "startFilePos": 1167,
+                          "endLine": 23,
+                          "endTokenPos": 469,
+                          "endFilePos": 1177
+                        },
+                        "name": "json_encode"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 471,
+                            "startFilePos": 1179,
+                            "endLine": 23,
+                            "endTokenPos": 477,
+                            "endFilePos": 1202
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 23,
+                              "startTokenPos": 471,
+                              "startFilePos": 1179,
+                              "endLine": 23,
+                              "endTokenPos": 477,
+                              "endFilePos": 1202
+                            },
+                            "var": {
+                              "nodeType": "Expr_ArrayDimFetch",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 471,
+                                "startFilePos": 1179,
+                                "endLine": 23,
+                                "endTokenPos": 474,
+                                "endFilePos": 1193
+                              },
+                              "var": {
+                                "nodeType": "Expr_Variable",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 471,
+                                  "startFilePos": 1179,
+                                  "endLine": 23,
+                                  "endTokenPos": 471,
+                                  "endFilePos": 1184
+                                },
+                                "name": "entry"
+                              },
+                              "dim": {
+                                "nodeType": "Scalar_String",
+                                "attributes": {
+                                  "startLine": 23,
+                                  "startTokenPos": 473,
+                                  "startFilePos": 1186,
+                                  "endLine": 23,
+                                  "endTokenPos": 473,
+                                  "endFilePos": 1192,
+                                  "kind": 2,
+                                  "rawValue": "\"order\""
+                                },
+                                "value": "order"
+                              }
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 23,
+                                "startTokenPos": 476,
+                                "startFilePos": 1195,
+                                "endLine": 23,
+                                "endTokenPos": 476,
+                                "endFilePos": 1201,
+                                "kind": 2,
+                                "rawValue": "\"total\""
+                              },
+                              "value": "total"
+                            }
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 480,
+                            "startFilePos": 1205,
+                            "endLine": 23,
+                            "endTokenPos": 480,
+                            "endFilePos": 1208
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 23,
+                              "startTokenPos": 480,
+                              "startFilePos": 1205,
+                              "endLine": 23,
+                              "endTokenPos": 480,
+                              "endFilePos": 1208,
+                              "rawValue": "1344",
+                              "kind": 10
+                            },
+                            "value": 1344
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "else": {
+                      "nodeType": "Expr_ArrayDimFetch",
+                      "attributes": {
+                        "startLine": 23,
+                        "startTokenPos": 485,
+                        "startFilePos": 1213,
+                        "endLine": 23,
+                        "endTokenPos": 491,
+                        "endFilePos": 1236
+                      },
+                      "var": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 485,
+                          "startFilePos": 1213,
+                          "endLine": 23,
+                          "endTokenPos": 488,
+                          "endFilePos": 1227
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 485,
+                            "startFilePos": 1213,
+                            "endLine": 23,
+                            "endTokenPos": 485,
+                            "endFilePos": 1218
+                          },
+                          "name": "entry"
+                        },
+                        "dim": {
+                          "nodeType": "Scalar_String",
+                          "attributes": {
+                            "startLine": 23,
+                            "startTokenPos": 487,
+                            "startFilePos": 1220,
+                            "endLine": 23,
+                            "endTokenPos": 487,
+                            "endFilePos": 1226,
+                            "kind": 2,
+                            "rawValue": "\"order\""
+                          },
+                          "value": "order"
+                        }
+                      },
+                      "dim": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 23,
+                          "startTokenPos": 490,
+                          "startFilePos": 1229,
+                          "endLine": 23,
+                          "endTokenPos": 490,
+                          "endFilePos": 1235,
+                          "kind": 2,
+                          "rawValue": "\"total\""
+                        },
+                        "value": "total"
+                      }
+                    }
+                  }
+                },
+                {
+                  "nodeType": "Expr_ConstFetch",
+                  "attributes": {
+                    "startLine": 23,
+                    "startTokenPos": 495,
+                    "startFilePos": 1240,
+                    "endLine": 23,
+                    "endTokenPos": 495,
+                    "endFilePos": 1246
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 23,
+                      "startTokenPos": 495,
+                      "startFilePos": 1240,
+                      "endLine": 23,
+                      "endTokenPos": 495,
+                      "endFilePos": 1246
+                    },
+                    "name": "PHP_EOL"
+                  }
+                }
+              ]
+            }
+          ],
+          "elseifs": [],
+          "else": {
+            "nodeType": "Stmt_Else",
+            "attributes": {
+              "startLine": 24,
+              "startTokenPos": 500,
+              "startFilePos": 1251,
+              "endLine": 26,
+              "endTokenPos": 556,
+              "endFilePos": 1422
+            },
+            "stmts": [
+              {
+                "nodeType": "Stmt_Echo",
+                "attributes": {
+                  "startLine": 25,
+                  "startTokenPos": 504,
+                  "startFilePos": 1260,
+                  "endLine": 25,
+                  "endTokenPos": 554,
+                  "endFilePos": 1420
+                },
+                "exprs": [
+                  {
+                    "nodeType": "Expr_BinaryOp_Concat",
+                    "attributes": {
+                      "startLine": 25,
+                      "startTokenPos": 506,
+                      "startFilePos": 1265,
+                      "endLine": 25,
+                      "endTokenPos": 550,
+                      "endFilePos": 1410
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Concat",
+                      "attributes": {
+                        "startLine": 25,
+                        "startTokenPos": 506,
+                        "startFilePos": 1265,
+                        "endLine": 25,
+                        "endTokenPos": 546,
+                        "endFilePos": 1392
+                      },
+                      "left": {
+                        "nodeType": "Expr_BinaryOp_Concat",
+                        "attributes": {
+                          "startLine": 25,
+                          "startTokenPos": 506,
+                          "startFilePos": 1265,
+                          "endLine": 25,
+                          "endTokenPos": 542,
+                          "endFilePos": 1386
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Concat",
+                          "attributes": {
+                            "startLine": 25,
+                            "startTokenPos": 506,
+                            "startFilePos": 1265,
+                            "endLine": 25,
+                            "endTokenPos": 510,
+                            "endFilePos": 1280
+                          },
+                          "left": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 506,
+                              "startFilePos": 1265,
+                              "endLine": 25,
+                              "endTokenPos": 506,
+                              "endFilePos": 1274,
+                              "kind": 2,
+                              "rawValue": "\"Customer\""
+                            },
+                            "value": "Customer"
+                          },
+                          "right": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 510,
+                              "startFilePos": 1278,
+                              "endLine": 25,
+                              "endTokenPos": 510,
+                              "endFilePos": 1280,
+                              "kind": 2,
+                              "rawValue": "\" \""
+                            },
+                            "value": " "
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Expr_Ternary",
+                          "attributes": {
+                            "startLine": 25,
+                            "startTokenPos": 515,
+                            "startFilePos": 1285,
+                            "endLine": 25,
+                            "endTokenPos": 541,
+                            "endFilePos": 1385
+                          },
+                          "cond": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 515,
+                              "startFilePos": 1285,
+                              "endLine": 25,
+                              "endTokenPos": 521,
+                              "endFilePos": 1316
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 515,
+                                "startFilePos": 1285,
+                                "endLine": 25,
+                                "endTokenPos": 515,
+                                "endFilePos": 1292
+                              },
+                              "name": "is_float"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 517,
+                                  "startFilePos": 1294,
+                                  "endLine": 25,
+                                  "endTokenPos": 520,
+                                  "endFilePos": 1315
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 517,
+                                    "startFilePos": 1294,
+                                    "endLine": 25,
+                                    "endTokenPos": 520,
+                                    "endFilePos": 1315
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 25,
+                                      "startTokenPos": 517,
+                                      "startFilePos": 1294,
+                                      "endLine": 25,
+                                      "endTokenPos": 517,
+                                      "endFilePos": 1299
+                                    },
+                                    "name": "entry"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 25,
+                                      "startTokenPos": 519,
+                                      "startFilePos": 1301,
+                                      "endLine": 25,
+                                      "endTokenPos": 519,
+                                      "endFilePos": 1314,
+                                      "kind": 2,
+                                      "rawValue": "\"customerName\""
+                                    },
+                                    "value": "customerName"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "if": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 525,
+                              "startFilePos": 1320,
+                              "endLine": 25,
+                              "endTokenPos": 534,
+                              "endFilePos": 1360
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 525,
+                                "startFilePos": 1320,
+                                "endLine": 25,
+                                "endTokenPos": 525,
+                                "endFilePos": 1330
+                              },
+                              "name": "json_encode"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 527,
+                                  "startFilePos": 1332,
+                                  "endLine": 25,
+                                  "endTokenPos": 530,
+                                  "endFilePos": 1353
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_ArrayDimFetch",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 527,
+                                    "startFilePos": 1332,
+                                    "endLine": 25,
+                                    "endTokenPos": 530,
+                                    "endFilePos": 1353
+                                  },
+                                  "var": {
+                                    "nodeType": "Expr_Variable",
+                                    "attributes": {
+                                      "startLine": 25,
+                                      "startTokenPos": 527,
+                                      "startFilePos": 1332,
+                                      "endLine": 25,
+                                      "endTokenPos": 527,
+                                      "endFilePos": 1337
+                                    },
+                                    "name": "entry"
+                                  },
+                                  "dim": {
+                                    "nodeType": "Scalar_String",
+                                    "attributes": {
+                                      "startLine": 25,
+                                      "startTokenPos": 529,
+                                      "startFilePos": 1339,
+                                      "endLine": 25,
+                                      "endTokenPos": 529,
+                                      "endFilePos": 1352,
+                                      "kind": 2,
+                                      "rawValue": "\"customerName\""
+                                    },
+                                    "value": "customerName"
+                                  }
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 25,
+                                  "startTokenPos": 533,
+                                  "startFilePos": 1356,
+                                  "endLine": 25,
+                                  "endTokenPos": 533,
+                                  "endFilePos": 1359
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_Int",
+                                  "attributes": {
+                                    "startLine": 25,
+                                    "startTokenPos": 533,
+                                    "startFilePos": 1356,
+                                    "endLine": 25,
+                                    "endTokenPos": 533,
+                                    "endFilePos": 1359,
+                                    "rawValue": "1344",
+                                    "kind": 10
+                                  },
+                                  "value": 1344
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "else": {
+                            "nodeType": "Expr_ArrayDimFetch",
+                            "attributes": {
+                              "startLine": 25,
+                              "startTokenPos": 538,
+                              "startFilePos": 1364,
+                              "endLine": 25,
+                              "endTokenPos": 541,
+                              "endFilePos": 1385
+                            },
+                            "var": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 538,
+                                "startFilePos": 1364,
+                                "endLine": 25,
+                                "endTokenPos": 538,
+                                "endFilePos": 1369
+                              },
+                              "name": "entry"
+                            },
+                            "dim": {
+                              "nodeType": "Scalar_String",
+                              "attributes": {
+                                "startLine": 25,
+                                "startTokenPos": 540,
+                                "startFilePos": 1371,
+                                "endLine": 25,
+                                "endTokenPos": 540,
+                                "endFilePos": 1384,
+                                "kind": 2,
+                                "rawValue": "\"customerName\""
+                              },
+                              "value": "customerName"
+                            }
+                          }
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 25,
+                          "startTokenPos": 546,
+                          "startFilePos": 1390,
+                          "endLine": 25,
+                          "endTokenPos": 546,
+                          "endFilePos": 1392,
+                          "kind": 2,
+                          "rawValue": "\" \""
+                        },
+                        "value": " "
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 25,
+                        "startTokenPos": 550,
+                        "startFilePos": 1396,
+                        "endLine": 25,
+                        "endTokenPos": 550,
+                        "endFilePos": 1410,
+                        "kind": 2,
+                        "rawValue": "\"has no orders\""
+                      },
+                      "value": "has no orders"
+                    }
+                  },
+                  {
+                    "nodeType": "Expr_ConstFetch",
+                    "attributes": {
+                      "startLine": 25,
+                      "startTokenPos": 553,
+                      "startFilePos": 1413,
+                      "endLine": 25,
+                      "endTokenPos": 553,
+                      "endFilePos": 1419
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 25,
+                        "startTokenPos": 553,
+                        "startFilePos": 1413,
+                        "endLine": 25,
+                        "endTokenPos": 553,
+                        "endFilePos": 1419
+                      },
+                      "name": "PHP_EOL"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/save_jsonl_stdout.php.json
+++ b/tests/json-ast/x/php/save_jsonl_stdout.php.json
@@ -1,0 +1,737 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 37,
+        "endFilePos": 82
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 36,
+          "endFilePos": 81
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 36,
+            "endFilePos": 81,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 48
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 48,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 34
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 23,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 34,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 37,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 47
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 37,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 41,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 46,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 47,
+                        "rawValue": "30",
+                        "kind": 10
+                      },
+                      "value": 30
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 51,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 80
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 51,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 80,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 52,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 66
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 52,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 57,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 62,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 69,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 79
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 69,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 73,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 78,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 79,
+                        "rawValue": "25",
+                        "kind": 10
+                      },
+                      "value": 25
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 39,
+        "startFilePos": 84,
+        "endLine": 8,
+        "endTokenPos": 102,
+        "endFilePos": 231
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 42,
+          "startFilePos": 93,
+          "endLine": 3,
+          "endTokenPos": 42,
+          "endFilePos": 99
+        },
+        "name": "people"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 46,
+          "startFilePos": 104,
+          "endLine": 3,
+          "endTokenPos": 46,
+          "endFilePos": 108
+        },
+        "name": "_row"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 51,
+            "startFilePos": 115,
+            "endLine": 4,
+            "endTokenPos": 59,
+            "endFilePos": 138
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 51,
+              "startFilePos": 115,
+              "endLine": 4,
+              "endTokenPos": 58,
+              "endFilePos": 137
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 51,
+                "startFilePos": 115,
+                "endLine": 4,
+                "endTokenPos": 51,
+                "endFilePos": 116
+              },
+              "name": "j"
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 55,
+                "startFilePos": 120,
+                "endLine": 4,
+                "endTokenPos": 58,
+                "endFilePos": 137
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 55,
+                  "startFilePos": 120,
+                  "endLine": 4,
+                  "endTokenPos": 55,
+                  "endFilePos": 130
+                },
+                "name": "json_encode"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 57,
+                    "startFilePos": 132,
+                    "endLine": 4,
+                    "endTokenPos": 57,
+                    "endFilePos": 136
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 57,
+                      "startFilePos": 132,
+                      "endLine": 4,
+                      "endTokenPos": 57,
+                      "endFilePos": 136
+                    },
+                    "name": "_row"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 61,
+            "startFilePos": 142,
+            "endLine": 5,
+            "endTokenPos": 75,
+            "endFilePos": 173
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 61,
+              "startFilePos": 142,
+              "endLine": 5,
+              "endTokenPos": 74,
+              "endFilePos": 172
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 61,
+                "startFilePos": 142,
+                "endLine": 5,
+                "endTokenPos": 61,
+                "endFilePos": 143
+              },
+              "name": "j"
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 65,
+                "startFilePos": 147,
+                "endLine": 5,
+                "endTokenPos": 74,
+                "endFilePos": 172
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 65,
+                  "startFilePos": 147,
+                  "endLine": 5,
+                  "endTokenPos": 65,
+                  "endFilePos": 157
+                },
+                "name": "str_replace"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 67,
+                    "startFilePos": 159,
+                    "endLine": 5,
+                    "endTokenPos": 67,
+                    "endFilePos": 161
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 67,
+                      "startFilePos": 159,
+                      "endLine": 5,
+                      "endTokenPos": 67,
+                      "endFilePos": 161,
+                      "kind": 2,
+                      "rawValue": "\":\""
+                    },
+                    "value": ":"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 70,
+                    "startFilePos": 164,
+                    "endLine": 5,
+                    "endTokenPos": 70,
+                    "endFilePos": 167
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 70,
+                      "startFilePos": 164,
+                      "endLine": 5,
+                      "endTokenPos": 70,
+                      "endFilePos": 167,
+                      "kind": 2,
+                      "rawValue": "\": \""
+                    },
+                    "value": ": "
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 73,
+                    "startFilePos": 170,
+                    "endLine": 5,
+                    "endTokenPos": 73,
+                    "endFilePos": 171
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 73,
+                      "startFilePos": 170,
+                      "endLine": 5,
+                      "endTokenPos": 73,
+                      "endFilePos": 171
+                    },
+                    "name": "j"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 77,
+            "startFilePos": 177,
+            "endLine": 6,
+            "endTokenPos": 91,
+            "endFilePos": 208
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 77,
+              "startFilePos": 177,
+              "endLine": 6,
+              "endTokenPos": 90,
+              "endFilePos": 207
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 77,
+                "startFilePos": 177,
+                "endLine": 6,
+                "endTokenPos": 77,
+                "endFilePos": 178
+              },
+              "name": "j"
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 81,
+                "startFilePos": 182,
+                "endLine": 6,
+                "endTokenPos": 90,
+                "endFilePos": 207
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 81,
+                  "startFilePos": 182,
+                  "endLine": 6,
+                  "endTokenPos": 81,
+                  "endFilePos": 192
+                },
+                "name": "str_replace"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 83,
+                    "startFilePos": 194,
+                    "endLine": 6,
+                    "endTokenPos": 83,
+                    "endFilePos": 196
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 83,
+                      "startFilePos": 194,
+                      "endLine": 6,
+                      "endTokenPos": 83,
+                      "endFilePos": 196,
+                      "kind": 2,
+                      "rawValue": "\",\""
+                    },
+                    "value": ","
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 86,
+                    "startFilePos": 199,
+                    "endLine": 6,
+                    "endTokenPos": 86,
+                    "endFilePos": 202
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 86,
+                      "startFilePos": 199,
+                      "endLine": 6,
+                      "endTokenPos": 86,
+                      "endFilePos": 202,
+                      "kind": 2,
+                      "rawValue": "\", \""
+                    },
+                    "value": ", "
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 89,
+                    "startFilePos": 205,
+                    "endLine": 6,
+                    "endTokenPos": 89,
+                    "endFilePos": 206
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 89,
+                      "startFilePos": 205,
+                      "endLine": 6,
+                      "endTokenPos": 89,
+                      "endFilePos": 206
+                    },
+                    "name": "j"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 93,
+            "startFilePos": 212,
+            "endLine": 7,
+            "endTokenPos": 100,
+            "endFilePos": 229
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_BinaryOp_Concat",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 95,
+                "startFilePos": 217,
+                "endLine": 7,
+                "endTokenPos": 99,
+                "endFilePos": 228
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 95,
+                  "startFilePos": 217,
+                  "endLine": 7,
+                  "endTokenPos": 95,
+                  "endFilePos": 218
+                },
+                "name": "j"
+              },
+              "right": {
+                "nodeType": "Expr_ConstFetch",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 99,
+                  "startFilePos": 222,
+                  "endLine": 7,
+                  "endTokenPos": 99,
+                  "endFilePos": 228
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 99,
+                    "startFilePos": 222,
+                    "endLine": 7,
+                    "endTokenPos": 99,
+                    "endFilePos": 228
+                  },
+                  "name": "PHP_EOL"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/short_circuit.php.json
+++ b/tests/json-ast/x/php/short_circuit.php.json
@@ -1,0 +1,558 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 5,
+        "endTokenPos": 26,
+        "endFilePos": 69
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 18
+        },
+        "name": "boom"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 20,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 21
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 20,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 21
+            },
+            "name": "a"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 8,
+            "startFilePos": 24,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 25
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 24,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 25
+            },
+            "name": "b"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 32,
+            "endLine": 3,
+            "endTokenPos": 19,
+            "endFilePos": 52
+          },
+          "exprs": [
+            {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 15,
+                "startFilePos": 37,
+                "endLine": 3,
+                "endTokenPos": 15,
+                "endFilePos": 42,
+                "kind": 2,
+                "rawValue": "\"boom\""
+              },
+              "value": "boom"
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 18,
+                "startFilePos": 45,
+                "endLine": 3,
+                "endTokenPos": 18,
+                "endFilePos": 51
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 18,
+                  "startFilePos": 45,
+                  "endLine": 3,
+                  "endTokenPos": 18,
+                  "endFilePos": 51
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        },
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 21,
+            "startFilePos": 56,
+            "endLine": 4,
+            "endTokenPos": 24,
+            "endFilePos": 67
+          },
+          "expr": {
+            "nodeType": "Expr_ConstFetch",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 23,
+              "startFilePos": 63,
+              "endLine": 4,
+              "endTokenPos": 23,
+              "endFilePos": 66
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 23,
+                "startFilePos": 63,
+                "endLine": 4,
+                "endTokenPos": 23,
+                "endFilePos": 66
+              },
+              "name": "true"
+            }
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 28,
+        "startFilePos": 71,
+        "endLine": 6,
+        "endTokenPos": 54,
+        "endFilePos": 125
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 31,
+            "startFilePos": 77,
+            "endLine": 6,
+            "endTokenPos": 49,
+            "endFilePos": 114
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_BooleanAnd",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 31,
+              "startFilePos": 77,
+              "endLine": 6,
+              "endTokenPos": 41,
+              "endFilePos": 95
+            },
+            "left": {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 31,
+                "startFilePos": 77,
+                "endLine": 6,
+                "endTokenPos": 31,
+                "endFilePos": 81
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 31,
+                  "startFilePos": 77,
+                  "endLine": 6,
+                  "endTokenPos": 31,
+                  "endFilePos": 81
+                },
+                "name": "false"
+              }
+            },
+            "right": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 35,
+                "startFilePos": 86,
+                "endLine": 6,
+                "endTokenPos": 41,
+                "endFilePos": 95
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 35,
+                  "startFilePos": 86,
+                  "endLine": 6,
+                  "endTokenPos": 35,
+                  "endFilePos": 89
+                },
+                "name": "boom"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 37,
+                    "startFilePos": 91,
+                    "endLine": 6,
+                    "endTokenPos": 37,
+                    "endFilePos": 91
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 37,
+                      "startFilePos": 91,
+                      "endLine": 6,
+                      "endTokenPos": 37,
+                      "endFilePos": 91,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 40,
+                    "startFilePos": 94,
+                    "endLine": 6,
+                    "endTokenPos": 40,
+                    "endFilePos": 94
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 40,
+                      "startFilePos": 94,
+                      "endLine": 6,
+                      "endTokenPos": 40,
+                      "endFilePos": 94,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 45,
+              "startFilePos": 99,
+              "endLine": 6,
+              "endTokenPos": 45,
+              "endFilePos": 104,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 49,
+              "startFilePos": 108,
+              "endLine": 6,
+              "endTokenPos": 49,
+              "endFilePos": 114,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 53,
+            "startFilePos": 118,
+            "endLine": 6,
+            "endTokenPos": 53,
+            "endFilePos": 124
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 53,
+              "startFilePos": 118,
+              "endLine": 6,
+              "endTokenPos": 53,
+              "endFilePos": 124
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 7,
+        "startTokenPos": 56,
+        "startFilePos": 127,
+        "endLine": 7,
+        "endTokenPos": 82,
+        "endFilePos": 180
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 59,
+            "startFilePos": 133,
+            "endLine": 7,
+            "endTokenPos": 77,
+            "endFilePos": 169
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_BooleanOr",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 59,
+              "startFilePos": 133,
+              "endLine": 7,
+              "endTokenPos": 69,
+              "endFilePos": 150
+            },
+            "left": {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 59,
+                "startFilePos": 133,
+                "endLine": 7,
+                "endTokenPos": 59,
+                "endFilePos": 136
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 59,
+                  "startFilePos": 133,
+                  "endLine": 7,
+                  "endTokenPos": 59,
+                  "endFilePos": 136
+                },
+                "name": "true"
+              }
+            },
+            "right": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 7,
+                "startTokenPos": 63,
+                "startFilePos": 141,
+                "endLine": 7,
+                "endTokenPos": 69,
+                "endFilePos": 150
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 7,
+                  "startTokenPos": 63,
+                  "startFilePos": 141,
+                  "endLine": 7,
+                  "endTokenPos": 63,
+                  "endFilePos": 144
+                },
+                "name": "boom"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 65,
+                    "startFilePos": 146,
+                    "endLine": 7,
+                    "endTokenPos": 65,
+                    "endFilePos": 146
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 65,
+                      "startFilePos": 146,
+                      "endLine": 7,
+                      "endTokenPos": 65,
+                      "endFilePos": 146,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 7,
+                    "startTokenPos": 68,
+                    "startFilePos": 149,
+                    "endLine": 7,
+                    "endTokenPos": 68,
+                    "endFilePos": 149
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 7,
+                      "startTokenPos": 68,
+                      "startFilePos": 149,
+                      "endLine": 7,
+                      "endTokenPos": 68,
+                      "endFilePos": 149,
+                      "rawValue": "2",
+                      "kind": 10
+                    },
+                    "value": 2
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 73,
+              "startFilePos": 154,
+              "endLine": 7,
+              "endTokenPos": 73,
+              "endFilePos": 159,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 77,
+              "startFilePos": 163,
+              "endLine": 7,
+              "endTokenPos": 77,
+              "endFilePos": 169,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 7,
+            "startTokenPos": 81,
+            "startFilePos": 173,
+            "endLine": 7,
+            "endTokenPos": 81,
+            "endFilePos": 179
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 7,
+              "startTokenPos": 81,
+              "startFilePos": 173,
+              "endLine": 7,
+              "endTokenPos": 81,
+              "endFilePos": 179
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/slice.php.json
+++ b/tests/json-ast/x/php/slice.php.json
@@ -1,0 +1,2151 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 79,
+        "endFilePos": 203
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 3,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 75,
+            "endFilePos": 193
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 3,
+              "startFilePos": 11,
+              "endLine": 2,
+              "endTokenPos": 3,
+              "endFilePos": 21
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 5,
+                "startFilePos": 23,
+                "endLine": 2,
+                "endTokenPos": 5,
+                "endFilePos": 29
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 5,
+                  "startFilePos": 23,
+                  "endLine": 2,
+                  "endTokenPos": 5,
+                  "endFilePos": 29,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 8,
+                "startFilePos": 32,
+                "endLine": 2,
+                "endTokenPos": 8,
+                "endFilePos": 38
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 8,
+                  "startFilePos": 32,
+                  "endLine": 2,
+                  "endTokenPos": 8,
+                  "endFilePos": 38,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 11,
+                "startFilePos": 41,
+                "endLine": 2,
+                "endTokenPos": 74,
+                "endFilePos": 192
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 11,
+                  "startFilePos": 41,
+                  "endLine": 2,
+                  "endTokenPos": 74,
+                  "endFilePos": 192
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 11,
+                    "startFilePos": 41,
+                    "endLine": 2,
+                    "endTokenPos": 11,
+                    "endFilePos": 51
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 13,
+                      "startFilePos": 53,
+                      "endLine": 2,
+                      "endTokenPos": 13,
+                      "endFilePos": 58
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 13,
+                        "startFilePos": 53,
+                        "endLine": 2,
+                        "endTokenPos": 13,
+                        "endFilePos": 58,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 61,
+                      "endLine": 2,
+                      "endTokenPos": 16,
+                      "endFilePos": 66
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 16,
+                        "startFilePos": 61,
+                        "endLine": 2,
+                        "endTokenPos": 16,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 19,
+                      "startFilePos": 69,
+                      "endLine": 2,
+                      "endTokenPos": 73,
+                      "endFilePos": 191
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 19,
+                        "startFilePos": 69,
+                        "endLine": 2,
+                        "endTokenPos": 73,
+                        "endFilePos": 191
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 19,
+                          "startFilePos": 69,
+                          "endLine": 2,
+                          "endTokenPos": 19,
+                          "endFilePos": 79
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 21,
+                            "startFilePos": 81,
+                            "endLine": 2,
+                            "endTokenPos": 21,
+                            "endFilePos": 84
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 21,
+                              "startFilePos": 81,
+                              "endLine": 2,
+                              "endTokenPos": 21,
+                              "endFilePos": 84,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 24,
+                            "startFilePos": 87,
+                            "endLine": 2,
+                            "endTokenPos": 24,
+                            "endFilePos": 89
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 24,
+                              "startFilePos": 87,
+                              "endLine": 2,
+                              "endTokenPos": 24,
+                              "endFilePos": 89,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 27,
+                            "startFilePos": 92,
+                            "endLine": 2,
+                            "endTokenPos": 72,
+                            "endFilePos": 190
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 27,
+                              "startFilePos": 92,
+                              "endLine": 2,
+                              "endTokenPos": 72,
+                              "endFilePos": 190
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 27,
+                                "startFilePos": 92,
+                                "endLine": 2,
+                                "endTokenPos": 27,
+                                "endFilePos": 102
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 29,
+                                  "startFilePos": 104,
+                                  "endLine": 2,
+                                  "endTokenPos": 29,
+                                  "endFilePos": 106
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 29,
+                                    "startFilePos": 104,
+                                    "endLine": 2,
+                                    "endTokenPos": 29,
+                                    "endFilePos": 106,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 32,
+                                  "startFilePos": 109,
+                                  "endLine": 2,
+                                  "endTokenPos": 32,
+                                  "endFilePos": 112
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 32,
+                                    "startFilePos": 109,
+                                    "endLine": 2,
+                                    "endTokenPos": 32,
+                                    "endFilePos": 112,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 2,
+                                  "startTokenPos": 35,
+                                  "startFilePos": 115,
+                                  "endLine": 2,
+                                  "endTokenPos": 71,
+                                  "endFilePos": 189
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 2,
+                                    "startTokenPos": 35,
+                                    "startFilePos": 115,
+                                    "endLine": 2,
+                                    "endTokenPos": 71,
+                                    "endFilePos": 189
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 2,
+                                      "startTokenPos": 35,
+                                      "startFilePos": 115,
+                                      "endLine": 2,
+                                      "endTokenPos": 35,
+                                      "endFilePos": 125
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 37,
+                                        "startFilePos": 127,
+                                        "endLine": 2,
+                                        "endTokenPos": 37,
+                                        "endFilePos": 129
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 37,
+                                          "startFilePos": 127,
+                                          "endLine": 2,
+                                          "endTokenPos": 37,
+                                          "endFilePos": 129,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 40,
+                                        "startFilePos": 132,
+                                        "endLine": 2,
+                                        "endTokenPos": 40,
+                                        "endFilePos": 135
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 40,
+                                          "startFilePos": 132,
+                                          "endLine": 2,
+                                          "endTokenPos": 40,
+                                          "endFilePos": 135,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 2,
+                                        "startTokenPos": 43,
+                                        "startFilePos": 138,
+                                        "endLine": 2,
+                                        "endTokenPos": 70,
+                                        "endFilePos": 188
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 2,
+                                          "startTokenPos": 43,
+                                          "startFilePos": 138,
+                                          "endLine": 2,
+                                          "endTokenPos": 70,
+                                          "endFilePos": 188
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 2,
+                                            "startTokenPos": 43,
+                                            "startFilePos": 138,
+                                            "endLine": 2,
+                                            "endTokenPos": 43,
+                                            "endFilePos": 148
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 45,
+                                              "startFilePos": 150,
+                                              "endLine": 2,
+                                              "endTokenPos": 66,
+                                              "endFilePos": 181
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 2,
+                                                "startTokenPos": 45,
+                                                "startFilePos": 150,
+                                                "endLine": 2,
+                                                "endTokenPos": 66,
+                                                "endFilePos": 181
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 2,
+                                                  "startTokenPos": 45,
+                                                  "startFilePos": 150,
+                                                  "endLine": 2,
+                                                  "endTokenPos": 45,
+                                                  "endFilePos": 160
+                                                },
+                                                "name": "array_slice"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 2,
+                                                    "startTokenPos": 47,
+                                                    "startFilePos": 162,
+                                                    "endLine": 2,
+                                                    "endTokenPos": 55,
+                                                    "endFilePos": 170
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_Array",
+                                                    "attributes": {
+                                                      "startLine": 2,
+                                                      "startTokenPos": 47,
+                                                      "startFilePos": 162,
+                                                      "endLine": 2,
+                                                      "endTokenPos": 55,
+                                                      "endFilePos": 170,
+                                                      "kind": 2
+                                                    },
+                                                    "items": [
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 2,
+                                                          "startTokenPos": 48,
+                                                          "startFilePos": 163,
+                                                          "endLine": 2,
+                                                          "endTokenPos": 48,
+                                                          "endFilePos": 163
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 2,
+                                                            "startTokenPos": 48,
+                                                            "startFilePos": 163,
+                                                            "endLine": 2,
+                                                            "endTokenPos": 48,
+                                                            "endFilePos": 163,
+                                                            "rawValue": "1",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 1
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 2,
+                                                          "startTokenPos": 51,
+                                                          "startFilePos": 166,
+                                                          "endLine": 2,
+                                                          "endTokenPos": 51,
+                                                          "endFilePos": 166
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 2,
+                                                            "startTokenPos": 51,
+                                                            "startFilePos": 166,
+                                                            "endLine": 2,
+                                                            "endTokenPos": 51,
+                                                            "endFilePos": 166,
+                                                            "rawValue": "2",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 2
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 2,
+                                                          "startTokenPos": 54,
+                                                          "startFilePos": 169,
+                                                          "endLine": 2,
+                                                          "endTokenPos": 54,
+                                                          "endFilePos": 169
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 2,
+                                                            "startTokenPos": 54,
+                                                            "startFilePos": 169,
+                                                            "endLine": 2,
+                                                            "endTokenPos": 54,
+                                                            "endFilePos": 169,
+                                                            "rawValue": "3",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 3
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      }
+                                                    ]
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                },
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 2,
+                                                    "startTokenPos": 58,
+                                                    "startFilePos": 173,
+                                                    "endLine": 2,
+                                                    "endTokenPos": 58,
+                                                    "endFilePos": 173
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Scalar_Int",
+                                                    "attributes": {
+                                                      "startLine": 2,
+                                                      "startTokenPos": 58,
+                                                      "startFilePos": 173,
+                                                      "endLine": 2,
+                                                      "endTokenPos": 58,
+                                                      "endFilePos": 173,
+                                                      "rawValue": "1",
+                                                      "kind": 10
+                                                    },
+                                                    "value": 1
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                },
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 2,
+                                                    "startTokenPos": 61,
+                                                    "startFilePos": 176,
+                                                    "endLine": 2,
+                                                    "endTokenPos": 65,
+                                                    "endFilePos": 180
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_BinaryOp_Minus",
+                                                    "attributes": {
+                                                      "startLine": 2,
+                                                      "startTokenPos": 61,
+                                                      "startFilePos": 176,
+                                                      "endLine": 2,
+                                                      "endTokenPos": 65,
+                                                      "endFilePos": 180
+                                                    },
+                                                    "left": {
+                                                      "nodeType": "Scalar_Int",
+                                                      "attributes": {
+                                                        "startLine": 2,
+                                                        "startTokenPos": 61,
+                                                        "startFilePos": 176,
+                                                        "endLine": 2,
+                                                        "endTokenPos": 61,
+                                                        "endFilePos": 176,
+                                                        "rawValue": "3",
+                                                        "kind": 10
+                                                      },
+                                                      "value": 3
+                                                    },
+                                                    "right": {
+                                                      "nodeType": "Scalar_Int",
+                                                      "attributes": {
+                                                        "startLine": 2,
+                                                        "startTokenPos": 65,
+                                                        "startFilePos": 180,
+                                                        "endLine": 2,
+                                                        "endTokenPos": 65,
+                                                        "endFilePos": 180,
+                                                        "rawValue": "1",
+                                                        "kind": 10
+                                                      },
+                                                      "value": 1
+                                                    }
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 2,
+                                              "startTokenPos": 69,
+                                              "startFilePos": 184,
+                                              "endLine": 2,
+                                              "endTokenPos": 69,
+                                              "endFilePos": 187
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 2,
+                                                "startTokenPos": 69,
+                                                "startFilePos": 184,
+                                                "endLine": 2,
+                                                "endTokenPos": 69,
+                                                "endFilePos": 187,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 78,
+            "startFilePos": 196,
+            "endLine": 2,
+            "endTokenPos": 78,
+            "endFilePos": 202
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 78,
+              "startFilePos": 196,
+              "endLine": 2,
+              "endTokenPos": 78,
+              "endFilePos": 202
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 81,
+        "startFilePos": 205,
+        "endLine": 3,
+        "endTokenPos": 159,
+        "endFilePos": 402
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 83,
+            "startFilePos": 210,
+            "endLine": 3,
+            "endTokenPos": 155,
+            "endFilePos": 392
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 83,
+              "startFilePos": 210,
+              "endLine": 3,
+              "endTokenPos": 83,
+              "endFilePos": 220
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 85,
+                "startFilePos": 222,
+                "endLine": 3,
+                "endTokenPos": 85,
+                "endFilePos": 228
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 85,
+                  "startFilePos": 222,
+                  "endLine": 3,
+                  "endTokenPos": 85,
+                  "endFilePos": 228,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 88,
+                "startFilePos": 231,
+                "endLine": 3,
+                "endTokenPos": 88,
+                "endFilePos": 237
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 88,
+                  "startFilePos": 231,
+                  "endLine": 3,
+                  "endTokenPos": 88,
+                  "endFilePos": 237,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 91,
+                "startFilePos": 240,
+                "endLine": 3,
+                "endTokenPos": 154,
+                "endFilePos": 391
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 91,
+                  "startFilePos": 240,
+                  "endLine": 3,
+                  "endTokenPos": 154,
+                  "endFilePos": 391
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 91,
+                    "startFilePos": 240,
+                    "endLine": 3,
+                    "endTokenPos": 91,
+                    "endFilePos": 250
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 93,
+                      "startFilePos": 252,
+                      "endLine": 3,
+                      "endTokenPos": 93,
+                      "endFilePos": 257
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 93,
+                        "startFilePos": 252,
+                        "endLine": 3,
+                        "endTokenPos": 93,
+                        "endFilePos": 257,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 96,
+                      "startFilePos": 260,
+                      "endLine": 3,
+                      "endTokenPos": 96,
+                      "endFilePos": 265
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 96,
+                        "startFilePos": 260,
+                        "endLine": 3,
+                        "endTokenPos": 96,
+                        "endFilePos": 265,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 99,
+                      "startFilePos": 268,
+                      "endLine": 3,
+                      "endTokenPos": 153,
+                      "endFilePos": 390
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 99,
+                        "startFilePos": 268,
+                        "endLine": 3,
+                        "endTokenPos": 153,
+                        "endFilePos": 390
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 99,
+                          "startFilePos": 268,
+                          "endLine": 3,
+                          "endTokenPos": 99,
+                          "endFilePos": 278
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 101,
+                            "startFilePos": 280,
+                            "endLine": 3,
+                            "endTokenPos": 101,
+                            "endFilePos": 283
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 101,
+                              "startFilePos": 280,
+                              "endLine": 3,
+                              "endTokenPos": 101,
+                              "endFilePos": 283,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 104,
+                            "startFilePos": 286,
+                            "endLine": 3,
+                            "endTokenPos": 104,
+                            "endFilePos": 288
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 104,
+                              "startFilePos": 286,
+                              "endLine": 3,
+                              "endTokenPos": 104,
+                              "endFilePos": 288,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 107,
+                            "startFilePos": 291,
+                            "endLine": 3,
+                            "endTokenPos": 152,
+                            "endFilePos": 389
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 107,
+                              "startFilePos": 291,
+                              "endLine": 3,
+                              "endTokenPos": 152,
+                              "endFilePos": 389
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 3,
+                                "startTokenPos": 107,
+                                "startFilePos": 291,
+                                "endLine": 3,
+                                "endTokenPos": 107,
+                                "endFilePos": 301
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 109,
+                                  "startFilePos": 303,
+                                  "endLine": 3,
+                                  "endTokenPos": 109,
+                                  "endFilePos": 305
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 109,
+                                    "startFilePos": 303,
+                                    "endLine": 3,
+                                    "endTokenPos": 109,
+                                    "endFilePos": 305,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 112,
+                                  "startFilePos": 308,
+                                  "endLine": 3,
+                                  "endTokenPos": 112,
+                                  "endFilePos": 311
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 112,
+                                    "startFilePos": 308,
+                                    "endLine": 3,
+                                    "endTokenPos": 112,
+                                    "endFilePos": 311,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 115,
+                                  "startFilePos": 314,
+                                  "endLine": 3,
+                                  "endTokenPos": 151,
+                                  "endFilePos": 388
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 115,
+                                    "startFilePos": 314,
+                                    "endLine": 3,
+                                    "endTokenPos": 151,
+                                    "endFilePos": 388
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 3,
+                                      "startTokenPos": 115,
+                                      "startFilePos": 314,
+                                      "endLine": 3,
+                                      "endTokenPos": 115,
+                                      "endFilePos": 324
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 117,
+                                        "startFilePos": 326,
+                                        "endLine": 3,
+                                        "endTokenPos": 117,
+                                        "endFilePos": 328
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 117,
+                                          "startFilePos": 326,
+                                          "endLine": 3,
+                                          "endTokenPos": 117,
+                                          "endFilePos": 328,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 120,
+                                        "startFilePos": 331,
+                                        "endLine": 3,
+                                        "endTokenPos": 120,
+                                        "endFilePos": 334
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 120,
+                                          "startFilePos": 331,
+                                          "endLine": 3,
+                                          "endTokenPos": 120,
+                                          "endFilePos": 334,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 123,
+                                        "startFilePos": 337,
+                                        "endLine": 3,
+                                        "endTokenPos": 150,
+                                        "endFilePos": 387
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 123,
+                                          "startFilePos": 337,
+                                          "endLine": 3,
+                                          "endTokenPos": 150,
+                                          "endFilePos": 387
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 3,
+                                            "startTokenPos": 123,
+                                            "startFilePos": 337,
+                                            "endLine": 3,
+                                            "endTokenPos": 123,
+                                            "endFilePos": 347
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 125,
+                                              "startFilePos": 349,
+                                              "endLine": 3,
+                                              "endTokenPos": 146,
+                                              "endFilePos": 380
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 125,
+                                                "startFilePos": 349,
+                                                "endLine": 3,
+                                                "endTokenPos": 146,
+                                                "endFilePos": 380
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 3,
+                                                  "startTokenPos": 125,
+                                                  "startFilePos": 349,
+                                                  "endLine": 3,
+                                                  "endTokenPos": 125,
+                                                  "endFilePos": 359
+                                                },
+                                                "name": "array_slice"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 127,
+                                                    "startFilePos": 361,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 135,
+                                                    "endFilePos": 369
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_Array",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 127,
+                                                      "startFilePos": 361,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 135,
+                                                      "endFilePos": 369,
+                                                      "kind": 2
+                                                    },
+                                                    "items": [
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 3,
+                                                          "startTokenPos": 128,
+                                                          "startFilePos": 362,
+                                                          "endLine": 3,
+                                                          "endTokenPos": 128,
+                                                          "endFilePos": 362
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 3,
+                                                            "startTokenPos": 128,
+                                                            "startFilePos": 362,
+                                                            "endLine": 3,
+                                                            "endTokenPos": 128,
+                                                            "endFilePos": 362,
+                                                            "rawValue": "1",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 1
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 3,
+                                                          "startTokenPos": 131,
+                                                          "startFilePos": 365,
+                                                          "endLine": 3,
+                                                          "endTokenPos": 131,
+                                                          "endFilePos": 365
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 3,
+                                                            "startTokenPos": 131,
+                                                            "startFilePos": 365,
+                                                            "endLine": 3,
+                                                            "endTokenPos": 131,
+                                                            "endFilePos": 365,
+                                                            "rawValue": "2",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 2
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      },
+                                                      {
+                                                        "nodeType": "ArrayItem",
+                                                        "attributes": {
+                                                          "startLine": 3,
+                                                          "startTokenPos": 134,
+                                                          "startFilePos": 368,
+                                                          "endLine": 3,
+                                                          "endTokenPos": 134,
+                                                          "endFilePos": 368
+                                                        },
+                                                        "key": null,
+                                                        "value": {
+                                                          "nodeType": "Scalar_Int",
+                                                          "attributes": {
+                                                            "startLine": 3,
+                                                            "startTokenPos": 134,
+                                                            "startFilePos": 368,
+                                                            "endLine": 3,
+                                                            "endTokenPos": 134,
+                                                            "endFilePos": 368,
+                                                            "rawValue": "3",
+                                                            "kind": 10
+                                                          },
+                                                          "value": 3
+                                                        },
+                                                        "byRef": false,
+                                                        "unpack": false
+                                                      }
+                                                    ]
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                },
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 138,
+                                                    "startFilePos": 372,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 138,
+                                                    "endFilePos": 372
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Scalar_Int",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 138,
+                                                      "startFilePos": 372,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 138,
+                                                      "endFilePos": 372,
+                                                      "rawValue": "0",
+                                                      "kind": 10
+                                                    },
+                                                    "value": 0
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                },
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 141,
+                                                    "startFilePos": 375,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 145,
+                                                    "endFilePos": 379
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_BinaryOp_Minus",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 141,
+                                                      "startFilePos": 375,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 145,
+                                                      "endFilePos": 379
+                                                    },
+                                                    "left": {
+                                                      "nodeType": "Scalar_Int",
+                                                      "attributes": {
+                                                        "startLine": 3,
+                                                        "startTokenPos": 141,
+                                                        "startFilePos": 375,
+                                                        "endLine": 3,
+                                                        "endTokenPos": 141,
+                                                        "endFilePos": 375,
+                                                        "rawValue": "2",
+                                                        "kind": 10
+                                                      },
+                                                      "value": 2
+                                                    },
+                                                    "right": {
+                                                      "nodeType": "Scalar_Int",
+                                                      "attributes": {
+                                                        "startLine": 3,
+                                                        "startTokenPos": 145,
+                                                        "startFilePos": 379,
+                                                        "endLine": 3,
+                                                        "endTokenPos": 145,
+                                                        "endFilePos": 379,
+                                                        "rawValue": "0",
+                                                        "kind": 10
+                                                      },
+                                                      "value": 0
+                                                    }
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 149,
+                                              "startFilePos": 383,
+                                              "endLine": 3,
+                                              "endTokenPos": 149,
+                                              "endFilePos": 386
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 149,
+                                                "startFilePos": 383,
+                                                "endLine": 3,
+                                                "endTokenPos": 149,
+                                                "endFilePos": 386,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 158,
+            "startFilePos": 395,
+            "endLine": 3,
+            "endTokenPos": 158,
+            "endFilePos": 401
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 158,
+              "startFilePos": 395,
+              "endLine": 3,
+              "endTokenPos": 158,
+              "endFilePos": 401
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 161,
+        "startFilePos": 404,
+        "endLine": 4,
+        "endTokenPos": 225,
+        "endFilePos": 530
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 164,
+            "startFilePos": 410,
+            "endLine": 4,
+            "endTokenPos": 220,
+            "endFilePos": 519
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 164,
+              "startFilePos": 410,
+              "endLine": 4,
+              "endTokenPos": 180,
+              "endFilePos": 444
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 164,
+                "startFilePos": 410,
+                "endLine": 4,
+                "endTokenPos": 164,
+                "endFilePos": 417
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 166,
+                  "startFilePos": 419,
+                  "endLine": 4,
+                  "endTokenPos": 179,
+                  "endFilePos": 443
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 166,
+                    "startFilePos": 419,
+                    "endLine": 4,
+                    "endTokenPos": 179,
+                    "endFilePos": 443
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 166,
+                      "startFilePos": 419,
+                      "endLine": 4,
+                      "endTokenPos": 166,
+                      "endFilePos": 424
+                    },
+                    "name": "substr"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 168,
+                        "startFilePos": 426,
+                        "endLine": 4,
+                        "endTokenPos": 168,
+                        "endFilePos": 432
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 168,
+                          "startFilePos": 426,
+                          "endLine": 4,
+                          "endTokenPos": 168,
+                          "endFilePos": 432,
+                          "kind": 2,
+                          "rawValue": "\"hello\""
+                        },
+                        "value": "hello"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 171,
+                        "startFilePos": 435,
+                        "endLine": 4,
+                        "endTokenPos": 171,
+                        "endFilePos": 435
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 171,
+                          "startFilePos": 435,
+                          "endLine": 4,
+                          "endTokenPos": 171,
+                          "endFilePos": 435,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 174,
+                        "startFilePos": 438,
+                        "endLine": 4,
+                        "endTokenPos": 178,
+                        "endFilePos": 442
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Minus",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 174,
+                          "startFilePos": 438,
+                          "endLine": 4,
+                          "endTokenPos": 178,
+                          "endFilePos": 442
+                        },
+                        "left": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 174,
+                            "startFilePos": 438,
+                            "endLine": 4,
+                            "endTokenPos": 174,
+                            "endFilePos": 438,
+                            "rawValue": "4",
+                            "kind": 10
+                          },
+                          "value": 4
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 178,
+                            "startFilePos": 442,
+                            "endLine": 4,
+                            "endTokenPos": 178,
+                            "endFilePos": 442,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 184,
+              "startFilePos": 448,
+              "endLine": 4,
+              "endTokenPos": 203,
+              "endFilePos": 491
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 184,
+                "startFilePos": 448,
+                "endLine": 4,
+                "endTokenPos": 184,
+                "endFilePos": 458
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 186,
+                  "startFilePos": 460,
+                  "endLine": 4,
+                  "endTokenPos": 199,
+                  "endFilePos": 484
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 186,
+                    "startFilePos": 460,
+                    "endLine": 4,
+                    "endTokenPos": 199,
+                    "endFilePos": 484
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 186,
+                      "startFilePos": 460,
+                      "endLine": 4,
+                      "endTokenPos": 186,
+                      "endFilePos": 465
+                    },
+                    "name": "substr"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 188,
+                        "startFilePos": 467,
+                        "endLine": 4,
+                        "endTokenPos": 188,
+                        "endFilePos": 473
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 188,
+                          "startFilePos": 467,
+                          "endLine": 4,
+                          "endTokenPos": 188,
+                          "endFilePos": 473,
+                          "kind": 2,
+                          "rawValue": "\"hello\""
+                        },
+                        "value": "hello"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 191,
+                        "startFilePos": 476,
+                        "endLine": 4,
+                        "endTokenPos": 191,
+                        "endFilePos": 476
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 191,
+                          "startFilePos": 476,
+                          "endLine": 4,
+                          "endTokenPos": 191,
+                          "endFilePos": 476,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 194,
+                        "startFilePos": 479,
+                        "endLine": 4,
+                        "endTokenPos": 198,
+                        "endFilePos": 483
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Minus",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 194,
+                          "startFilePos": 479,
+                          "endLine": 4,
+                          "endTokenPos": 198,
+                          "endFilePos": 483
+                        },
+                        "left": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 194,
+                            "startFilePos": 479,
+                            "endLine": 4,
+                            "endTokenPos": 194,
+                            "endFilePos": 479,
+                            "rawValue": "4",
+                            "kind": 10
+                          },
+                          "value": 4
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 198,
+                            "startFilePos": 483,
+                            "endLine": 4,
+                            "endTokenPos": 198,
+                            "endFilePos": 483,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 202,
+                  "startFilePos": 487,
+                  "endLine": 4,
+                  "endTokenPos": 202,
+                  "endFilePos": 490
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 202,
+                    "startFilePos": 487,
+                    "endLine": 4,
+                    "endTokenPos": 202,
+                    "endFilePos": 490,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 207,
+              "startFilePos": 495,
+              "endLine": 4,
+              "endTokenPos": 220,
+              "endFilePos": 519
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 207,
+                "startFilePos": 495,
+                "endLine": 4,
+                "endTokenPos": 207,
+                "endFilePos": 500
+              },
+              "name": "substr"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 209,
+                  "startFilePos": 502,
+                  "endLine": 4,
+                  "endTokenPos": 209,
+                  "endFilePos": 508
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 209,
+                    "startFilePos": 502,
+                    "endLine": 4,
+                    "endTokenPos": 209,
+                    "endFilePos": 508,
+                    "kind": 2,
+                    "rawValue": "\"hello\""
+                  },
+                  "value": "hello"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 212,
+                  "startFilePos": 511,
+                  "endLine": 4,
+                  "endTokenPos": 212,
+                  "endFilePos": 511
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 212,
+                    "startFilePos": 511,
+                    "endLine": 4,
+                    "endTokenPos": 212,
+                    "endFilePos": 511,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 215,
+                  "startFilePos": 514,
+                  "endLine": 4,
+                  "endTokenPos": 219,
+                  "endFilePos": 518
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Minus",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 215,
+                    "startFilePos": 514,
+                    "endLine": 4,
+                    "endTokenPos": 219,
+                    "endFilePos": 518
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 215,
+                      "startFilePos": 514,
+                      "endLine": 4,
+                      "endTokenPos": 215,
+                      "endFilePos": 514,
+                      "rawValue": "4",
+                      "kind": 10
+                    },
+                    "value": 4
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 219,
+                      "startFilePos": 518,
+                      "endLine": 4,
+                      "endTokenPos": 219,
+                      "endFilePos": 518,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 224,
+            "startFilePos": 523,
+            "endLine": 4,
+            "endTokenPos": 224,
+            "endFilePos": 529
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 224,
+              "startFilePos": 523,
+              "endLine": 4,
+              "endTokenPos": 224,
+              "endFilePos": 529
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/sort_stable.php.json
+++ b/tests/json-ast/x/php/sort_stable.php.json
@@ -1,0 +1,1141 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 53,
+        "endFilePos": 87
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 52,
+          "endFilePos": 86
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 11
+          },
+          "name": "items"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 15,
+            "endLine": 2,
+            "endTokenPos": 52,
+            "endFilePos": 86,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 16,
+                "endLine": 2,
+                "endTokenPos": 19,
+                "endFilePos": 37
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 16,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 37,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 17,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 24
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 17,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 19,
+                        "kind": 2,
+                        "rawValue": "\"n\""
+                      },
+                      "value": "n"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 24,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 24,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 27,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 36
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 27,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 29,
+                        "kind": 2,
+                        "rawValue": "\"v\""
+                      },
+                      "value": "v"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 34,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 36,
+                        "kind": 2,
+                        "rawValue": "\"a\""
+                      },
+                      "value": "a"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 40,
+                "endLine": 2,
+                "endTokenPos": 35,
+                "endFilePos": 61
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 40,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 61,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 23,
+                      "startFilePos": 41,
+                      "endLine": 2,
+                      "endTokenPos": 27,
+                      "endFilePos": 48
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 23,
+                        "startFilePos": 41,
+                        "endLine": 2,
+                        "endTokenPos": 23,
+                        "endFilePos": 43,
+                        "kind": 2,
+                        "rawValue": "\"n\""
+                      },
+                      "value": "n"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 27,
+                        "startFilePos": 48,
+                        "endLine": 2,
+                        "endTokenPos": 27,
+                        "endFilePos": 48,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 51,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 60
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 51,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 53,
+                        "kind": 2,
+                        "rawValue": "\"v\""
+                      },
+                      "value": "v"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 58,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 60,
+                        "kind": 2,
+                        "rawValue": "\"b\""
+                      },
+                      "value": "b"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 38,
+                "startFilePos": 64,
+                "endLine": 2,
+                "endTokenPos": 51,
+                "endFilePos": 85
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 64,
+                  "endLine": 2,
+                  "endTokenPos": 51,
+                  "endFilePos": 85,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 39,
+                      "startFilePos": 65,
+                      "endLine": 2,
+                      "endTokenPos": 43,
+                      "endFilePos": 72
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 39,
+                        "startFilePos": 65,
+                        "endLine": 2,
+                        "endTokenPos": 39,
+                        "endFilePos": 67,
+                        "kind": 2,
+                        "rawValue": "\"n\""
+                      },
+                      "value": "n"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 43,
+                        "startFilePos": 72,
+                        "endLine": 2,
+                        "endTokenPos": 43,
+                        "endFilePos": 72,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 46,
+                      "startFilePos": 75,
+                      "endLine": 2,
+                      "endTokenPos": 50,
+                      "endFilePos": 84
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 75,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 77,
+                        "kind": 2,
+                        "rawValue": "\"v\""
+                      },
+                      "value": "v"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 50,
+                        "startFilePos": 82,
+                        "endLine": 2,
+                        "endTokenPos": 50,
+                        "endFilePos": 84,
+                        "kind": 2,
+                        "rawValue": "\"c\""
+                      },
+                      "value": "c"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 55,
+        "startFilePos": 89,
+        "endLine": 3,
+        "endTokenPos": 61,
+        "endFilePos": 101
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 55,
+          "startFilePos": 89,
+          "endLine": 3,
+          "endTokenPos": 60,
+          "endFilePos": 100
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 55,
+            "startFilePos": 89,
+            "endLine": 3,
+            "endTokenPos": 55,
+            "endFilePos": 95
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 59,
+            "startFilePos": 99,
+            "endLine": 3,
+            "endTokenPos": 60,
+            "endFilePos": 100,
+            "kind": 2
+          },
+          "items": []
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 63,
+        "startFilePos": 103,
+        "endLine": 6,
+        "endTokenPos": 87,
+        "endFilePos": 151
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 66,
+          "startFilePos": 112,
+          "endLine": 4,
+          "endTokenPos": 66,
+          "endFilePos": 117
+        },
+        "name": "items"
+      },
+      "keyVar": null,
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 4,
+          "startTokenPos": 70,
+          "startFilePos": 122,
+          "endLine": 4,
+          "endTokenPos": 70,
+          "endFilePos": 123
+        },
+        "name": "i"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 75,
+            "startFilePos": 130,
+            "endLine": 5,
+            "endTokenPos": 85,
+            "endFilePos": 149
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 75,
+              "startFilePos": 130,
+              "endLine": 5,
+              "endTokenPos": 84,
+              "endFilePos": 148
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 75,
+                "startFilePos": 130,
+                "endLine": 5,
+                "endTokenPos": 77,
+                "endFilePos": 138
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 75,
+                  "startFilePos": 130,
+                  "endLine": 5,
+                  "endTokenPos": 75,
+                  "endFilePos": 136
+                },
+                "name": "result"
+              },
+              "dim": null
+            },
+            "expr": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 81,
+                "startFilePos": 142,
+                "endLine": 5,
+                "endTokenPos": 84,
+                "endFilePos": 148
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 81,
+                  "startFilePos": 142,
+                  "endLine": 5,
+                  "endTokenPos": 81,
+                  "endFilePos": 143
+                },
+                "name": "i"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 83,
+                  "startFilePos": 145,
+                  "endLine": 5,
+                  "endTokenPos": 83,
+                  "endFilePos": 147,
+                  "kind": 2,
+                  "rawValue": "\"v\""
+                },
+                "value": "v"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 89,
+        "startFilePos": 154,
+        "endLine": 8,
+        "endTokenPos": 146,
+        "endFilePos": 326
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 91,
+            "startFilePos": 159,
+            "endLine": 8,
+            "endTokenPos": 142,
+            "endFilePos": 316
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 91,
+              "startFilePos": 159,
+              "endLine": 8,
+              "endTokenPos": 91,
+              "endFilePos": 169
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 93,
+                "startFilePos": 171,
+                "endLine": 8,
+                "endTokenPos": 93,
+                "endFilePos": 177
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 93,
+                  "startFilePos": 171,
+                  "endLine": 8,
+                  "endTokenPos": 93,
+                  "endFilePos": 177,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 96,
+                "startFilePos": 180,
+                "endLine": 8,
+                "endTokenPos": 96,
+                "endFilePos": 186
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 96,
+                  "startFilePos": 180,
+                  "endLine": 8,
+                  "endTokenPos": 96,
+                  "endFilePos": 186,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 99,
+                "startFilePos": 189,
+                "endLine": 8,
+                "endTokenPos": 141,
+                "endFilePos": 315
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 99,
+                  "startFilePos": 189,
+                  "endLine": 8,
+                  "endTokenPos": 141,
+                  "endFilePos": 315
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 99,
+                    "startFilePos": 189,
+                    "endLine": 8,
+                    "endTokenPos": 99,
+                    "endFilePos": 199
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 101,
+                      "startFilePos": 201,
+                      "endLine": 8,
+                      "endTokenPos": 101,
+                      "endFilePos": 206
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 101,
+                        "startFilePos": 201,
+                        "endLine": 8,
+                        "endTokenPos": 101,
+                        "endFilePos": 206,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 104,
+                      "startFilePos": 209,
+                      "endLine": 8,
+                      "endTokenPos": 104,
+                      "endFilePos": 214
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 104,
+                        "startFilePos": 209,
+                        "endLine": 8,
+                        "endTokenPos": 104,
+                        "endFilePos": 214,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 107,
+                      "startFilePos": 217,
+                      "endLine": 8,
+                      "endTokenPos": 140,
+                      "endFilePos": 314
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 107,
+                        "startFilePos": 217,
+                        "endLine": 8,
+                        "endTokenPos": 140,
+                        "endFilePos": 314
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 107,
+                          "startFilePos": 217,
+                          "endLine": 8,
+                          "endTokenPos": 107,
+                          "endFilePos": 227
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 109,
+                            "startFilePos": 229,
+                            "endLine": 8,
+                            "endTokenPos": 109,
+                            "endFilePos": 232
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 109,
+                              "startFilePos": 229,
+                              "endLine": 8,
+                              "endTokenPos": 109,
+                              "endFilePos": 232,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 112,
+                            "startFilePos": 235,
+                            "endLine": 8,
+                            "endTokenPos": 112,
+                            "endFilePos": 237
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 112,
+                              "startFilePos": 235,
+                              "endLine": 8,
+                              "endTokenPos": 112,
+                              "endFilePos": 237,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 8,
+                            "startTokenPos": 115,
+                            "startFilePos": 240,
+                            "endLine": 8,
+                            "endTokenPos": 139,
+                            "endFilePos": 313
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 8,
+                              "startTokenPos": 115,
+                              "startFilePos": 240,
+                              "endLine": 8,
+                              "endTokenPos": 139,
+                              "endFilePos": 313
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 8,
+                                "startTokenPos": 115,
+                                "startFilePos": 240,
+                                "endLine": 8,
+                                "endTokenPos": 115,
+                                "endFilePos": 250
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 8,
+                                  "startTokenPos": 117,
+                                  "startFilePos": 252,
+                                  "endLine": 8,
+                                  "endTokenPos": 117,
+                                  "endFilePos": 254
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 8,
+                                    "startTokenPos": 117,
+                                    "startFilePos": 252,
+                                    "endLine": 8,
+                                    "endTokenPos": 117,
+                                    "endFilePos": 254,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 8,
+                                  "startTokenPos": 120,
+                                  "startFilePos": 257,
+                                  "endLine": 8,
+                                  "endTokenPos": 120,
+                                  "endFilePos": 260
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 8,
+                                    "startTokenPos": 120,
+                                    "startFilePos": 257,
+                                    "endLine": 8,
+                                    "endTokenPos": 120,
+                                    "endFilePos": 260,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 8,
+                                  "startTokenPos": 123,
+                                  "startFilePos": 263,
+                                  "endLine": 8,
+                                  "endTokenPos": 138,
+                                  "endFilePos": 312
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 8,
+                                    "startTokenPos": 123,
+                                    "startFilePos": 263,
+                                    "endLine": 8,
+                                    "endTokenPos": 138,
+                                    "endFilePos": 312
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 8,
+                                      "startTokenPos": 123,
+                                      "startFilePos": 263,
+                                      "endLine": 8,
+                                      "endTokenPos": 123,
+                                      "endFilePos": 273
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 8,
+                                        "startTokenPos": 125,
+                                        "startFilePos": 275,
+                                        "endLine": 8,
+                                        "endTokenPos": 125,
+                                        "endFilePos": 277
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 8,
+                                          "startTokenPos": 125,
+                                          "startFilePos": 275,
+                                          "endLine": 8,
+                                          "endTokenPos": 125,
+                                          "endFilePos": 277,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 8,
+                                        "startTokenPos": 128,
+                                        "startFilePos": 280,
+                                        "endLine": 8,
+                                        "endTokenPos": 128,
+                                        "endFilePos": 283
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 8,
+                                          "startTokenPos": 128,
+                                          "startFilePos": 280,
+                                          "endLine": 8,
+                                          "endTokenPos": 128,
+                                          "endFilePos": 283,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 8,
+                                        "startTokenPos": 131,
+                                        "startFilePos": 286,
+                                        "endLine": 8,
+                                        "endTokenPos": 137,
+                                        "endFilePos": 311
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 8,
+                                          "startTokenPos": 131,
+                                          "startFilePos": 286,
+                                          "endLine": 8,
+                                          "endTokenPos": 137,
+                                          "endFilePos": 311
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 8,
+                                            "startTokenPos": 131,
+                                            "startFilePos": 286,
+                                            "endLine": 8,
+                                            "endTokenPos": 131,
+                                            "endFilePos": 296
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 8,
+                                              "startTokenPos": 133,
+                                              "startFilePos": 298,
+                                              "endLine": 8,
+                                              "endTokenPos": 133,
+                                              "endFilePos": 304
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_Variable",
+                                              "attributes": {
+                                                "startLine": 8,
+                                                "startTokenPos": 133,
+                                                "startFilePos": 298,
+                                                "endLine": 8,
+                                                "endTokenPos": 133,
+                                                "endFilePos": 304
+                                              },
+                                              "name": "result"
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 8,
+                                              "startTokenPos": 136,
+                                              "startFilePos": 307,
+                                              "endLine": 8,
+                                              "endTokenPos": 136,
+                                              "endFilePos": 310
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 8,
+                                                "startTokenPos": 136,
+                                                "startFilePos": 307,
+                                                "endLine": 8,
+                                                "endTokenPos": 136,
+                                                "endFilePos": 310,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 145,
+            "startFilePos": 319,
+            "endLine": 8,
+            "endTokenPos": 145,
+            "endFilePos": 325
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 145,
+              "startFilePos": 319,
+              "endLine": 8,
+              "endTokenPos": 145,
+              "endFilePos": 325
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/str_builtin.php.json
+++ b/tests/json-ast/x/php/str_builtin.php.json
@@ -1,0 +1,316 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 35,
+        "endFilePos": 90
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 30,
+            "endFilePos": 79
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 10,
+              "endFilePos": 32
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 9,
+                  "endFilePos": 31
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 9,
+                    "endFilePos": 31
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 26
+                    },
+                    "name": "strval"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 8,
+                        "endFilePos": 30
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 28,
+                          "endLine": 2,
+                          "endTokenPos": 8,
+                          "endFilePos": 30,
+                          "rawValue": "123",
+                          "kind": 10
+                        },
+                        "value": 123
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 14,
+              "startFilePos": 36,
+              "endLine": 2,
+              "endTokenPos": 23,
+              "endFilePos": 65
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 14,
+                "startFilePos": 36,
+                "endLine": 2,
+                "endTokenPos": 14,
+                "endFilePos": 46
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 16,
+                  "startFilePos": 48,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 58
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 16,
+                    "startFilePos": 48,
+                    "endLine": 2,
+                    "endTokenPos": 19,
+                    "endFilePos": 58
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 16,
+                      "startFilePos": 48,
+                      "endLine": 2,
+                      "endTokenPos": 16,
+                      "endFilePos": 53
+                    },
+                    "name": "strval"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 55,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 57
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 18,
+                          "startFilePos": 55,
+                          "endLine": 2,
+                          "endTokenPos": 18,
+                          "endFilePos": 57,
+                          "rawValue": "123",
+                          "kind": 10
+                        },
+                        "value": 123
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 22,
+                  "startFilePos": 61,
+                  "endLine": 2,
+                  "endTokenPos": 22,
+                  "endFilePos": 64
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 22,
+                    "startFilePos": 61,
+                    "endLine": 2,
+                    "endTokenPos": 22,
+                    "endFilePos": 64,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 27,
+              "startFilePos": 69,
+              "endLine": 2,
+              "endTokenPos": 30,
+              "endFilePos": 79
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 27,
+                "startFilePos": 69,
+                "endLine": 2,
+                "endTokenPos": 27,
+                "endFilePos": 74
+              },
+              "name": "strval"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 76,
+                  "endLine": 2,
+                  "endTokenPos": 29,
+                  "endFilePos": 78
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 29,
+                    "startFilePos": 76,
+                    "endLine": 2,
+                    "endTokenPos": 29,
+                    "endFilePos": 78,
+                    "rawValue": "123",
+                    "kind": 10
+                  },
+                  "value": 123
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 34,
+            "startFilePos": 83,
+            "endLine": 2,
+            "endTokenPos": 34,
+            "endFilePos": 89
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 34,
+              "startFilePos": 83,
+              "endLine": 2,
+              "endTokenPos": 34,
+              "endFilePos": 89
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/string_compare.php.json
+++ b/tests/json-ast/x/php/string_compare.php.json
@@ -1,0 +1,460 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 21,
+        "endFilePos": 50
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 16,
+            "endFilePos": 39
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Smaller",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 20
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 14,
+                "kind": 2,
+                "rawValue": "\"a\""
+              },
+              "value": "a"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 8,
+                "startFilePos": 18,
+                "endLine": 2,
+                "endTokenPos": 8,
+                "endFilePos": 20,
+                "kind": 2,
+                "rawValue": "\"b\""
+              },
+              "value": "b"
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 12,
+              "startFilePos": 24,
+              "endLine": 2,
+              "endTokenPos": 12,
+              "endFilePos": 29,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 16,
+              "startFilePos": 33,
+              "endLine": 2,
+              "endTokenPos": 16,
+              "endFilePos": 39,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 20,
+            "startFilePos": 43,
+            "endLine": 2,
+            "endTokenPos": 20,
+            "endFilePos": 49
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 20,
+              "startFilePos": 43,
+              "endLine": 2,
+              "endTokenPos": 20,
+              "endFilePos": 49
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 23,
+        "startFilePos": 52,
+        "endLine": 3,
+        "endTokenPos": 43,
+        "endFilePos": 97
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 26,
+            "startFilePos": 58,
+            "endLine": 3,
+            "endTokenPos": 38,
+            "endFilePos": 86
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_SmallerOrEqual",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 26,
+              "startFilePos": 58,
+              "endLine": 3,
+              "endTokenPos": 30,
+              "endFilePos": 67
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 26,
+                "startFilePos": 58,
+                "endLine": 3,
+                "endTokenPos": 26,
+                "endFilePos": 60,
+                "kind": 2,
+                "rawValue": "\"a\""
+              },
+              "value": "a"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 30,
+                "startFilePos": 65,
+                "endLine": 3,
+                "endTokenPos": 30,
+                "endFilePos": 67,
+                "kind": 2,
+                "rawValue": "\"a\""
+              },
+              "value": "a"
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 34,
+              "startFilePos": 71,
+              "endLine": 3,
+              "endTokenPos": 34,
+              "endFilePos": 76,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 38,
+              "startFilePos": 80,
+              "endLine": 3,
+              "endTokenPos": 38,
+              "endFilePos": 86,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 42,
+            "startFilePos": 90,
+            "endLine": 3,
+            "endTokenPos": 42,
+            "endFilePos": 96
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 42,
+              "startFilePos": 90,
+              "endLine": 3,
+              "endTokenPos": 42,
+              "endFilePos": 96
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 45,
+        "startFilePos": 99,
+        "endLine": 4,
+        "endTokenPos": 65,
+        "endFilePos": 143
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 48,
+            "startFilePos": 105,
+            "endLine": 4,
+            "endTokenPos": 60,
+            "endFilePos": 132
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Greater",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 48,
+              "startFilePos": 105,
+              "endLine": 4,
+              "endTokenPos": 52,
+              "endFilePos": 113
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 48,
+                "startFilePos": 105,
+                "endLine": 4,
+                "endTokenPos": 48,
+                "endFilePos": 107,
+                "kind": 2,
+                "rawValue": "\"b\""
+              },
+              "value": "b"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 52,
+                "startFilePos": 111,
+                "endLine": 4,
+                "endTokenPos": 52,
+                "endFilePos": 113,
+                "kind": 2,
+                "rawValue": "\"a\""
+              },
+              "value": "a"
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 56,
+              "startFilePos": 117,
+              "endLine": 4,
+              "endTokenPos": 56,
+              "endFilePos": 122,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 60,
+              "startFilePos": 126,
+              "endLine": 4,
+              "endTokenPos": 60,
+              "endFilePos": 132,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 64,
+            "startFilePos": 136,
+            "endLine": 4,
+            "endTokenPos": 64,
+            "endFilePos": 142
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 64,
+              "startFilePos": 136,
+              "endLine": 4,
+              "endTokenPos": 64,
+              "endFilePos": 142
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 67,
+        "startFilePos": 145,
+        "endLine": 5,
+        "endTokenPos": 87,
+        "endFilePos": 190
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 70,
+            "startFilePos": 151,
+            "endLine": 5,
+            "endTokenPos": 82,
+            "endFilePos": 179
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 70,
+              "startFilePos": 151,
+              "endLine": 5,
+              "endTokenPos": 74,
+              "endFilePos": 160
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 70,
+                "startFilePos": 151,
+                "endLine": 5,
+                "endTokenPos": 70,
+                "endFilePos": 153,
+                "kind": 2,
+                "rawValue": "\"b\""
+              },
+              "value": "b"
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 74,
+                "startFilePos": 158,
+                "endLine": 5,
+                "endTokenPos": 74,
+                "endFilePos": 160,
+                "kind": 2,
+                "rawValue": "\"b\""
+              },
+              "value": "b"
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 78,
+              "startFilePos": 164,
+              "endLine": 5,
+              "endTokenPos": 78,
+              "endFilePos": 169,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 82,
+              "startFilePos": 173,
+              "endLine": 5,
+              "endTokenPos": 82,
+              "endFilePos": 179,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 86,
+            "startFilePos": 183,
+            "endLine": 5,
+            "endTokenPos": 86,
+            "endFilePos": 189
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 86,
+              "startFilePos": 183,
+              "endLine": 5,
+              "endTokenPos": 86,
+              "endFilePos": 189
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/string_concat.php.json
+++ b/tests/json-ast/x/php/string_concat.php.json
@@ -1,0 +1,274 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 38,
+        "endFilePos": 111
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 33,
+            "endFilePos": 100
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 11,
+              "endFilePos": 39
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 38
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 10,
+                    "endFilePos": 38
+                  },
+                  "left": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 28,
+                      "kind": 2,
+                      "rawValue": "\"hello \""
+                    },
+                    "value": "hello "
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 10,
+                      "startFilePos": 32,
+                      "endLine": 2,
+                      "endTokenPos": 10,
+                      "endFilePos": 38,
+                      "kind": 2,
+                      "rawValue": "\"world\""
+                    },
+                    "value": "world"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 15,
+              "startFilePos": 43,
+              "endLine": 2,
+              "endTokenPos": 25,
+              "endFilePos": 79
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 15,
+                "startFilePos": 43,
+                "endLine": 2,
+                "endTokenPos": 15,
+                "endFilePos": 53
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 55,
+                  "endLine": 2,
+                  "endTokenPos": 21,
+                  "endFilePos": 72
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Concat",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 17,
+                    "startFilePos": 55,
+                    "endLine": 2,
+                    "endTokenPos": 21,
+                    "endFilePos": 72
+                  },
+                  "left": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 17,
+                      "startFilePos": 55,
+                      "endLine": 2,
+                      "endTokenPos": 17,
+                      "endFilePos": 62,
+                      "kind": 2,
+                      "rawValue": "\"hello \""
+                    },
+                    "value": "hello "
+                  },
+                  "right": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 66,
+                      "endLine": 2,
+                      "endTokenPos": 21,
+                      "endFilePos": 72,
+                      "kind": 2,
+                      "rawValue": "\"world\""
+                    },
+                    "value": "world"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 75,
+                  "endLine": 2,
+                  "endTokenPos": 24,
+                  "endFilePos": 78
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 24,
+                    "startFilePos": 75,
+                    "endLine": 2,
+                    "endTokenPos": 24,
+                    "endFilePos": 78,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Concat",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 29,
+              "startFilePos": 83,
+              "endLine": 2,
+              "endTokenPos": 33,
+              "endFilePos": 100
+            },
+            "left": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 29,
+                "startFilePos": 83,
+                "endLine": 2,
+                "endTokenPos": 29,
+                "endFilePos": 90,
+                "kind": 2,
+                "rawValue": "\"hello \""
+              },
+              "value": "hello "
+            },
+            "right": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 33,
+                "startFilePos": 94,
+                "endLine": 2,
+                "endTokenPos": 33,
+                "endFilePos": 100,
+                "kind": 2,
+                "rawValue": "\"world\""
+              },
+              "value": "world"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 37,
+            "startFilePos": 104,
+            "endLine": 2,
+            "endTokenPos": 37,
+            "endFilePos": 110
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 37,
+              "startFilePos": 104,
+              "endLine": 2,
+              "endTokenPos": 37,
+              "endFilePos": 110
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/string_contains.php.json
+++ b/tests/json-ast/x/php/string_contains.php.json
@@ -1,0 +1,360 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 18
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 17
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "s"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 17,
+            "kind": 2,
+            "rawValue": "\"catch\""
+          },
+          "value": "catch"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 20,
+        "endLine": 3,
+        "endTokenPos": 30,
+        "endFilePos": 78
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 26,
+            "endLine": 3,
+            "endTokenPos": 25,
+            "endFilePos": 67
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 11,
+              "startFilePos": 26,
+              "endLine": 3,
+              "endTokenPos": 17,
+              "endFilePos": 48
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 11,
+                "startFilePos": 26,
+                "endLine": 3,
+                "endTokenPos": 11,
+                "endFilePos": 37
+              },
+              "name": "str_contains"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 13,
+                  "startFilePos": 39,
+                  "endLine": 3,
+                  "endTokenPos": 13,
+                  "endFilePos": 40
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 13,
+                    "startFilePos": 39,
+                    "endLine": 3,
+                    "endTokenPos": 13,
+                    "endFilePos": 40
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 16,
+                  "startFilePos": 43,
+                  "endLine": 3,
+                  "endTokenPos": 16,
+                  "endFilePos": 47
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 16,
+                    "startFilePos": 43,
+                    "endLine": 3,
+                    "endTokenPos": 16,
+                    "endFilePos": 47,
+                    "kind": 2,
+                    "rawValue": "\"cat\""
+                  },
+                  "value": "cat"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 21,
+              "startFilePos": 52,
+              "endLine": 3,
+              "endTokenPos": 21,
+              "endFilePos": 57,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 25,
+              "startFilePos": 61,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 67,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 29,
+            "startFilePos": 71,
+            "endLine": 3,
+            "endTokenPos": 29,
+            "endFilePos": 77
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 29,
+              "startFilePos": 71,
+              "endLine": 3,
+              "endTokenPos": 29,
+              "endFilePos": 77
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 32,
+        "startFilePos": 80,
+        "endLine": 4,
+        "endTokenPos": 54,
+        "endFilePos": 138
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 35,
+            "startFilePos": 86,
+            "endLine": 4,
+            "endTokenPos": 49,
+            "endFilePos": 127
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 35,
+              "startFilePos": 86,
+              "endLine": 4,
+              "endTokenPos": 41,
+              "endFilePos": 108
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 35,
+                "startFilePos": 86,
+                "endLine": 4,
+                "endTokenPos": 35,
+                "endFilePos": 97
+              },
+              "name": "str_contains"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 37,
+                  "startFilePos": 99,
+                  "endLine": 4,
+                  "endTokenPos": 37,
+                  "endFilePos": 100
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 37,
+                    "startFilePos": 99,
+                    "endLine": 4,
+                    "endTokenPos": 37,
+                    "endFilePos": 100
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 40,
+                  "startFilePos": 103,
+                  "endLine": 4,
+                  "endTokenPos": 40,
+                  "endFilePos": 107
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 40,
+                    "startFilePos": 103,
+                    "endLine": 4,
+                    "endTokenPos": 40,
+                    "endFilePos": 107,
+                    "kind": 2,
+                    "rawValue": "\"dog\""
+                  },
+                  "value": "dog"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 45,
+              "startFilePos": 112,
+              "endLine": 4,
+              "endTokenPos": 45,
+              "endFilePos": 117,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 49,
+              "startFilePos": 121,
+              "endLine": 4,
+              "endTokenPos": 49,
+              "endFilePos": 127,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 53,
+            "startFilePos": 131,
+            "endLine": 4,
+            "endTokenPos": 53,
+            "endFilePos": 137
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 53,
+              "startFilePos": 131,
+              "endLine": 4,
+              "endTokenPos": 53,
+              "endFilePos": 137
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/string_in_operator.php.json
+++ b/tests/json-ast/x/php/string_in_operator.php.json
@@ -1,0 +1,360 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 18
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 17
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "s"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 17,
+            "kind": 2,
+            "rawValue": "\"catch\""
+          },
+          "value": "catch"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 20,
+        "endLine": 3,
+        "endTokenPos": 30,
+        "endFilePos": 78
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 26,
+            "endLine": 3,
+            "endTokenPos": 25,
+            "endFilePos": 67
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 11,
+              "startFilePos": 26,
+              "endLine": 3,
+              "endTokenPos": 17,
+              "endFilePos": 48
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 11,
+                "startFilePos": 26,
+                "endLine": 3,
+                "endTokenPos": 11,
+                "endFilePos": 37
+              },
+              "name": "str_contains"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 13,
+                  "startFilePos": 39,
+                  "endLine": 3,
+                  "endTokenPos": 13,
+                  "endFilePos": 40
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 13,
+                    "startFilePos": 39,
+                    "endLine": 3,
+                    "endTokenPos": 13,
+                    "endFilePos": 40
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 16,
+                  "startFilePos": 43,
+                  "endLine": 3,
+                  "endTokenPos": 16,
+                  "endFilePos": 47
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 16,
+                    "startFilePos": 43,
+                    "endLine": 3,
+                    "endTokenPos": 16,
+                    "endFilePos": 47,
+                    "kind": 2,
+                    "rawValue": "\"cat\""
+                  },
+                  "value": "cat"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 21,
+              "startFilePos": 52,
+              "endLine": 3,
+              "endTokenPos": 21,
+              "endFilePos": 57,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 25,
+              "startFilePos": 61,
+              "endLine": 3,
+              "endTokenPos": 25,
+              "endFilePos": 67,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 29,
+            "startFilePos": 71,
+            "endLine": 3,
+            "endTokenPos": 29,
+            "endFilePos": 77
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 29,
+              "startFilePos": 71,
+              "endLine": 3,
+              "endTokenPos": 29,
+              "endFilePos": 77
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 32,
+        "startFilePos": 80,
+        "endLine": 4,
+        "endTokenPos": 54,
+        "endFilePos": 138
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 35,
+            "startFilePos": 86,
+            "endLine": 4,
+            "endTokenPos": 49,
+            "endFilePos": 127
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 35,
+              "startFilePos": 86,
+              "endLine": 4,
+              "endTokenPos": 41,
+              "endFilePos": 108
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 35,
+                "startFilePos": 86,
+                "endLine": 4,
+                "endTokenPos": 35,
+                "endFilePos": 97
+              },
+              "name": "str_contains"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 37,
+                  "startFilePos": 99,
+                  "endLine": 4,
+                  "endTokenPos": 37,
+                  "endFilePos": 100
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 37,
+                    "startFilePos": 99,
+                    "endLine": 4,
+                    "endTokenPos": 37,
+                    "endFilePos": 100
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 40,
+                  "startFilePos": 103,
+                  "endLine": 4,
+                  "endTokenPos": 40,
+                  "endFilePos": 107
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 40,
+                    "startFilePos": 103,
+                    "endLine": 4,
+                    "endTokenPos": 40,
+                    "endFilePos": 107,
+                    "kind": 2,
+                    "rawValue": "\"dog\""
+                  },
+                  "value": "dog"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 45,
+              "startFilePos": 112,
+              "endLine": 4,
+              "endTokenPos": 45,
+              "endFilePos": 117,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 49,
+              "startFilePos": 121,
+              "endLine": 4,
+              "endTokenPos": 49,
+              "endFilePos": 127,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 53,
+            "startFilePos": 131,
+            "endLine": 4,
+            "endTokenPos": 53,
+            "endFilePos": 137
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 53,
+              "startFilePos": 131,
+              "endLine": 4,
+              "endTokenPos": 53,
+              "endFilePos": 137
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/string_index.php.json
+++ b/tests/json-ast/x/php/string_index.php.json
@@ -1,0 +1,676 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 18
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 17
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "s"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 17,
+            "kind": 2,
+            "rawValue": "\"mochi\""
+          },
+          "value": "mochi"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 20,
+        "endLine": 3,
+        "endTokenPos": 84,
+        "endFilePos": 143
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 26,
+            "endLine": 3,
+            "endTokenPos": 79,
+            "endFilePos": 132
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 11,
+              "startFilePos": 26,
+              "endLine": 3,
+              "endTokenPos": 31,
+              "endFilePos": 59
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 11,
+                "startFilePos": 26,
+                "endLine": 3,
+                "endTokenPos": 11,
+                "endFilePos": 33
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 13,
+                  "startFilePos": 35,
+                  "endLine": 3,
+                  "endTokenPos": 30,
+                  "endFilePos": 58
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 13,
+                    "startFilePos": 35,
+                    "endLine": 3,
+                    "endTokenPos": 30,
+                    "endFilePos": 58
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 13,
+                      "startFilePos": 35,
+                      "endLine": 3,
+                      "endTokenPos": 13,
+                      "endFilePos": 40
+                    },
+                    "name": "substr"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 15,
+                        "startFilePos": 42,
+                        "endLine": 3,
+                        "endTokenPos": 15,
+                        "endFilePos": 43
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 15,
+                          "startFilePos": 42,
+                          "endLine": 3,
+                          "endTokenPos": 15,
+                          "endFilePos": 43
+                        },
+                        "name": "s"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 18,
+                        "startFilePos": 46,
+                        "endLine": 3,
+                        "endTokenPos": 18,
+                        "endFilePos": 46
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 18,
+                          "startFilePos": 46,
+                          "endLine": 3,
+                          "endTokenPos": 18,
+                          "endFilePos": 46,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 21,
+                        "startFilePos": 49,
+                        "endLine": 3,
+                        "endTokenPos": 29,
+                        "endFilePos": 57
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Minus",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 21,
+                          "startFilePos": 49,
+                          "endLine": 3,
+                          "endTokenPos": 29,
+                          "endFilePos": 57
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Plus",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 21,
+                            "startFilePos": 49,
+                            "endLine": 3,
+                            "endTokenPos": 25,
+                            "endFilePos": 53
+                          },
+                          "left": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 21,
+                              "startFilePos": 49,
+                              "endLine": 3,
+                              "endTokenPos": 21,
+                              "endFilePos": 49,
+                              "rawValue": "1",
+                              "kind": 10
+                            },
+                            "value": 1
+                          },
+                          "right": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 25,
+                              "startFilePos": 53,
+                              "endLine": 3,
+                              "endTokenPos": 25,
+                              "endFilePos": 53,
+                              "rawValue": "1",
+                              "kind": 10
+                            },
+                            "value": 1
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 29,
+                            "startFilePos": 57,
+                            "endLine": 3,
+                            "endTokenPos": 29,
+                            "endFilePos": 57,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 35,
+              "startFilePos": 63,
+              "endLine": 3,
+              "endTokenPos": 58,
+              "endFilePos": 105
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 35,
+                "startFilePos": 63,
+                "endLine": 3,
+                "endTokenPos": 35,
+                "endFilePos": 73
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 37,
+                  "startFilePos": 75,
+                  "endLine": 3,
+                  "endTokenPos": 54,
+                  "endFilePos": 98
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 37,
+                    "startFilePos": 75,
+                    "endLine": 3,
+                    "endTokenPos": 54,
+                    "endFilePos": 98
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 37,
+                      "startFilePos": 75,
+                      "endLine": 3,
+                      "endTokenPos": 37,
+                      "endFilePos": 80
+                    },
+                    "name": "substr"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 39,
+                        "startFilePos": 82,
+                        "endLine": 3,
+                        "endTokenPos": 39,
+                        "endFilePos": 83
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 39,
+                          "startFilePos": 82,
+                          "endLine": 3,
+                          "endTokenPos": 39,
+                          "endFilePos": 83
+                        },
+                        "name": "s"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 42,
+                        "startFilePos": 86,
+                        "endLine": 3,
+                        "endTokenPos": 42,
+                        "endFilePos": 86
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 42,
+                          "startFilePos": 86,
+                          "endLine": 3,
+                          "endTokenPos": 42,
+                          "endFilePos": 86,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 45,
+                        "startFilePos": 89,
+                        "endLine": 3,
+                        "endTokenPos": 53,
+                        "endFilePos": 97
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Minus",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 45,
+                          "startFilePos": 89,
+                          "endLine": 3,
+                          "endTokenPos": 53,
+                          "endFilePos": 97
+                        },
+                        "left": {
+                          "nodeType": "Expr_BinaryOp_Plus",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 45,
+                            "startFilePos": 89,
+                            "endLine": 3,
+                            "endTokenPos": 49,
+                            "endFilePos": 93
+                          },
+                          "left": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 45,
+                              "startFilePos": 89,
+                              "endLine": 3,
+                              "endTokenPos": 45,
+                              "endFilePos": 89,
+                              "rawValue": "1",
+                              "kind": 10
+                            },
+                            "value": 1
+                          },
+                          "right": {
+                            "nodeType": "Scalar_Int",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 49,
+                              "startFilePos": 93,
+                              "endLine": 3,
+                              "endTokenPos": 49,
+                              "endFilePos": 93,
+                              "rawValue": "1",
+                              "kind": 10
+                            },
+                            "value": 1
+                          }
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 53,
+                            "startFilePos": 97,
+                            "endLine": 3,
+                            "endTokenPos": 53,
+                            "endFilePos": 97,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 57,
+                  "startFilePos": 101,
+                  "endLine": 3,
+                  "endTokenPos": 57,
+                  "endFilePos": 104
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 57,
+                    "startFilePos": 101,
+                    "endLine": 3,
+                    "endTokenPos": 57,
+                    "endFilePos": 104,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 62,
+              "startFilePos": 109,
+              "endLine": 3,
+              "endTokenPos": 79,
+              "endFilePos": 132
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 62,
+                "startFilePos": 109,
+                "endLine": 3,
+                "endTokenPos": 62,
+                "endFilePos": 114
+              },
+              "name": "substr"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 64,
+                  "startFilePos": 116,
+                  "endLine": 3,
+                  "endTokenPos": 64,
+                  "endFilePos": 117
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 64,
+                    "startFilePos": 116,
+                    "endLine": 3,
+                    "endTokenPos": 64,
+                    "endFilePos": 117
+                  },
+                  "name": "s"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 67,
+                  "startFilePos": 120,
+                  "endLine": 3,
+                  "endTokenPos": 67,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 67,
+                    "startFilePos": 120,
+                    "endLine": 3,
+                    "endTokenPos": 67,
+                    "endFilePos": 120,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 70,
+                  "startFilePos": 123,
+                  "endLine": 3,
+                  "endTokenPos": 78,
+                  "endFilePos": 131
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Minus",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 70,
+                    "startFilePos": 123,
+                    "endLine": 3,
+                    "endTokenPos": 78,
+                    "endFilePos": 131
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 70,
+                      "startFilePos": 123,
+                      "endLine": 3,
+                      "endTokenPos": 74,
+                      "endFilePos": 127
+                    },
+                    "left": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 70,
+                        "startFilePos": 123,
+                        "endLine": 3,
+                        "endTokenPos": 70,
+                        "endFilePos": 123,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 74,
+                        "startFilePos": 127,
+                        "endLine": 3,
+                        "endTokenPos": 74,
+                        "endFilePos": 127,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 78,
+                      "startFilePos": 131,
+                      "endLine": 3,
+                      "endTokenPos": 78,
+                      "endFilePos": 131,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 83,
+            "startFilePos": 136,
+            "endLine": 3,
+            "endTokenPos": 83,
+            "endFilePos": 142
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 83,
+              "startFilePos": 136,
+              "endLine": 3,
+              "endTokenPos": 83,
+              "endFilePos": 142
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/string_prefix_slice.php.json
+++ b/tests/json-ast/x/php/string_prefix_slice.php.json
@@ -1,0 +1,682 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 22
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 21
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "prefix"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 21,
+            "kind": 2,
+            "rawValue": "\"fore\""
+          },
+          "value": "fore"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 24,
+        "endLine": 3,
+        "endTokenPos": 13,
+        "endFilePos": 38
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 24,
+          "endLine": 3,
+          "endTokenPos": 12,
+          "endFilePos": 37
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 24,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 26
+          },
+          "name": "s1"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 30,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 37,
+            "kind": 2,
+            "rawValue": "\"forest\""
+          },
+          "value": "forest"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 15,
+        "startFilePos": 40,
+        "endLine": 4,
+        "endTokenPos": 51,
+        "endFilePos": 121
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 18,
+            "startFilePos": 46,
+            "endLine": 4,
+            "endTokenPos": 46,
+            "endFilePos": 110
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Equal",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 18,
+              "startFilePos": 46,
+              "endLine": 4,
+              "endTokenPos": 38,
+              "endFilePos": 91
+            },
+            "left": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 18,
+                "startFilePos": 46,
+                "endLine": 4,
+                "endTokenPos": 34,
+                "endFilePos": 80
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 18,
+                  "startFilePos": 46,
+                  "endLine": 4,
+                  "endTokenPos": 18,
+                  "endFilePos": 51
+                },
+                "name": "substr"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 20,
+                    "startFilePos": 53,
+                    "endLine": 4,
+                    "endTokenPos": 20,
+                    "endFilePos": 55
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 20,
+                      "startFilePos": 53,
+                      "endLine": 4,
+                      "endTokenPos": 20,
+                      "endFilePos": 55
+                    },
+                    "name": "s1"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 23,
+                    "startFilePos": 58,
+                    "endLine": 4,
+                    "endTokenPos": 23,
+                    "endFilePos": 58
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 23,
+                      "startFilePos": 58,
+                      "endLine": 4,
+                      "endTokenPos": 23,
+                      "endFilePos": 58,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 26,
+                    "startFilePos": 61,
+                    "endLine": 4,
+                    "endTokenPos": 33,
+                    "endFilePos": 79
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_BinaryOp_Minus",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 26,
+                      "startFilePos": 61,
+                      "endLine": 4,
+                      "endTokenPos": 33,
+                      "endFilePos": 79
+                    },
+                    "left": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 26,
+                        "startFilePos": 61,
+                        "endLine": 4,
+                        "endTokenPos": 29,
+                        "endFilePos": 75
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 4,
+                          "startTokenPos": 26,
+                          "startFilePos": 61,
+                          "endLine": 4,
+                          "endTokenPos": 26,
+                          "endFilePos": 66
+                        },
+                        "name": "strlen"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 4,
+                            "startTokenPos": 28,
+                            "startFilePos": 68,
+                            "endLine": 4,
+                            "endTokenPos": 28,
+                            "endFilePos": 74
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 4,
+                              "startTokenPos": 28,
+                              "startFilePos": 68,
+                              "endLine": 4,
+                              "endTokenPos": 28,
+                              "endFilePos": 74
+                            },
+                            "name": "prefix"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 33,
+                        "startFilePos": 79,
+                        "endLine": 4,
+                        "endTokenPos": 33,
+                        "endFilePos": 79,
+                        "rawValue": "0",
+                        "kind": 10
+                      },
+                      "value": 0
+                    }
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 38,
+                "startFilePos": 85,
+                "endLine": 4,
+                "endTokenPos": 38,
+                "endFilePos": 91
+              },
+              "name": "prefix"
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 42,
+              "startFilePos": 95,
+              "endLine": 4,
+              "endTokenPos": 42,
+              "endFilePos": 100,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 46,
+              "startFilePos": 104,
+              "endLine": 4,
+              "endTokenPos": 46,
+              "endFilePos": 110,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 50,
+            "startFilePos": 114,
+            "endLine": 4,
+            "endTokenPos": 50,
+            "endFilePos": 120
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 50,
+              "startFilePos": 114,
+              "endLine": 4,
+              "endTokenPos": 50,
+              "endFilePos": 120
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 5,
+        "startTokenPos": 53,
+        "startFilePos": 123,
+        "endLine": 5,
+        "endTokenPos": 58,
+        "endFilePos": 137
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 5,
+          "startTokenPos": 53,
+          "startFilePos": 123,
+          "endLine": 5,
+          "endTokenPos": 57,
+          "endFilePos": 136
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 53,
+            "startFilePos": 123,
+            "endLine": 5,
+            "endTokenPos": 53,
+            "endFilePos": 125
+          },
+          "name": "s2"
+        },
+        "expr": {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 57,
+            "startFilePos": 129,
+            "endLine": 5,
+            "endTokenPos": 57,
+            "endFilePos": 136,
+            "kind": 2,
+            "rawValue": "\"desert\""
+          },
+          "value": "desert"
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 6,
+        "startTokenPos": 60,
+        "startFilePos": 139,
+        "endLine": 6,
+        "endTokenPos": 96,
+        "endFilePos": 220
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 63,
+            "startFilePos": 145,
+            "endLine": 6,
+            "endTokenPos": 91,
+            "endFilePos": 209
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Equal",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 63,
+              "startFilePos": 145,
+              "endLine": 6,
+              "endTokenPos": 83,
+              "endFilePos": 190
+            },
+            "left": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 63,
+                "startFilePos": 145,
+                "endLine": 6,
+                "endTokenPos": 79,
+                "endFilePos": 179
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 63,
+                  "startFilePos": 145,
+                  "endLine": 6,
+                  "endTokenPos": 63,
+                  "endFilePos": 150
+                },
+                "name": "substr"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 65,
+                    "startFilePos": 152,
+                    "endLine": 6,
+                    "endTokenPos": 65,
+                    "endFilePos": 154
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 65,
+                      "startFilePos": 152,
+                      "endLine": 6,
+                      "endTokenPos": 65,
+                      "endFilePos": 154
+                    },
+                    "name": "s2"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 68,
+                    "startFilePos": 157,
+                    "endLine": 6,
+                    "endTokenPos": 68,
+                    "endFilePos": 157
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 68,
+                      "startFilePos": 157,
+                      "endLine": 6,
+                      "endTokenPos": 68,
+                      "endFilePos": 157,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  },
+                  "byRef": false,
+                  "unpack": false
+                },
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 71,
+                    "startFilePos": 160,
+                    "endLine": 6,
+                    "endTokenPos": 78,
+                    "endFilePos": 178
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_BinaryOp_Minus",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 71,
+                      "startFilePos": 160,
+                      "endLine": 6,
+                      "endTokenPos": 78,
+                      "endFilePos": 178
+                    },
+                    "left": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 71,
+                        "startFilePos": 160,
+                        "endLine": 6,
+                        "endTokenPos": 74,
+                        "endFilePos": 174
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 71,
+                          "startFilePos": 160,
+                          "endLine": 6,
+                          "endTokenPos": 71,
+                          "endFilePos": 165
+                        },
+                        "name": "strlen"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 73,
+                            "startFilePos": 167,
+                            "endLine": 6,
+                            "endTokenPos": 73,
+                            "endFilePos": 173
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 6,
+                              "startTokenPos": 73,
+                              "startFilePos": 167,
+                              "endLine": 6,
+                              "endTokenPos": 73,
+                              "endFilePos": 173
+                            },
+                            "name": "prefix"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 78,
+                        "startFilePos": 178,
+                        "endLine": 6,
+                        "endTokenPos": 78,
+                        "endFilePos": 178,
+                        "rawValue": "0",
+                        "kind": 10
+                      },
+                      "value": 0
+                    }
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            },
+            "right": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 83,
+                "startFilePos": 184,
+                "endLine": 6,
+                "endTokenPos": 83,
+                "endFilePos": 190
+              },
+              "name": "prefix"
+            }
+          },
+          "if": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 87,
+              "startFilePos": 194,
+              "endLine": 6,
+              "endTokenPos": 87,
+              "endFilePos": 199,
+              "kind": 2,
+              "rawValue": "\"True\""
+            },
+            "value": "True"
+          },
+          "else": {
+            "nodeType": "Scalar_String",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 91,
+              "startFilePos": 203,
+              "endLine": 6,
+              "endTokenPos": 91,
+              "endFilePos": 209,
+              "kind": 2,
+              "rawValue": "\"False\""
+            },
+            "value": "False"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 95,
+            "startFilePos": 213,
+            "endLine": 6,
+            "endTokenPos": 95,
+            "endFilePos": 219
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 95,
+              "startFilePos": 213,
+              "endLine": 6,
+              "endTokenPos": 95,
+              "endFilePos": 219
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/substring_builtin.php.json
+++ b/tests/json-ast/x/php/substring_builtin.php.json
@@ -1,0 +1,559 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 65,
+        "endFilePos": 132
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 60,
+            "endFilePos": 121
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 20,
+              "endFilePos": 46
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 19,
+                  "endFilePos": 45
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 19,
+                    "endFilePos": 45
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 26
+                    },
+                    "name": "substr"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 8,
+                        "endFilePos": 34
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 28,
+                          "endLine": 2,
+                          "endTokenPos": 8,
+                          "endFilePos": 34,
+                          "kind": 2,
+                          "rawValue": "\"mochi\""
+                        },
+                        "value": "mochi"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 37,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 37
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 11,
+                          "startFilePos": 37,
+                          "endLine": 2,
+                          "endTokenPos": 11,
+                          "endFilePos": 37,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 40,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 44
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Minus",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 14,
+                          "startFilePos": 40,
+                          "endLine": 2,
+                          "endTokenPos": 18,
+                          "endFilePos": 44
+                        },
+                        "left": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 14,
+                            "startFilePos": 40,
+                            "endLine": 2,
+                            "endTokenPos": 14,
+                            "endFilePos": 40,
+                            "rawValue": "4",
+                            "kind": 10
+                          },
+                          "value": 4
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 18,
+                            "startFilePos": 44,
+                            "endLine": 2,
+                            "endTokenPos": 18,
+                            "endFilePos": 44,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 24,
+              "startFilePos": 50,
+              "endLine": 2,
+              "endTokenPos": 43,
+              "endFilePos": 93
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 24,
+                "startFilePos": 50,
+                "endLine": 2,
+                "endTokenPos": 24,
+                "endFilePos": 60
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 26,
+                  "startFilePos": 62,
+                  "endLine": 2,
+                  "endTokenPos": 39,
+                  "endFilePos": 86
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 26,
+                    "startFilePos": 62,
+                    "endLine": 2,
+                    "endTokenPos": 39,
+                    "endFilePos": 86
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 26,
+                      "startFilePos": 62,
+                      "endLine": 2,
+                      "endTokenPos": 26,
+                      "endFilePos": 67
+                    },
+                    "name": "substr"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 28,
+                        "startFilePos": 69,
+                        "endLine": 2,
+                        "endTokenPos": 28,
+                        "endFilePos": 75
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_String",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 28,
+                          "startFilePos": 69,
+                          "endLine": 2,
+                          "endTokenPos": 28,
+                          "endFilePos": 75,
+                          "kind": 2,
+                          "rawValue": "\"mochi\""
+                        },
+                        "value": "mochi"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 31,
+                        "startFilePos": 78,
+                        "endLine": 2,
+                        "endTokenPos": 31,
+                        "endFilePos": 78
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 31,
+                          "startFilePos": 78,
+                          "endLine": 2,
+                          "endTokenPos": 31,
+                          "endFilePos": 78,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 81,
+                        "endLine": 2,
+                        "endTokenPos": 38,
+                        "endFilePos": 85
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_BinaryOp_Minus",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 34,
+                          "startFilePos": 81,
+                          "endLine": 2,
+                          "endTokenPos": 38,
+                          "endFilePos": 85
+                        },
+                        "left": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 34,
+                            "startFilePos": 81,
+                            "endLine": 2,
+                            "endTokenPos": 34,
+                            "endFilePos": 81,
+                            "rawValue": "4",
+                            "kind": 10
+                          },
+                          "value": 4
+                        },
+                        "right": {
+                          "nodeType": "Scalar_Int",
+                          "attributes": {
+                            "startLine": 2,
+                            "startTokenPos": 38,
+                            "startFilePos": 85,
+                            "endLine": 2,
+                            "endTokenPos": 38,
+                            "endFilePos": 85,
+                            "rawValue": "1",
+                            "kind": 10
+                          },
+                          "value": 1
+                        }
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 42,
+                  "startFilePos": 89,
+                  "endLine": 2,
+                  "endTokenPos": 42,
+                  "endFilePos": 92
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 42,
+                    "startFilePos": 89,
+                    "endLine": 2,
+                    "endTokenPos": 42,
+                    "endFilePos": 92,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 47,
+              "startFilePos": 97,
+              "endLine": 2,
+              "endTokenPos": 60,
+              "endFilePos": 121
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 47,
+                "startFilePos": 97,
+                "endLine": 2,
+                "endTokenPos": 47,
+                "endFilePos": 102
+              },
+              "name": "substr"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 49,
+                  "startFilePos": 104,
+                  "endLine": 2,
+                  "endTokenPos": 49,
+                  "endFilePos": 110
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 49,
+                    "startFilePos": 104,
+                    "endLine": 2,
+                    "endTokenPos": 49,
+                    "endFilePos": 110,
+                    "kind": 2,
+                    "rawValue": "\"mochi\""
+                  },
+                  "value": "mochi"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 52,
+                  "startFilePos": 113,
+                  "endLine": 2,
+                  "endTokenPos": 52,
+                  "endFilePos": 113
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 52,
+                    "startFilePos": 113,
+                    "endLine": 2,
+                    "endTokenPos": 52,
+                    "endFilePos": 113,
+                    "rawValue": "1",
+                    "kind": 10
+                  },
+                  "value": 1
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 55,
+                  "startFilePos": 116,
+                  "endLine": 2,
+                  "endTokenPos": 59,
+                  "endFilePos": 120
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Minus",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 55,
+                    "startFilePos": 116,
+                    "endLine": 2,
+                    "endTokenPos": 59,
+                    "endFilePos": 120
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 55,
+                      "startFilePos": 116,
+                      "endLine": 2,
+                      "endTokenPos": 55,
+                      "endFilePos": 116,
+                      "rawValue": "4",
+                      "kind": 10
+                    },
+                    "value": 4
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 59,
+                      "startFilePos": 120,
+                      "endLine": 2,
+                      "endTokenPos": 59,
+                      "endFilePos": 120,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 64,
+            "startFilePos": 125,
+            "endLine": 2,
+            "endTokenPos": 64,
+            "endFilePos": 131
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 64,
+              "startFilePos": 125,
+              "endLine": 2,
+              "endTokenPos": 64,
+              "endFilePos": 131
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/sum_builtin.php.json
+++ b/tests/json-ast/x/php/sum_builtin.php.json
@@ -1,0 +1,568 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 59,
+        "endFilePos": 117
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 54,
+            "endFilePos": 106
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 18,
+              "endFilePos": 41
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 40
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 17,
+                    "endFilePos": 40
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 6,
+                      "startFilePos": 21,
+                      "endLine": 2,
+                      "endTokenPos": 6,
+                      "endFilePos": 29
+                    },
+                    "name": "array_sum"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 8,
+                        "startFilePos": 31,
+                        "endLine": 2,
+                        "endTokenPos": 16,
+                        "endFilePos": 39
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 8,
+                          "startFilePos": 31,
+                          "endLine": 2,
+                          "endTokenPos": 16,
+                          "endFilePos": 39,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 9,
+                              "startFilePos": 32,
+                              "endLine": 2,
+                              "endTokenPos": 9,
+                              "endFilePos": 32
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 9,
+                                "startFilePos": 32,
+                                "endLine": 2,
+                                "endTokenPos": 9,
+                                "endFilePos": 32,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 12,
+                              "startFilePos": 35,
+                              "endLine": 2,
+                              "endTokenPos": 12,
+                              "endFilePos": 35
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 12,
+                                "startFilePos": 35,
+                                "endLine": 2,
+                                "endTokenPos": 12,
+                                "endFilePos": 35,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 15,
+                              "startFilePos": 38,
+                              "endLine": 2,
+                              "endTokenPos": 15,
+                              "endFilePos": 38
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 15,
+                                "startFilePos": 38,
+                                "endLine": 2,
+                                "endTokenPos": 15,
+                                "endFilePos": 38,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 22,
+              "startFilePos": 45,
+              "endLine": 2,
+              "endTokenPos": 39,
+              "endFilePos": 83
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 22,
+                "startFilePos": 45,
+                "endLine": 2,
+                "endTokenPos": 22,
+                "endFilePos": 55
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 57,
+                  "endLine": 2,
+                  "endTokenPos": 35,
+                  "endFilePos": 76
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 24,
+                    "startFilePos": 57,
+                    "endLine": 2,
+                    "endTokenPos": 35,
+                    "endFilePos": 76
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 24,
+                      "startFilePos": 57,
+                      "endLine": 2,
+                      "endTokenPos": 24,
+                      "endFilePos": 65
+                    },
+                    "name": "array_sum"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 26,
+                        "startFilePos": 67,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 75
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 26,
+                          "startFilePos": 67,
+                          "endLine": 2,
+                          "endTokenPos": 34,
+                          "endFilePos": 75,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 27,
+                              "startFilePos": 68,
+                              "endLine": 2,
+                              "endTokenPos": 27,
+                              "endFilePos": 68
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 27,
+                                "startFilePos": 68,
+                                "endLine": 2,
+                                "endTokenPos": 27,
+                                "endFilePos": 68,
+                                "rawValue": "1",
+                                "kind": 10
+                              },
+                              "value": 1
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 30,
+                              "startFilePos": 71,
+                              "endLine": 2,
+                              "endTokenPos": 30,
+                              "endFilePos": 71
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 30,
+                                "startFilePos": 71,
+                                "endLine": 2,
+                                "endTokenPos": 30,
+                                "endFilePos": 71,
+                                "rawValue": "2",
+                                "kind": 10
+                              },
+                              "value": 2
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 2,
+                              "startTokenPos": 33,
+                              "startFilePos": 74,
+                              "endLine": 2,
+                              "endTokenPos": 33,
+                              "endFilePos": 74
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Scalar_Int",
+                              "attributes": {
+                                "startLine": 2,
+                                "startTokenPos": 33,
+                                "startFilePos": 74,
+                                "endLine": 2,
+                                "endTokenPos": 33,
+                                "endFilePos": 74,
+                                "rawValue": "3",
+                                "kind": 10
+                              },
+                              "value": 3
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 38,
+                  "startFilePos": 79,
+                  "endLine": 2,
+                  "endTokenPos": 38,
+                  "endFilePos": 82
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 38,
+                    "startFilePos": 79,
+                    "endLine": 2,
+                    "endTokenPos": 38,
+                    "endFilePos": 82,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 43,
+              "startFilePos": 87,
+              "endLine": 2,
+              "endTokenPos": 54,
+              "endFilePos": 106
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 43,
+                "startFilePos": 87,
+                "endLine": 2,
+                "endTokenPos": 43,
+                "endFilePos": 95
+              },
+              "name": "array_sum"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 45,
+                  "startFilePos": 97,
+                  "endLine": 2,
+                  "endTokenPos": 53,
+                  "endFilePos": 105
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Array",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 45,
+                    "startFilePos": 97,
+                    "endLine": 2,
+                    "endTokenPos": 53,
+                    "endFilePos": 105,
+                    "kind": 2
+                  },
+                  "items": [
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 46,
+                        "startFilePos": 98,
+                        "endLine": 2,
+                        "endTokenPos": 46,
+                        "endFilePos": 98
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 46,
+                          "startFilePos": 98,
+                          "endLine": 2,
+                          "endTokenPos": 46,
+                          "endFilePos": 98,
+                          "rawValue": "1",
+                          "kind": 10
+                        },
+                        "value": 1
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 49,
+                        "startFilePos": 101,
+                        "endLine": 2,
+                        "endTokenPos": 49,
+                        "endFilePos": 101
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 49,
+                          "startFilePos": 101,
+                          "endLine": 2,
+                          "endTokenPos": 49,
+                          "endFilePos": 101,
+                          "rawValue": "2",
+                          "kind": 10
+                        },
+                        "value": 2
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "ArrayItem",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 52,
+                        "startFilePos": 104,
+                        "endLine": 2,
+                        "endTokenPos": 52,
+                        "endFilePos": 104
+                      },
+                      "key": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 2,
+                          "startTokenPos": 52,
+                          "startFilePos": 104,
+                          "endLine": 2,
+                          "endTokenPos": 52,
+                          "endFilePos": 104,
+                          "rawValue": "3",
+                          "kind": 10
+                        },
+                        "value": 3
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 58,
+            "startFilePos": 110,
+            "endLine": 2,
+            "endTokenPos": 58,
+            "endFilePos": 116
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 58,
+              "startFilePos": 110,
+              "endLine": 2,
+              "endTokenPos": 58,
+              "endFilePos": 116
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/tail_recursion.php.json
+++ b/tests/json-ast/x/php/tail_recursion.php.json
@@ -1,0 +1,701 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 7,
+        "endTokenPos": 51,
+        "endFilePos": 106
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 21
+        },
+        "name": "sum_rec"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 23,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 24
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 23,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 24
+            },
+            "name": "n"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 8,
+            "startFilePos": 27,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 30
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 27,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 30
+            },
+            "name": "acc"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 37,
+            "endLine": 5,
+            "endTokenPos": 30,
+            "endFilePos": 67
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_Equal",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 16,
+              "startFilePos": 41,
+              "endLine": 3,
+              "endTokenPos": 20,
+              "endFilePos": 47
+            },
+            "left": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 16,
+                "startFilePos": 41,
+                "endLine": 3,
+                "endTokenPos": 16,
+                "endFilePos": 42
+              },
+              "name": "n"
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 20,
+                "startFilePos": 47,
+                "endLine": 3,
+                "endTokenPos": 20,
+                "endFilePos": 47,
+                "rawValue": "0",
+                "kind": 10
+              },
+              "value": 0
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Return",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 25,
+                "startFilePos": 54,
+                "endLine": 4,
+                "endTokenPos": 28,
+                "endFilePos": 65
+              },
+              "expr": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 27,
+                  "startFilePos": 61,
+                  "endLine": 4,
+                  "endTokenPos": 27,
+                  "endFilePos": 64
+                },
+                "name": "acc"
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        },
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 6,
+            "startTokenPos": 32,
+            "startFilePos": 71,
+            "endLine": 6,
+            "endTokenPos": 49,
+            "endFilePos": 104
+          },
+          "expr": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 6,
+              "startTokenPos": 34,
+              "startFilePos": 78,
+              "endLine": 6,
+              "endTokenPos": 48,
+              "endFilePos": 103
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 34,
+                "startFilePos": 78,
+                "endLine": 6,
+                "endTokenPos": 34,
+                "endFilePos": 84
+              },
+              "name": "sum_rec"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 36,
+                  "startFilePos": 86,
+                  "endLine": 6,
+                  "endTokenPos": 40,
+                  "endFilePos": 91
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Minus",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 36,
+                    "startFilePos": 86,
+                    "endLine": 6,
+                    "endTokenPos": 40,
+                    "endFilePos": 91
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 36,
+                      "startFilePos": 86,
+                      "endLine": 6,
+                      "endTokenPos": 36,
+                      "endFilePos": 87
+                    },
+                    "name": "n"
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 40,
+                      "startFilePos": 91,
+                      "endLine": 6,
+                      "endTokenPos": 40,
+                      "endFilePos": 91,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 43,
+                  "startFilePos": 94,
+                  "endLine": 6,
+                  "endTokenPos": 47,
+                  "endFilePos": 102
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 43,
+                    "startFilePos": 94,
+                    "endLine": 6,
+                    "endTokenPos": 47,
+                    "endFilePos": 102
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 43,
+                      "startFilePos": 94,
+                      "endLine": 6,
+                      "endTokenPos": 43,
+                      "endFilePos": 97
+                    },
+                    "name": "acc"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 47,
+                      "startFilePos": 101,
+                      "endLine": 6,
+                      "endTokenPos": 47,
+                      "endFilePos": 102
+                    },
+                    "name": "n"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 53,
+        "startFilePos": 108,
+        "endLine": 8,
+        "endTokenPos": 96,
+        "endFilePos": 201
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 56,
+            "startFilePos": 114,
+            "endLine": 8,
+            "endTokenPos": 91,
+            "endFilePos": 190
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 56,
+              "startFilePos": 114,
+              "endLine": 8,
+              "endTokenPos": 65,
+              "endFilePos": 137
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 56,
+                "startFilePos": 114,
+                "endLine": 8,
+                "endTokenPos": 56,
+                "endFilePos": 121
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 58,
+                  "startFilePos": 123,
+                  "endLine": 8,
+                  "endTokenPos": 64,
+                  "endFilePos": 136
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 58,
+                    "startFilePos": 123,
+                    "endLine": 8,
+                    "endTokenPos": 64,
+                    "endFilePos": 136
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 58,
+                      "startFilePos": 123,
+                      "endLine": 8,
+                      "endTokenPos": 58,
+                      "endFilePos": 129
+                    },
+                    "name": "sum_rec"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 60,
+                        "startFilePos": 131,
+                        "endLine": 8,
+                        "endTokenPos": 60,
+                        "endFilePos": 132
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 60,
+                          "startFilePos": 131,
+                          "endLine": 8,
+                          "endTokenPos": 60,
+                          "endFilePos": 132,
+                          "rawValue": "10",
+                          "kind": 10
+                        },
+                        "value": 10
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 63,
+                        "startFilePos": 135,
+                        "endLine": 8,
+                        "endTokenPos": 63,
+                        "endFilePos": 135
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 63,
+                          "startFilePos": 135,
+                          "endLine": 8,
+                          "endTokenPos": 63,
+                          "endFilePos": 135,
+                          "rawValue": "0",
+                          "kind": 10
+                        },
+                        "value": 0
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 69,
+              "startFilePos": 141,
+              "endLine": 8,
+              "endTokenPos": 81,
+              "endFilePos": 173
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 69,
+                "startFilePos": 141,
+                "endLine": 8,
+                "endTokenPos": 69,
+                "endFilePos": 151
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 71,
+                  "startFilePos": 153,
+                  "endLine": 8,
+                  "endTokenPos": 77,
+                  "endFilePos": 166
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 71,
+                    "startFilePos": 153,
+                    "endLine": 8,
+                    "endTokenPos": 77,
+                    "endFilePos": 166
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 71,
+                      "startFilePos": 153,
+                      "endLine": 8,
+                      "endTokenPos": 71,
+                      "endFilePos": 159
+                    },
+                    "name": "sum_rec"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 73,
+                        "startFilePos": 161,
+                        "endLine": 8,
+                        "endTokenPos": 73,
+                        "endFilePos": 162
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 73,
+                          "startFilePos": 161,
+                          "endLine": 8,
+                          "endTokenPos": 73,
+                          "endFilePos": 162,
+                          "rawValue": "10",
+                          "kind": 10
+                        },
+                        "value": 10
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    },
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 76,
+                        "startFilePos": 165,
+                        "endLine": 8,
+                        "endTokenPos": 76,
+                        "endFilePos": 165
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Scalar_Int",
+                        "attributes": {
+                          "startLine": 8,
+                          "startTokenPos": 76,
+                          "startFilePos": 165,
+                          "endLine": 8,
+                          "endTokenPos": 76,
+                          "endFilePos": 165,
+                          "rawValue": "0",
+                          "kind": 10
+                        },
+                        "value": 0
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 80,
+                  "startFilePos": 169,
+                  "endLine": 8,
+                  "endTokenPos": 80,
+                  "endFilePos": 172
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 80,
+                    "startFilePos": 169,
+                    "endLine": 8,
+                    "endTokenPos": 80,
+                    "endFilePos": 172,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 85,
+              "startFilePos": 177,
+              "endLine": 8,
+              "endTokenPos": 91,
+              "endFilePos": 190
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 85,
+                "startFilePos": 177,
+                "endLine": 8,
+                "endTokenPos": 85,
+                "endFilePos": 183
+              },
+              "name": "sum_rec"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 87,
+                  "startFilePos": 185,
+                  "endLine": 8,
+                  "endTokenPos": 87,
+                  "endFilePos": 186
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 87,
+                    "startFilePos": 185,
+                    "endLine": 8,
+                    "endTokenPos": 87,
+                    "endFilePos": 186,
+                    "rawValue": "10",
+                    "kind": 10
+                  },
+                  "value": 10
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 90,
+                  "startFilePos": 189,
+                  "endLine": 8,
+                  "endTokenPos": 90,
+                  "endFilePos": 189
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 8,
+                    "startTokenPos": 90,
+                    "startFilePos": 189,
+                    "endLine": 8,
+                    "endTokenPos": 90,
+                    "endFilePos": 189,
+                    "rawValue": "0",
+                    "kind": 10
+                  },
+                  "value": 0
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 95,
+            "startFilePos": 194,
+            "endLine": 8,
+            "endTokenPos": 95,
+            "endFilePos": 200
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 95,
+              "startFilePos": 194,
+              "endLine": 8,
+              "endTokenPos": 95,
+              "endFilePos": 200
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/test_block.php.json
+++ b/tests/json-ast/x/php/test_block.php.json
@@ -1,0 +1,54 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 7,
+        "endFilePos": 24
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 3,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 3,
+            "endFilePos": 14,
+            "kind": 2,
+            "rawValue": "\"ok\""
+          },
+          "value": "ok"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 6,
+            "startFilePos": 17,
+            "endLine": 2,
+            "endTokenPos": 6,
+            "endFilePos": 23
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 6,
+              "startFilePos": 17,
+              "endLine": 2,
+              "endTokenPos": 6,
+              "endFilePos": 23
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/tree_sum.php.json
+++ b/tests/json-ast/x/php/tree_sum.php.json
@@ -1,0 +1,985 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 7,
+        "endTokenPos": 59,
+        "endFilePos": 150
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 22
+        },
+        "name": "sum_tree"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 24,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 25
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 24,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 25
+            },
+            "name": "t"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 10,
+            "startFilePos": 32,
+            "endLine": 6,
+            "endTokenPos": 57,
+            "endFilePos": 148
+          },
+          "expr": {
+            "nodeType": "Expr_Match",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 12,
+              "startFilePos": 39,
+              "endLine": 6,
+              "endTokenPos": 56,
+              "endFilePos": 147
+            },
+            "cond": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 14,
+                "startFilePos": 45,
+                "endLine": 3,
+                "endTokenPos": 14,
+                "endFilePos": 46
+              },
+              "name": "t"
+            },
+            "arms": [
+              {
+                "nodeType": "MatchArm",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 19,
+                  "startFilePos": 55,
+                  "endLine": 4,
+                  "endTokenPos": 23,
+                  "endFilePos": 64
+                },
+                "conds": [
+                  {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 19,
+                      "startFilePos": 55,
+                      "endLine": 4,
+                      "endTokenPos": 19,
+                      "endFilePos": 59
+                    },
+                    "name": "Leaf"
+                  }
+                ],
+                "body": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 23,
+                    "startFilePos": 64,
+                    "endLine": 4,
+                    "endTokenPos": 23,
+                    "endFilePos": 64,
+                    "rawValue": "0",
+                    "kind": 10
+                  },
+                  "value": 0
+                }
+              },
+              {
+                "nodeType": "MatchArm",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 26,
+                  "startFilePos": 71,
+                  "endLine": 5,
+                  "endTokenPos": 53,
+                  "endFilePos": 144
+                },
+                "conds": [
+                  {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 26,
+                      "startFilePos": 71,
+                      "endLine": 5,
+                      "endTokenPos": 35,
+                      "endFilePos": 97
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 26,
+                        "startFilePos": 71,
+                        "endLine": 5,
+                        "endTokenPos": 26,
+                        "endFilePos": 74
+                      },
+                      "name": "Node"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 28,
+                          "startFilePos": 76,
+                          "endLine": 5,
+                          "endTokenPos": 28,
+                          "endFilePos": 80
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 28,
+                            "startFilePos": 76,
+                            "endLine": 5,
+                            "endTokenPos": 28,
+                            "endFilePos": 80
+                          },
+                          "name": "left"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 31,
+                          "startFilePos": 83,
+                          "endLine": 5,
+                          "endTokenPos": 31,
+                          "endFilePos": 88
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 31,
+                            "startFilePos": 83,
+                            "endLine": 5,
+                            "endTokenPos": 31,
+                            "endFilePos": 88
+                          },
+                          "name": "value"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      },
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 34,
+                          "startFilePos": 91,
+                          "endLine": 5,
+                          "endTokenPos": 34,
+                          "endFilePos": 96
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 34,
+                            "startFilePos": 91,
+                            "endLine": 5,
+                            "endTokenPos": 34,
+                            "endFilePos": 96
+                          },
+                          "name": "right"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                ],
+                "body": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 39,
+                    "startFilePos": 102,
+                    "endLine": 5,
+                    "endTokenPos": 53,
+                    "endFilePos": 144
+                  },
+                  "left": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 39,
+                      "startFilePos": 102,
+                      "endLine": 5,
+                      "endTokenPos": 46,
+                      "endFilePos": 125
+                    },
+                    "left": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 39,
+                        "startFilePos": 102,
+                        "endLine": 5,
+                        "endTokenPos": 42,
+                        "endFilePos": 116
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 39,
+                          "startFilePos": 102,
+                          "endLine": 5,
+                          "endTokenPos": 39,
+                          "endFilePos": 109
+                        },
+                        "name": "sum_tree"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 41,
+                            "startFilePos": 111,
+                            "endLine": 5,
+                            "endTokenPos": 41,
+                            "endFilePos": 115
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_Variable",
+                            "attributes": {
+                              "startLine": 5,
+                              "startTokenPos": 41,
+                              "startFilePos": 111,
+                              "endLine": 5,
+                              "endTokenPos": 41,
+                              "endFilePos": 115
+                            },
+                            "name": "left"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "right": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 46,
+                        "startFilePos": 120,
+                        "endLine": 5,
+                        "endTokenPos": 46,
+                        "endFilePos": 125
+                      },
+                      "name": "value"
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Expr_FuncCall",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 50,
+                      "startFilePos": 129,
+                      "endLine": 5,
+                      "endTokenPos": 53,
+                      "endFilePos": 144
+                    },
+                    "name": {
+                      "nodeType": "Name",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 50,
+                        "startFilePos": 129,
+                        "endLine": 5,
+                        "endTokenPos": 50,
+                        "endFilePos": 136
+                      },
+                      "name": "sum_tree"
+                    },
+                    "args": [
+                      {
+                        "nodeType": "Arg",
+                        "attributes": {
+                          "startLine": 5,
+                          "startTokenPos": 52,
+                          "startFilePos": 138,
+                          "endLine": 5,
+                          "endTokenPos": 52,
+                          "endFilePos": 143
+                        },
+                        "name": null,
+                        "value": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 5,
+                            "startTokenPos": 52,
+                            "startFilePos": 138,
+                            "endLine": 5,
+                            "endTokenPos": 52,
+                            "endFilePos": 143
+                          },
+                          "name": "right"
+                        },
+                        "byRef": false,
+                        "unpack": false
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 8,
+        "startTokenPos": 61,
+        "startFilePos": 152,
+        "endLine": 8,
+        "endTokenPos": 106,
+        "endFilePos": 250
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 8,
+          "startTokenPos": 61,
+          "startFilePos": 152,
+          "endLine": 8,
+          "endTokenPos": 105,
+          "endFilePos": 249
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 61,
+            "startFilePos": 152,
+            "endLine": 8,
+            "endTokenPos": 61,
+            "endFilePos": 153
+          },
+          "name": "t"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 65,
+            "startFilePos": 157,
+            "endLine": 8,
+            "endTokenPos": 105,
+            "endFilePos": 249,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 66,
+                "startFilePos": 158,
+                "endLine": 8,
+                "endTokenPos": 70,
+                "endFilePos": 172
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 66,
+                  "startFilePos": 158,
+                  "endLine": 8,
+                  "endTokenPos": 66,
+                  "endFilePos": 163,
+                  "kind": 2,
+                  "rawValue": "\"left\""
+                },
+                "value": "left"
+              },
+              "value": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 70,
+                  "startFilePos": 168,
+                  "endLine": 8,
+                  "endTokenPos": 70,
+                  "endFilePos": 172
+                },
+                "name": "Leaf"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 73,
+                "startFilePos": 175,
+                "endLine": 8,
+                "endTokenPos": 77,
+                "endFilePos": 186
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 73,
+                  "startFilePos": 175,
+                  "endLine": 8,
+                  "endTokenPos": 73,
+                  "endFilePos": 181,
+                  "kind": 2,
+                  "rawValue": "\"value\""
+                },
+                "value": "value"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 77,
+                  "startFilePos": 186,
+                  "endLine": 8,
+                  "endTokenPos": 77,
+                  "endFilePos": 186,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 80,
+                "startFilePos": 189,
+                "endLine": 8,
+                "endTokenPos": 104,
+                "endFilePos": 248
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 80,
+                  "startFilePos": 189,
+                  "endLine": 8,
+                  "endTokenPos": 80,
+                  "endFilePos": 195,
+                  "kind": 2,
+                  "rawValue": "\"right\""
+                },
+                "value": "right"
+              },
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 84,
+                  "startFilePos": 200,
+                  "endLine": 8,
+                  "endTokenPos": 104,
+                  "endFilePos": 248,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 85,
+                      "startFilePos": 201,
+                      "endLine": 8,
+                      "endTokenPos": 89,
+                      "endFilePos": 215
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 85,
+                        "startFilePos": 201,
+                        "endLine": 8,
+                        "endTokenPos": 85,
+                        "endFilePos": 206,
+                        "kind": 2,
+                        "rawValue": "\"left\""
+                      },
+                      "value": "left"
+                    },
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 89,
+                        "startFilePos": 211,
+                        "endLine": 8,
+                        "endTokenPos": 89,
+                        "endFilePos": 215
+                      },
+                      "name": "Leaf"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 92,
+                      "startFilePos": 218,
+                      "endLine": 8,
+                      "endTokenPos": 96,
+                      "endFilePos": 229
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 92,
+                        "startFilePos": 218,
+                        "endLine": 8,
+                        "endTokenPos": 92,
+                        "endFilePos": 224,
+                        "kind": 2,
+                        "rawValue": "\"value\""
+                      },
+                      "value": "value"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 96,
+                        "startFilePos": 229,
+                        "endLine": 8,
+                        "endTokenPos": 96,
+                        "endFilePos": 229,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 8,
+                      "startTokenPos": 99,
+                      "startFilePos": 232,
+                      "endLine": 8,
+                      "endTokenPos": 103,
+                      "endFilePos": 247
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 99,
+                        "startFilePos": 232,
+                        "endLine": 8,
+                        "endTokenPos": 99,
+                        "endFilePos": 238,
+                        "kind": 2,
+                        "rawValue": "\"right\""
+                      },
+                      "value": "right"
+                    },
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 8,
+                        "startTokenPos": 103,
+                        "startFilePos": 243,
+                        "endLine": 8,
+                        "endTokenPos": 103,
+                        "endFilePos": 247
+                      },
+                      "name": "Leaf"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 9,
+        "startTokenPos": 108,
+        "startFilePos": 252,
+        "endLine": 9,
+        "endTokenPos": 142,
+        "endFilePos": 339
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 111,
+            "startFilePos": 258,
+            "endLine": 9,
+            "endTokenPos": 137,
+            "endFilePos": 328
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 111,
+              "startFilePos": 258,
+              "endLine": 9,
+              "endTokenPos": 117,
+              "endFilePos": 279
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 111,
+                "startFilePos": 258,
+                "endLine": 9,
+                "endTokenPos": 111,
+                "endFilePos": 265
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 113,
+                  "startFilePos": 267,
+                  "endLine": 9,
+                  "endTokenPos": 116,
+                  "endFilePos": 278
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 113,
+                    "startFilePos": 267,
+                    "endLine": 9,
+                    "endTokenPos": 116,
+                    "endFilePos": 278
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 113,
+                      "startFilePos": 267,
+                      "endLine": 9,
+                      "endTokenPos": 113,
+                      "endFilePos": 274
+                    },
+                    "name": "sum_tree"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 115,
+                        "startFilePos": 276,
+                        "endLine": 9,
+                        "endTokenPos": 115,
+                        "endFilePos": 277
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 115,
+                          "startFilePos": 276,
+                          "endLine": 9,
+                          "endTokenPos": 115,
+                          "endFilePos": 277
+                        },
+                        "name": "t"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 121,
+              "startFilePos": 283,
+              "endLine": 9,
+              "endTokenPos": 130,
+              "endFilePos": 313
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 121,
+                "startFilePos": 283,
+                "endLine": 9,
+                "endTokenPos": 121,
+                "endFilePos": 293
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 123,
+                  "startFilePos": 295,
+                  "endLine": 9,
+                  "endTokenPos": 126,
+                  "endFilePos": 306
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_FuncCall",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 123,
+                    "startFilePos": 295,
+                    "endLine": 9,
+                    "endTokenPos": 126,
+                    "endFilePos": 306
+                  },
+                  "name": {
+                    "nodeType": "Name",
+                    "attributes": {
+                      "startLine": 9,
+                      "startTokenPos": 123,
+                      "startFilePos": 295,
+                      "endLine": 9,
+                      "endTokenPos": 123,
+                      "endFilePos": 302
+                    },
+                    "name": "sum_tree"
+                  },
+                  "args": [
+                    {
+                      "nodeType": "Arg",
+                      "attributes": {
+                        "startLine": 9,
+                        "startTokenPos": 125,
+                        "startFilePos": 304,
+                        "endLine": 9,
+                        "endTokenPos": 125,
+                        "endFilePos": 305
+                      },
+                      "name": null,
+                      "value": {
+                        "nodeType": "Expr_Variable",
+                        "attributes": {
+                          "startLine": 9,
+                          "startTokenPos": 125,
+                          "startFilePos": 304,
+                          "endLine": 9,
+                          "endTokenPos": 125,
+                          "endFilePos": 305
+                        },
+                        "name": "t"
+                      },
+                      "byRef": false,
+                      "unpack": false
+                    }
+                  ]
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 129,
+                  "startFilePos": 309,
+                  "endLine": 9,
+                  "endTokenPos": 129,
+                  "endFilePos": 312
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 129,
+                    "startFilePos": 309,
+                    "endLine": 9,
+                    "endTokenPos": 129,
+                    "endFilePos": 312,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 134,
+              "startFilePos": 317,
+              "endLine": 9,
+              "endTokenPos": 137,
+              "endFilePos": 328
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 9,
+                "startTokenPos": 134,
+                "startFilePos": 317,
+                "endLine": 9,
+                "endTokenPos": 134,
+                "endFilePos": 324
+              },
+              "name": "sum_tree"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 9,
+                  "startTokenPos": 136,
+                  "startFilePos": 326,
+                  "endLine": 9,
+                  "endTokenPos": 136,
+                  "endFilePos": 327
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 9,
+                    "startTokenPos": 136,
+                    "startFilePos": 326,
+                    "endLine": 9,
+                    "endTokenPos": 136,
+                    "endFilePos": 327
+                  },
+                  "name": "t"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 9,
+            "startTokenPos": 141,
+            "startFilePos": 332,
+            "endLine": 9,
+            "endTokenPos": 141,
+            "endFilePos": 338
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 9,
+              "startTokenPos": 141,
+              "startFilePos": 332,
+              "endLine": 9,
+              "endTokenPos": 141,
+              "endFilePos": 338
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/two-sum.php.json
+++ b/tests/json-ast/x/php/two-sum.php.json
@@ -1,0 +1,1484 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Function",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 12,
+        "endTokenPos": 125,
+        "endFilePos": 218
+      },
+      "byRef": false,
+      "name": {
+        "nodeType": "Identifier",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 3,
+          "startFilePos": 15,
+          "endLine": 2,
+          "endTokenPos": 3,
+          "endFilePos": 20
+        },
+        "name": "twoSum"
+      },
+      "params": [
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 22,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 26
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 5,
+              "startFilePos": 22,
+              "endLine": 2,
+              "endTokenPos": 5,
+              "endFilePos": 26
+            },
+            "name": "nums"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        },
+        {
+          "nodeType": "Param",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 8,
+            "startFilePos": 29,
+            "endLine": 2,
+            "endTokenPos": 8,
+            "endFilePos": 35
+          },
+          "type": null,
+          "byRef": false,
+          "variadic": false,
+          "var": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 8,
+              "startFilePos": 29,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 35
+            },
+            "name": "target"
+          },
+          "default": null,
+          "flags": 0,
+          "attrGroups": [],
+          "hooks": []
+        }
+      ],
+      "returnType": null,
+      "stmts": [
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 13,
+            "startFilePos": 42,
+            "endLine": 3,
+            "endTokenPos": 21,
+            "endFilePos": 59
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 13,
+              "startFilePos": 42,
+              "endLine": 3,
+              "endTokenPos": 20,
+              "endFilePos": 58
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 13,
+                "startFilePos": 42,
+                "endLine": 3,
+                "endTokenPos": 13,
+                "endFilePos": 43
+              },
+              "name": "n"
+            },
+            "expr": {
+              "nodeType": "Expr_FuncCall",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 17,
+                "startFilePos": 47,
+                "endLine": 3,
+                "endTokenPos": 20,
+                "endFilePos": 58
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 17,
+                  "startFilePos": 47,
+                  "endLine": 3,
+                  "endTokenPos": 17,
+                  "endFilePos": 51
+                },
+                "name": "count"
+              },
+              "args": [
+                {
+                  "nodeType": "Arg",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 19,
+                    "startFilePos": 53,
+                    "endLine": 3,
+                    "endTokenPos": 19,
+                    "endFilePos": 57
+                  },
+                  "name": null,
+                  "value": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 19,
+                      "startFilePos": 53,
+                      "endLine": 3,
+                      "endTokenPos": 19,
+                      "endFilePos": 57
+                    },
+                    "name": "nums"
+                  },
+                  "byRef": false,
+                  "unpack": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "nodeType": "Stmt_For",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 23,
+            "startFilePos": 63,
+            "endLine": 10,
+            "endTokenPos": 110,
+            "endFilePos": 196
+          },
+          "init": [
+            {
+              "nodeType": "Expr_Assign",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 26,
+                "startFilePos": 68,
+                "endLine": 4,
+                "endTokenPos": 30,
+                "endFilePos": 73
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 26,
+                  "startFilePos": 68,
+                  "endLine": 4,
+                  "endTokenPos": 26,
+                  "endFilePos": 69
+                },
+                "name": "i"
+              },
+              "expr": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 30,
+                  "startFilePos": 73,
+                  "endLine": 4,
+                  "endTokenPos": 30,
+                  "endFilePos": 73,
+                  "rawValue": "0",
+                  "kind": 10
+                },
+                "value": 0
+              }
+            }
+          ],
+          "cond": [
+            {
+              "nodeType": "Expr_BinaryOp_Smaller",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 33,
+                "startFilePos": 76,
+                "endLine": 4,
+                "endTokenPos": 37,
+                "endFilePos": 82
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 33,
+                  "startFilePos": 76,
+                  "endLine": 4,
+                  "endTokenPos": 33,
+                  "endFilePos": 77
+                },
+                "name": "i"
+              },
+              "right": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 37,
+                  "startFilePos": 81,
+                  "endLine": 4,
+                  "endTokenPos": 37,
+                  "endFilePos": 82
+                },
+                "name": "n"
+              }
+            }
+          ],
+          "loop": [
+            {
+              "nodeType": "Expr_PostInc",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 40,
+                "startFilePos": 85,
+                "endLine": 4,
+                "endTokenPos": 41,
+                "endFilePos": 88
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 40,
+                  "startFilePos": 85,
+                  "endLine": 4,
+                  "endTokenPos": 40,
+                  "endFilePos": 86
+                },
+                "name": "i"
+              }
+            }
+          ],
+          "stmts": [
+            {
+              "nodeType": "Stmt_For",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 46,
+                "startFilePos": 95,
+                "endLine": 9,
+                "endTokenPos": 107,
+                "endFilePos": 193
+              },
+              "init": [
+                {
+                  "nodeType": "Expr_Assign",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 49,
+                    "startFilePos": 100,
+                    "endLine": 5,
+                    "endTokenPos": 57,
+                    "endFilePos": 110
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 49,
+                      "startFilePos": 100,
+                      "endLine": 5,
+                      "endTokenPos": 49,
+                      "endFilePos": 101
+                    },
+                    "name": "j"
+                  },
+                  "expr": {
+                    "nodeType": "Expr_BinaryOp_Plus",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 53,
+                      "startFilePos": 105,
+                      "endLine": 5,
+                      "endTokenPos": 57,
+                      "endFilePos": 110
+                    },
+                    "left": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 53,
+                        "startFilePos": 105,
+                        "endLine": 5,
+                        "endTokenPos": 53,
+                        "endFilePos": 106
+                      },
+                      "name": "i"
+                    },
+                    "right": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 5,
+                        "startTokenPos": 57,
+                        "startFilePos": 110,
+                        "endLine": 5,
+                        "endTokenPos": 57,
+                        "endFilePos": 110,
+                        "rawValue": "1",
+                        "kind": 10
+                      },
+                      "value": 1
+                    }
+                  }
+                }
+              ],
+              "cond": [
+                {
+                  "nodeType": "Expr_BinaryOp_Smaller",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 60,
+                    "startFilePos": 113,
+                    "endLine": 5,
+                    "endTokenPos": 64,
+                    "endFilePos": 119
+                  },
+                  "left": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 60,
+                      "startFilePos": 113,
+                      "endLine": 5,
+                      "endTokenPos": 60,
+                      "endFilePos": 114
+                    },
+                    "name": "j"
+                  },
+                  "right": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 64,
+                      "startFilePos": 118,
+                      "endLine": 5,
+                      "endTokenPos": 64,
+                      "endFilePos": 119
+                    },
+                    "name": "n"
+                  }
+                }
+              ],
+              "loop": [
+                {
+                  "nodeType": "Expr_PostInc",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 67,
+                    "startFilePos": 122,
+                    "endLine": 5,
+                    "endTokenPos": 68,
+                    "endFilePos": 125
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 67,
+                      "startFilePos": 122,
+                      "endLine": 5,
+                      "endTokenPos": 67,
+                      "endFilePos": 123
+                    },
+                    "name": "j"
+                  }
+                }
+              ],
+              "stmts": [
+                {
+                  "nodeType": "Stmt_If",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 73,
+                    "startFilePos": 132,
+                    "endLine": 8,
+                    "endTokenPos": 105,
+                    "endFilePos": 191
+                  },
+                  "cond": {
+                    "nodeType": "Expr_BinaryOp_Equal",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 76,
+                      "startFilePos": 136,
+                      "endLine": 6,
+                      "endTokenPos": 90,
+                      "endFilePos": 167
+                    },
+                    "left": {
+                      "nodeType": "Expr_BinaryOp_Plus",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 76,
+                        "startFilePos": 136,
+                        "endLine": 6,
+                        "endTokenPos": 86,
+                        "endFilePos": 156
+                      },
+                      "left": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 76,
+                          "startFilePos": 136,
+                          "endLine": 6,
+                          "endTokenPos": 79,
+                          "endFilePos": 144
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 76,
+                            "startFilePos": 136,
+                            "endLine": 6,
+                            "endTokenPos": 76,
+                            "endFilePos": 140
+                          },
+                          "name": "nums"
+                        },
+                        "dim": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 78,
+                            "startFilePos": 142,
+                            "endLine": 6,
+                            "endTokenPos": 78,
+                            "endFilePos": 143
+                          },
+                          "name": "i"
+                        }
+                      },
+                      "right": {
+                        "nodeType": "Expr_ArrayDimFetch",
+                        "attributes": {
+                          "startLine": 6,
+                          "startTokenPos": 83,
+                          "startFilePos": 148,
+                          "endLine": 6,
+                          "endTokenPos": 86,
+                          "endFilePos": 156
+                        },
+                        "var": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 83,
+                            "startFilePos": 148,
+                            "endLine": 6,
+                            "endTokenPos": 83,
+                            "endFilePos": 152
+                          },
+                          "name": "nums"
+                        },
+                        "dim": {
+                          "nodeType": "Expr_Variable",
+                          "attributes": {
+                            "startLine": 6,
+                            "startTokenPos": 85,
+                            "startFilePos": 154,
+                            "endLine": 6,
+                            "endTokenPos": 85,
+                            "endFilePos": 155
+                          },
+                          "name": "j"
+                        }
+                      }
+                    },
+                    "right": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 90,
+                        "startFilePos": 161,
+                        "endLine": 6,
+                        "endTokenPos": 90,
+                        "endFilePos": 167
+                      },
+                      "name": "target"
+                    }
+                  },
+                  "stmts": [
+                    {
+                      "nodeType": "Stmt_Return",
+                      "attributes": {
+                        "startLine": 7,
+                        "startTokenPos": 95,
+                        "startFilePos": 174,
+                        "endLine": 7,
+                        "endTokenPos": 103,
+                        "endFilePos": 189
+                      },
+                      "expr": {
+                        "nodeType": "Expr_Array",
+                        "attributes": {
+                          "startLine": 7,
+                          "startTokenPos": 97,
+                          "startFilePos": 181,
+                          "endLine": 7,
+                          "endTokenPos": 102,
+                          "endFilePos": 188,
+                          "kind": 2
+                        },
+                        "items": [
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 98,
+                              "startFilePos": 182,
+                              "endLine": 7,
+                              "endTokenPos": 98,
+                              "endFilePos": 183
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 98,
+                                "startFilePos": 182,
+                                "endLine": 7,
+                                "endTokenPos": 98,
+                                "endFilePos": 183
+                              },
+                              "name": "i"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          },
+                          {
+                            "nodeType": "ArrayItem",
+                            "attributes": {
+                              "startLine": 7,
+                              "startTokenPos": 101,
+                              "startFilePos": 186,
+                              "endLine": 7,
+                              "endTokenPos": 101,
+                              "endFilePos": 187
+                            },
+                            "key": null,
+                            "value": {
+                              "nodeType": "Expr_Variable",
+                              "attributes": {
+                                "startLine": 7,
+                                "startTokenPos": 101,
+                                "startFilePos": 186,
+                                "endLine": 7,
+                                "endTokenPos": 101,
+                                "endFilePos": 187
+                              },
+                              "name": "j"
+                            },
+                            "byRef": false,
+                            "unpack": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "elseifs": [],
+                  "else": null
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "nodeType": "Stmt_Return",
+          "attributes": {
+            "startLine": 11,
+            "startTokenPos": 113,
+            "startFilePos": 201,
+            "endLine": 11,
+            "endTokenPos": 123,
+            "endFilePos": 216
+          },
+          "expr": {
+            "nodeType": "Expr_Array",
+            "attributes": {
+              "startLine": 11,
+              "startTokenPos": 115,
+              "startFilePos": 208,
+              "endLine": 11,
+              "endTokenPos": 122,
+              "endFilePos": 215,
+              "kind": 2
+            },
+            "items": [
+              {
+                "nodeType": "ArrayItem",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 116,
+                  "startFilePos": 209,
+                  "endLine": 11,
+                  "endTokenPos": 117,
+                  "endFilePos": 210
+                },
+                "key": null,
+                "value": {
+                  "nodeType": "Expr_UnaryMinus",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 116,
+                    "startFilePos": 209,
+                    "endLine": 11,
+                    "endTokenPos": 117,
+                    "endFilePos": 210
+                  },
+                  "expr": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 117,
+                      "startFilePos": 210,
+                      "endLine": 11,
+                      "endTokenPos": 117,
+                      "endFilePos": 210,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "ArrayItem",
+                "attributes": {
+                  "startLine": 11,
+                  "startTokenPos": 120,
+                  "startFilePos": 213,
+                  "endLine": 11,
+                  "endTokenPos": 121,
+                  "endFilePos": 214
+                },
+                "key": null,
+                "value": {
+                  "nodeType": "Expr_UnaryMinus",
+                  "attributes": {
+                    "startLine": 11,
+                    "startTokenPos": 120,
+                    "startFilePos": 213,
+                    "endLine": 11,
+                    "endTokenPos": 121,
+                    "endFilePos": 214
+                  },
+                  "expr": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 11,
+                      "startTokenPos": 121,
+                      "startFilePos": 214,
+                      "endLine": 11,
+                      "endTokenPos": 121,
+                      "endFilePos": 214,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          }
+        }
+      ],
+      "attrGroups": []
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 13,
+        "startTokenPos": 127,
+        "startFilePos": 220,
+        "endLine": 13,
+        "endTokenPos": 149,
+        "endFilePos": 255
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 13,
+          "startTokenPos": 127,
+          "startFilePos": 220,
+          "endLine": 13,
+          "endTokenPos": 148,
+          "endFilePos": 254
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 127,
+            "startFilePos": 220,
+            "endLine": 13,
+            "endTokenPos": 127,
+            "endFilePos": 226
+          },
+          "name": "result"
+        },
+        "expr": {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 13,
+            "startTokenPos": 131,
+            "startFilePos": 230,
+            "endLine": 13,
+            "endTokenPos": 148,
+            "endFilePos": 254
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 13,
+              "startTokenPos": 131,
+              "startFilePos": 230,
+              "endLine": 13,
+              "endTokenPos": 131,
+              "endFilePos": 235
+            },
+            "name": "twoSum"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 133,
+                "startFilePos": 237,
+                "endLine": 13,
+                "endTokenPos": 144,
+                "endFilePos": 250
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 133,
+                  "startFilePos": 237,
+                  "endLine": 13,
+                  "endTokenPos": 144,
+                  "endFilePos": 250,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 134,
+                      "startFilePos": 238,
+                      "endLine": 13,
+                      "endTokenPos": 134,
+                      "endFilePos": 238
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 134,
+                        "startFilePos": 238,
+                        "endLine": 13,
+                        "endTokenPos": 134,
+                        "endFilePos": 238,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 137,
+                      "startFilePos": 241,
+                      "endLine": 13,
+                      "endTokenPos": 137,
+                      "endFilePos": 241
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 137,
+                        "startFilePos": 241,
+                        "endLine": 13,
+                        "endTokenPos": 137,
+                        "endFilePos": 241,
+                        "rawValue": "7",
+                        "kind": 10
+                      },
+                      "value": 7
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 140,
+                      "startFilePos": 244,
+                      "endLine": 13,
+                      "endTokenPos": 140,
+                      "endFilePos": 245
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 140,
+                        "startFilePos": 244,
+                        "endLine": 13,
+                        "endTokenPos": 140,
+                        "endFilePos": 245,
+                        "rawValue": "11",
+                        "kind": 10
+                      },
+                      "value": 11
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 13,
+                      "startTokenPos": 143,
+                      "startFilePos": 248,
+                      "endLine": 13,
+                      "endTokenPos": 143,
+                      "endFilePos": 249
+                    },
+                    "key": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 13,
+                        "startTokenPos": 143,
+                        "startFilePos": 248,
+                        "endLine": 13,
+                        "endTokenPos": 143,
+                        "endFilePos": 249,
+                        "rawValue": "15",
+                        "kind": 10
+                      },
+                      "value": 15
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 13,
+                "startTokenPos": 147,
+                "startFilePos": 253,
+                "endLine": 13,
+                "endTokenPos": 147,
+                "endFilePos": 253
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 13,
+                  "startTokenPos": 147,
+                  "startFilePos": 253,
+                  "endLine": 13,
+                  "endTokenPos": 147,
+                  "endFilePos": 253,
+                  "rawValue": "9",
+                  "kind": 10
+                },
+                "value": 9
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 14,
+        "startTokenPos": 151,
+        "startFilePos": 257,
+        "endLine": 14,
+        "endTokenPos": 185,
+        "endFilePos": 338
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 154,
+            "startFilePos": 263,
+            "endLine": 14,
+            "endTokenPos": 180,
+            "endFilePos": 327
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 154,
+              "startFilePos": 263,
+              "endLine": 14,
+              "endTokenPos": 160,
+              "endFilePos": 282
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 154,
+                "startFilePos": 263,
+                "endLine": 14,
+                "endTokenPos": 154,
+                "endFilePos": 270
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 156,
+                  "startFilePos": 272,
+                  "endLine": 14,
+                  "endTokenPos": 159,
+                  "endFilePos": 281
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 156,
+                    "startFilePos": 272,
+                    "endLine": 14,
+                    "endTokenPos": 159,
+                    "endFilePos": 281
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 156,
+                      "startFilePos": 272,
+                      "endLine": 14,
+                      "endTokenPos": 156,
+                      "endFilePos": 278
+                    },
+                    "name": "result"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 158,
+                      "startFilePos": 280,
+                      "endLine": 14,
+                      "endTokenPos": 158,
+                      "endFilePos": 280,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 164,
+              "startFilePos": 286,
+              "endLine": 14,
+              "endTokenPos": 173,
+              "endFilePos": 314
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 164,
+                "startFilePos": 286,
+                "endLine": 14,
+                "endTokenPos": 164,
+                "endFilePos": 296
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 166,
+                  "startFilePos": 298,
+                  "endLine": 14,
+                  "endTokenPos": 169,
+                  "endFilePos": 307
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 166,
+                    "startFilePos": 298,
+                    "endLine": 14,
+                    "endTokenPos": 169,
+                    "endFilePos": 307
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 166,
+                      "startFilePos": 298,
+                      "endLine": 14,
+                      "endTokenPos": 166,
+                      "endFilePos": 304
+                    },
+                    "name": "result"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 14,
+                      "startTokenPos": 168,
+                      "startFilePos": 306,
+                      "endLine": 14,
+                      "endTokenPos": 168,
+                      "endFilePos": 306,
+                      "rawValue": "0",
+                      "kind": 10
+                    },
+                    "value": 0
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 14,
+                  "startTokenPos": 172,
+                  "startFilePos": 310,
+                  "endLine": 14,
+                  "endTokenPos": 172,
+                  "endFilePos": 313
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 14,
+                    "startTokenPos": 172,
+                    "startFilePos": 310,
+                    "endLine": 14,
+                    "endTokenPos": 172,
+                    "endFilePos": 313,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 177,
+              "startFilePos": 318,
+              "endLine": 14,
+              "endTokenPos": 180,
+              "endFilePos": 327
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 177,
+                "startFilePos": 318,
+                "endLine": 14,
+                "endTokenPos": 177,
+                "endFilePos": 324
+              },
+              "name": "result"
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 14,
+                "startTokenPos": 179,
+                "startFilePos": 326,
+                "endLine": 14,
+                "endTokenPos": 179,
+                "endFilePos": 326,
+                "rawValue": "0",
+                "kind": 10
+              },
+              "value": 0
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 14,
+            "startTokenPos": 184,
+            "startFilePos": 331,
+            "endLine": 14,
+            "endTokenPos": 184,
+            "endFilePos": 337
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 14,
+              "startTokenPos": 184,
+              "startFilePos": 331,
+              "endLine": 14,
+              "endTokenPos": 184,
+              "endFilePos": 337
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 15,
+        "startTokenPos": 187,
+        "startFilePos": 340,
+        "endLine": 15,
+        "endTokenPos": 221,
+        "endFilePos": 421
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 190,
+            "startFilePos": 346,
+            "endLine": 15,
+            "endTokenPos": 216,
+            "endFilePos": 410
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 15,
+              "startTokenPos": 190,
+              "startFilePos": 346,
+              "endLine": 15,
+              "endTokenPos": 196,
+              "endFilePos": 365
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 190,
+                "startFilePos": 346,
+                "endLine": 15,
+                "endTokenPos": 190,
+                "endFilePos": 353
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 192,
+                  "startFilePos": 355,
+                  "endLine": 15,
+                  "endTokenPos": 195,
+                  "endFilePos": 364
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 192,
+                    "startFilePos": 355,
+                    "endLine": 15,
+                    "endTokenPos": 195,
+                    "endFilePos": 364
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 192,
+                      "startFilePos": 355,
+                      "endLine": 15,
+                      "endTokenPos": 192,
+                      "endFilePos": 361
+                    },
+                    "name": "result"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 194,
+                      "startFilePos": 363,
+                      "endLine": 15,
+                      "endTokenPos": 194,
+                      "endFilePos": 363,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 15,
+              "startTokenPos": 200,
+              "startFilePos": 369,
+              "endLine": 15,
+              "endTokenPos": 209,
+              "endFilePos": 397
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 200,
+                "startFilePos": 369,
+                "endLine": 15,
+                "endTokenPos": 200,
+                "endFilePos": 379
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 202,
+                  "startFilePos": 381,
+                  "endLine": 15,
+                  "endTokenPos": 205,
+                  "endFilePos": 390
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 202,
+                    "startFilePos": 381,
+                    "endLine": 15,
+                    "endTokenPos": 205,
+                    "endFilePos": 390
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 202,
+                      "startFilePos": 381,
+                      "endLine": 15,
+                      "endTokenPos": 202,
+                      "endFilePos": 387
+                    },
+                    "name": "result"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 15,
+                      "startTokenPos": 204,
+                      "startFilePos": 389,
+                      "endLine": 15,
+                      "endTokenPos": 204,
+                      "endFilePos": 389,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 15,
+                  "startTokenPos": 208,
+                  "startFilePos": 393,
+                  "endLine": 15,
+                  "endTokenPos": 208,
+                  "endFilePos": 396
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 15,
+                    "startTokenPos": 208,
+                    "startFilePos": 393,
+                    "endLine": 15,
+                    "endTokenPos": 208,
+                    "endFilePos": 396,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 15,
+              "startTokenPos": 213,
+              "startFilePos": 401,
+              "endLine": 15,
+              "endTokenPos": 216,
+              "endFilePos": 410
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 213,
+                "startFilePos": 401,
+                "endLine": 15,
+                "endTokenPos": 213,
+                "endFilePos": 407
+              },
+              "name": "result"
+            },
+            "dim": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 15,
+                "startTokenPos": 215,
+                "startFilePos": 409,
+                "endLine": 15,
+                "endTokenPos": 215,
+                "endFilePos": 409,
+                "rawValue": "1",
+                "kind": 10
+              },
+              "value": 1
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 15,
+            "startTokenPos": 220,
+            "startFilePos": 414,
+            "endLine": 15,
+            "endTokenPos": 220,
+            "endFilePos": 420
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 15,
+              "startTokenPos": 220,
+              "startFilePos": 414,
+              "endLine": 15,
+              "endTokenPos": 220,
+              "endFilePos": 420
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/typed_let.php.json
+++ b/tests/json-ast/x/php/typed_let.php.json
@@ -1,0 +1,241 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "y"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "0",
+            "kind": 10
+          },
+          "value": 0
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 3,
+        "endTokenPos": 33,
+        "endFilePos": 71
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 20,
+            "endLine": 3,
+            "endTokenPos": 28,
+            "endFilePos": 60
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 11,
+              "startFilePos": 20,
+              "endLine": 3,
+              "endTokenPos": 14,
+              "endFilePos": 31
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 11,
+                "startFilePos": 20,
+                "endLine": 3,
+                "endTokenPos": 11,
+                "endFilePos": 27
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 13,
+                  "startFilePos": 29,
+                  "endLine": 3,
+                  "endTokenPos": 13,
+                  "endFilePos": 30
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 13,
+                    "startFilePos": 29,
+                    "endLine": 3,
+                    "endTokenPos": 13,
+                    "endFilePos": 30
+                  },
+                  "name": "y"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 18,
+              "startFilePos": 35,
+              "endLine": 3,
+              "endTokenPos": 24,
+              "endFilePos": 55
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 18,
+                "startFilePos": 35,
+                "endLine": 3,
+                "endTokenPos": 18,
+                "endFilePos": 45
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 20,
+                  "startFilePos": 47,
+                  "endLine": 3,
+                  "endTokenPos": 20,
+                  "endFilePos": 48
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 20,
+                    "startFilePos": 47,
+                    "endLine": 3,
+                    "endTokenPos": 20,
+                    "endFilePos": 48
+                  },
+                  "name": "y"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 23,
+                  "startFilePos": 51,
+                  "endLine": 3,
+                  "endTokenPos": 23,
+                  "endFilePos": 54
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 23,
+                    "startFilePos": 51,
+                    "endLine": 3,
+                    "endTokenPos": 23,
+                    "endFilePos": 54,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 28,
+              "startFilePos": 59,
+              "endLine": 3,
+              "endTokenPos": 28,
+              "endFilePos": 60
+            },
+            "name": "y"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 32,
+            "startFilePos": 64,
+            "endLine": 3,
+            "endTokenPos": 32,
+            "endFilePos": 70
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 32,
+              "startFilePos": 64,
+              "endLine": 3,
+              "endTokenPos": 32,
+              "endFilePos": 70
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/typed_var.php.json
+++ b/tests/json-ast/x/php/typed_var.php.json
@@ -1,0 +1,241 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "0",
+            "kind": 10
+          },
+          "value": 0
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 3,
+        "endTokenPos": 33,
+        "endFilePos": 71
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 20,
+            "endLine": 3,
+            "endTokenPos": 28,
+            "endFilePos": 60
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 11,
+              "startFilePos": 20,
+              "endLine": 3,
+              "endTokenPos": 14,
+              "endFilePos": 31
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 11,
+                "startFilePos": 20,
+                "endLine": 3,
+                "endTokenPos": 11,
+                "endFilePos": 27
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 13,
+                  "startFilePos": 29,
+                  "endLine": 3,
+                  "endTokenPos": 13,
+                  "endFilePos": 30
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 13,
+                    "startFilePos": 29,
+                    "endLine": 3,
+                    "endTokenPos": 13,
+                    "endFilePos": 30
+                  },
+                  "name": "x"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 18,
+              "startFilePos": 35,
+              "endLine": 3,
+              "endTokenPos": 24,
+              "endFilePos": 55
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 18,
+                "startFilePos": 35,
+                "endLine": 3,
+                "endTokenPos": 18,
+                "endFilePos": 45
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 20,
+                  "startFilePos": 47,
+                  "endLine": 3,
+                  "endTokenPos": 20,
+                  "endFilePos": 48
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 20,
+                    "startFilePos": 47,
+                    "endLine": 3,
+                    "endTokenPos": 20,
+                    "endFilePos": 48
+                  },
+                  "name": "x"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 23,
+                  "startFilePos": 51,
+                  "endLine": 3,
+                  "endTokenPos": 23,
+                  "endFilePos": 54
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 23,
+                    "startFilePos": 51,
+                    "endLine": 3,
+                    "endTokenPos": 23,
+                    "endFilePos": 54,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 28,
+              "startFilePos": 59,
+              "endLine": 3,
+              "endTokenPos": 28,
+              "endFilePos": 60
+            },
+            "name": "x"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 32,
+            "startFilePos": 64,
+            "endLine": 3,
+            "endTokenPos": 32,
+            "endFilePos": 70
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 32,
+              "startFilePos": 64,
+              "endLine": 3,
+              "endTokenPos": 32,
+              "endFilePos": 70
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/unary_neg.php.json
+++ b/tests/json-ast/x/php/unary_neg.php.json
@@ -1,0 +1,535 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 29,
+        "endFilePos": 63
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 4,
+            "startFilePos": 12,
+            "endLine": 2,
+            "endTokenPos": 24,
+            "endFilePos": 52
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 4,
+              "startFilePos": 12,
+              "endLine": 2,
+              "endTokenPos": 8,
+              "endFilePos": 23
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 4,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 4,
+                "endFilePos": 19
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 21,
+                  "endLine": 2,
+                  "endTokenPos": 7,
+                  "endFilePos": 22
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_UnaryMinus",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 6,
+                    "startFilePos": 21,
+                    "endLine": 2,
+                    "endTokenPos": 7,
+                    "endFilePos": 22
+                  },
+                  "expr": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 22,
+                      "endLine": 2,
+                      "endTokenPos": 7,
+                      "endFilePos": 22,
+                      "rawValue": "3",
+                      "kind": 10
+                    },
+                    "value": 3
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 12,
+              "startFilePos": 27,
+              "endLine": 2,
+              "endTokenPos": 19,
+              "endFilePos": 47
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 12,
+                "startFilePos": 27,
+                "endLine": 2,
+                "endTokenPos": 12,
+                "endFilePos": 37
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 14,
+                  "startFilePos": 39,
+                  "endLine": 2,
+                  "endTokenPos": 15,
+                  "endFilePos": 40
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_UnaryMinus",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 14,
+                    "startFilePos": 39,
+                    "endLine": 2,
+                    "endTokenPos": 15,
+                    "endFilePos": 40
+                  },
+                  "expr": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 15,
+                      "startFilePos": 40,
+                      "endLine": 2,
+                      "endTokenPos": 15,
+                      "endFilePos": 40,
+                      "rawValue": "3",
+                      "kind": 10
+                    },
+                    "value": 3
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 18,
+                  "startFilePos": 43,
+                  "endLine": 2,
+                  "endTokenPos": 18,
+                  "endFilePos": 46
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 2,
+                    "startTokenPos": 18,
+                    "startFilePos": 43,
+                    "endLine": 2,
+                    "endTokenPos": 18,
+                    "endFilePos": 46,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_UnaryMinus",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 23,
+              "startFilePos": 51,
+              "endLine": 2,
+              "endTokenPos": 24,
+              "endFilePos": 52
+            },
+            "expr": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 24,
+                "startFilePos": 52,
+                "endLine": 2,
+                "endTokenPos": 24,
+                "endFilePos": 52,
+                "rawValue": "3",
+                "kind": 10
+              },
+              "value": 3
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 28,
+            "startFilePos": 56,
+            "endLine": 2,
+            "endTokenPos": 28,
+            "endFilePos": 62
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 2,
+              "startTokenPos": 28,
+              "startFilePos": 56,
+              "endLine": 2,
+              "endTokenPos": 28,
+              "endFilePos": 62
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 31,
+        "startFilePos": 65,
+        "endLine": 3,
+        "endTokenPos": 77,
+        "endFilePos": 140
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 34,
+            "startFilePos": 71,
+            "endLine": 3,
+            "endTokenPos": 72,
+            "endFilePos": 129
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 34,
+              "startFilePos": 71,
+              "endLine": 3,
+              "endTokenPos": 44,
+              "endFilePos": 88
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 34,
+                "startFilePos": 71,
+                "endLine": 3,
+                "endTokenPos": 34,
+                "endFilePos": 78
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 36,
+                  "startFilePos": 80,
+                  "endLine": 3,
+                  "endTokenPos": 43,
+                  "endFilePos": 87
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 36,
+                    "startFilePos": 80,
+                    "endLine": 3,
+                    "endTokenPos": 43,
+                    "endFilePos": 87
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 36,
+                      "startFilePos": 80,
+                      "endLine": 3,
+                      "endTokenPos": 36,
+                      "endFilePos": 80,
+                      "rawValue": "5",
+                      "kind": 10
+                    },
+                    "value": 5
+                  },
+                  "right": {
+                    "nodeType": "Expr_UnaryMinus",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 41,
+                      "startFilePos": 85,
+                      "endLine": 3,
+                      "endTokenPos": 42,
+                      "endFilePos": 86
+                    },
+                    "expr": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 42,
+                        "startFilePos": 86,
+                        "endLine": 3,
+                        "endTokenPos": 42,
+                        "endFilePos": 86,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    }
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 48,
+              "startFilePos": 92,
+              "endLine": 3,
+              "endTokenPos": 61,
+              "endFilePos": 118
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 48,
+                "startFilePos": 92,
+                "endLine": 3,
+                "endTokenPos": 48,
+                "endFilePos": 102
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 50,
+                  "startFilePos": 104,
+                  "endLine": 3,
+                  "endTokenPos": 57,
+                  "endFilePos": 111
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 50,
+                    "startFilePos": 104,
+                    "endLine": 3,
+                    "endTokenPos": 57,
+                    "endFilePos": 111
+                  },
+                  "left": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 50,
+                      "startFilePos": 104,
+                      "endLine": 3,
+                      "endTokenPos": 50,
+                      "endFilePos": 104,
+                      "rawValue": "5",
+                      "kind": 10
+                    },
+                    "value": 5
+                  },
+                  "right": {
+                    "nodeType": "Expr_UnaryMinus",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 55,
+                      "startFilePos": 109,
+                      "endLine": 3,
+                      "endTokenPos": 56,
+                      "endFilePos": 110
+                    },
+                    "expr": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 56,
+                        "startFilePos": 110,
+                        "endLine": 3,
+                        "endTokenPos": 56,
+                        "endFilePos": 110,
+                        "rawValue": "2",
+                        "kind": 10
+                      },
+                      "value": 2
+                    }
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 60,
+                  "startFilePos": 114,
+                  "endLine": 3,
+                  "endTokenPos": 60,
+                  "endFilePos": 117
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 60,
+                    "startFilePos": 114,
+                    "endLine": 3,
+                    "endTokenPos": 60,
+                    "endFilePos": 117,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_BinaryOp_Plus",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 65,
+              "startFilePos": 122,
+              "endLine": 3,
+              "endTokenPos": 72,
+              "endFilePos": 129
+            },
+            "left": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 65,
+                "startFilePos": 122,
+                "endLine": 3,
+                "endTokenPos": 65,
+                "endFilePos": 122,
+                "rawValue": "5",
+                "kind": 10
+              },
+              "value": 5
+            },
+            "right": {
+              "nodeType": "Expr_UnaryMinus",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 70,
+                "startFilePos": 127,
+                "endLine": 3,
+                "endTokenPos": 71,
+                "endFilePos": 128
+              },
+              "expr": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 71,
+                  "startFilePos": 128,
+                  "endLine": 3,
+                  "endTokenPos": 71,
+                  "endFilePos": 128,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              }
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 76,
+            "startFilePos": 133,
+            "endLine": 3,
+            "endTokenPos": 76,
+            "endFilePos": 139
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 76,
+              "startFilePos": 133,
+              "endLine": 3,
+              "endTokenPos": 76,
+              "endFilePos": 139
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/update_stmt.php.json
+++ b/tests/json-ast/x/php/update_stmt.php.json
@@ -1,0 +1,1096 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 97,
+        "endFilePos": 240
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 96,
+          "endFilePos": 239
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 12
+          },
+          "name": "people"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 16,
+            "endLine": 2,
+            "endTokenPos": 96,
+            "endFilePos": 239,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 17,
+                "endLine": 2,
+                "endTokenPos": 26,
+                "endFilePos": 69
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 17,
+                  "endLine": 2,
+                  "endTokenPos": 26,
+                  "endFilePos": 69,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 7,
+                      "startFilePos": 18,
+                      "endLine": 2,
+                      "endTokenPos": 11,
+                      "endFilePos": 34
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 7,
+                        "startFilePos": 18,
+                        "endLine": 2,
+                        "endTokenPos": 7,
+                        "endFilePos": 23,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 11,
+                        "startFilePos": 28,
+                        "endLine": 2,
+                        "endTokenPos": 11,
+                        "endFilePos": 34,
+                        "kind": 2,
+                        "rawValue": "\"Alice\""
+                      },
+                      "value": "Alice"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 14,
+                      "startFilePos": 37,
+                      "endLine": 2,
+                      "endTokenPos": 18,
+                      "endFilePos": 47
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 14,
+                        "startFilePos": 37,
+                        "endLine": 2,
+                        "endTokenPos": 14,
+                        "endFilePos": 41,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 46,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 47,
+                        "rawValue": "17",
+                        "kind": 10
+                      },
+                      "value": 17
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 21,
+                      "startFilePos": 50,
+                      "endLine": 2,
+                      "endTokenPos": 25,
+                      "endFilePos": 68
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 21,
+                        "startFilePos": 50,
+                        "endLine": 2,
+                        "endTokenPos": 21,
+                        "endFilePos": 57,
+                        "kind": 2,
+                        "rawValue": "\"status\""
+                      },
+                      "value": "status"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 62,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 68,
+                        "kind": 2,
+                        "rawValue": "\"minor\""
+                      },
+                      "value": "minor"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 29,
+                "startFilePos": 72,
+                "endLine": 2,
+                "endTokenPos": 49,
+                "endFilePos": 124
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 29,
+                  "startFilePos": 72,
+                  "endLine": 2,
+                  "endTokenPos": 49,
+                  "endFilePos": 124,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 30,
+                      "startFilePos": 73,
+                      "endLine": 2,
+                      "endTokenPos": 34,
+                      "endFilePos": 87
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 30,
+                        "startFilePos": 73,
+                        "endLine": 2,
+                        "endTokenPos": 30,
+                        "endFilePos": 78,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 34,
+                        "startFilePos": 83,
+                        "endLine": 2,
+                        "endTokenPos": 34,
+                        "endFilePos": 87,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 37,
+                      "startFilePos": 90,
+                      "endLine": 2,
+                      "endTokenPos": 41,
+                      "endFilePos": 100
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 37,
+                        "startFilePos": 90,
+                        "endLine": 2,
+                        "endTokenPos": 37,
+                        "endFilePos": 94,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 41,
+                        "startFilePos": 99,
+                        "endLine": 2,
+                        "endTokenPos": 41,
+                        "endFilePos": 100,
+                        "rawValue": "25",
+                        "kind": 10
+                      },
+                      "value": 25
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 44,
+                      "startFilePos": 103,
+                      "endLine": 2,
+                      "endTokenPos": 48,
+                      "endFilePos": 123
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 44,
+                        "startFilePos": 103,
+                        "endLine": 2,
+                        "endTokenPos": 44,
+                        "endFilePos": 110,
+                        "kind": 2,
+                        "rawValue": "\"status\""
+                      },
+                      "value": "status"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 48,
+                        "startFilePos": 115,
+                        "endLine": 2,
+                        "endTokenPos": 48,
+                        "endFilePos": 123,
+                        "kind": 2,
+                        "rawValue": "\"unknown\""
+                      },
+                      "value": "unknown"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 52,
+                "startFilePos": 127,
+                "endLine": 2,
+                "endTokenPos": 72,
+                "endFilePos": 183
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 52,
+                  "startFilePos": 127,
+                  "endLine": 2,
+                  "endTokenPos": 72,
+                  "endFilePos": 183,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 53,
+                      "startFilePos": 128,
+                      "endLine": 2,
+                      "endTokenPos": 57,
+                      "endFilePos": 146
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 53,
+                        "startFilePos": 128,
+                        "endLine": 2,
+                        "endTokenPos": 53,
+                        "endFilePos": 133,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 57,
+                        "startFilePos": 138,
+                        "endLine": 2,
+                        "endTokenPos": 57,
+                        "endFilePos": 146,
+                        "kind": 2,
+                        "rawValue": "\"Charlie\""
+                      },
+                      "value": "Charlie"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 60,
+                      "startFilePos": 149,
+                      "endLine": 2,
+                      "endTokenPos": 64,
+                      "endFilePos": 159
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 60,
+                        "startFilePos": 149,
+                        "endLine": 2,
+                        "endTokenPos": 60,
+                        "endFilePos": 153,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 64,
+                        "startFilePos": 158,
+                        "endLine": 2,
+                        "endTokenPos": 64,
+                        "endFilePos": 159,
+                        "rawValue": "18",
+                        "kind": 10
+                      },
+                      "value": 18
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 67,
+                      "startFilePos": 162,
+                      "endLine": 2,
+                      "endTokenPos": 71,
+                      "endFilePos": 182
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 67,
+                        "startFilePos": 162,
+                        "endLine": 2,
+                        "endTokenPos": 67,
+                        "endFilePos": 169,
+                        "kind": 2,
+                        "rawValue": "\"status\""
+                      },
+                      "value": "status"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 71,
+                        "startFilePos": 174,
+                        "endLine": 2,
+                        "endTokenPos": 71,
+                        "endFilePos": 182,
+                        "kind": 2,
+                        "rawValue": "\"unknown\""
+                      },
+                      "value": "unknown"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 75,
+                "startFilePos": 186,
+                "endLine": 2,
+                "endTokenPos": 95,
+                "endFilePos": 238
+              },
+              "key": null,
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 75,
+                  "startFilePos": 186,
+                  "endLine": 2,
+                  "endTokenPos": 95,
+                  "endFilePos": 238,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 76,
+                      "startFilePos": 187,
+                      "endLine": 2,
+                      "endTokenPos": 80,
+                      "endFilePos": 203
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 76,
+                        "startFilePos": 187,
+                        "endLine": 2,
+                        "endTokenPos": 76,
+                        "endFilePos": 192,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 80,
+                        "startFilePos": 197,
+                        "endLine": 2,
+                        "endTokenPos": 80,
+                        "endFilePos": 203,
+                        "kind": 2,
+                        "rawValue": "\"Diana\""
+                      },
+                      "value": "Diana"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 83,
+                      "startFilePos": 206,
+                      "endLine": 2,
+                      "endTokenPos": 87,
+                      "endFilePos": 216
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 83,
+                        "startFilePos": 206,
+                        "endLine": 2,
+                        "endTokenPos": 83,
+                        "endFilePos": 210,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 87,
+                        "startFilePos": 215,
+                        "endLine": 2,
+                        "endTokenPos": 87,
+                        "endFilePos": 216,
+                        "rawValue": "16",
+                        "kind": 10
+                      },
+                      "value": 16
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 90,
+                      "startFilePos": 219,
+                      "endLine": 2,
+                      "endTokenPos": 94,
+                      "endFilePos": 237
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 90,
+                        "startFilePos": 219,
+                        "endLine": 2,
+                        "endTokenPos": 90,
+                        "endFilePos": 226,
+                        "kind": 2,
+                        "rawValue": "\"status\""
+                      },
+                      "value": "status"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 94,
+                        "startFilePos": 231,
+                        "endLine": 2,
+                        "endTokenPos": 94,
+                        "endFilePos": 237,
+                        "kind": 2,
+                        "rawValue": "\"minor\""
+                      },
+                      "value": "minor"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Foreach",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 99,
+        "startFilePos": 242,
+        "endLine": 9,
+        "endTokenPos": 169,
+        "endFilePos": 404
+      },
+      "expr": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 102,
+          "startFilePos": 251,
+          "endLine": 3,
+          "endTokenPos": 102,
+          "endFilePos": 257
+        },
+        "name": "people"
+      },
+      "keyVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 106,
+          "startFilePos": 262,
+          "endLine": 3,
+          "endTokenPos": 106,
+          "endFilePos": 265
+        },
+        "name": "idx"
+      },
+      "byRef": false,
+      "valueVar": {
+        "nodeType": "Expr_Variable",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 110,
+          "startFilePos": 270,
+          "endLine": 3,
+          "endTokenPos": 110,
+          "endFilePos": 274
+        },
+        "name": "item"
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_If",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 115,
+            "startFilePos": 281,
+            "endLine": 7,
+            "endTokenPos": 157,
+            "endFilePos": 377
+          },
+          "cond": {
+            "nodeType": "Expr_BinaryOp_GreaterOrEqual",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 118,
+              "startFilePos": 285,
+              "endLine": 4,
+              "endTokenPos": 125,
+              "endFilePos": 302
+            },
+            "left": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 118,
+                "startFilePos": 285,
+                "endLine": 4,
+                "endTokenPos": 121,
+                "endFilePos": 296
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 118,
+                  "startFilePos": 285,
+                  "endLine": 4,
+                  "endTokenPos": 118,
+                  "endFilePos": 289
+                },
+                "name": "item"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 120,
+                  "startFilePos": 291,
+                  "endLine": 4,
+                  "endTokenPos": 120,
+                  "endFilePos": 295,
+                  "kind": 2,
+                  "rawValue": "\"age\""
+                },
+                "value": "age"
+              }
+            },
+            "right": {
+              "nodeType": "Scalar_Int",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 125,
+                "startFilePos": 301,
+                "endLine": 4,
+                "endTokenPos": 125,
+                "endFilePos": 302,
+                "rawValue": "18",
+                "kind": 10
+              },
+              "value": 18
+            }
+          },
+          "stmts": [
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 130,
+                "startFilePos": 311,
+                "endLine": 5,
+                "endTokenPos": 138,
+                "endFilePos": 336
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 130,
+                  "startFilePos": 311,
+                  "endLine": 5,
+                  "endTokenPos": 137,
+                  "endFilePos": 335
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 130,
+                    "startFilePos": 311,
+                    "endLine": 5,
+                    "endTokenPos": 133,
+                    "endFilePos": 325
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 130,
+                      "startFilePos": 311,
+                      "endLine": 5,
+                      "endTokenPos": 130,
+                      "endFilePos": 315
+                    },
+                    "name": "item"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 5,
+                      "startTokenPos": 132,
+                      "startFilePos": 317,
+                      "endLine": 5,
+                      "endTokenPos": 132,
+                      "endFilePos": 324,
+                      "kind": 1,
+                      "rawValue": "'status'"
+                    },
+                    "value": "status"
+                  }
+                },
+                "expr": {
+                  "nodeType": "Scalar_String",
+                  "attributes": {
+                    "startLine": 5,
+                    "startTokenPos": 137,
+                    "startFilePos": 329,
+                    "endLine": 5,
+                    "endTokenPos": 137,
+                    "endFilePos": 335,
+                    "kind": 2,
+                    "rawValue": "\"adult\""
+                  },
+                  "value": "adult"
+                }
+              }
+            },
+            {
+              "nodeType": "Stmt_Expression",
+              "attributes": {
+                "startLine": 6,
+                "startTokenPos": 140,
+                "startFilePos": 342,
+                "endLine": 6,
+                "endTokenPos": 155,
+                "endFilePos": 373
+              },
+              "expr": {
+                "nodeType": "Expr_Assign",
+                "attributes": {
+                  "startLine": 6,
+                  "startTokenPos": 140,
+                  "startFilePos": 342,
+                  "endLine": 6,
+                  "endTokenPos": 154,
+                  "endFilePos": 372
+                },
+                "var": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 140,
+                    "startFilePos": 342,
+                    "endLine": 6,
+                    "endTokenPos": 143,
+                    "endFilePos": 353
+                  },
+                  "var": {
+                    "nodeType": "Expr_Variable",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 140,
+                      "startFilePos": 342,
+                      "endLine": 6,
+                      "endTokenPos": 140,
+                      "endFilePos": 346
+                    },
+                    "name": "item"
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 142,
+                      "startFilePos": 348,
+                      "endLine": 6,
+                      "endTokenPos": 142,
+                      "endFilePos": 352,
+                      "kind": 1,
+                      "rawValue": "'age'"
+                    },
+                    "value": "age"
+                  }
+                },
+                "expr": {
+                  "nodeType": "Expr_BinaryOp_Plus",
+                  "attributes": {
+                    "startLine": 6,
+                    "startTokenPos": 147,
+                    "startFilePos": 357,
+                    "endLine": 6,
+                    "endTokenPos": 154,
+                    "endFilePos": 372
+                  },
+                  "left": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 147,
+                      "startFilePos": 357,
+                      "endLine": 6,
+                      "endTokenPos": 150,
+                      "endFilePos": 368
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 147,
+                        "startFilePos": 357,
+                        "endLine": 6,
+                        "endTokenPos": 147,
+                        "endFilePos": 361
+                      },
+                      "name": "item"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 6,
+                        "startTokenPos": 149,
+                        "startFilePos": 363,
+                        "endLine": 6,
+                        "endTokenPos": 149,
+                        "endFilePos": 367,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    }
+                  },
+                  "right": {
+                    "nodeType": "Scalar_Int",
+                    "attributes": {
+                      "startLine": 6,
+                      "startTokenPos": 154,
+                      "startFilePos": 372,
+                      "endLine": 6,
+                      "endTokenPos": 154,
+                      "endFilePos": 372,
+                      "rawValue": "1",
+                      "kind": 10
+                    },
+                    "value": 1
+                  }
+                }
+              }
+            }
+          ],
+          "elseifs": [],
+          "else": null
+        },
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 8,
+            "startTokenPos": 159,
+            "startFilePos": 381,
+            "endLine": 8,
+            "endTokenPos": 167,
+            "endFilePos": 402
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 8,
+              "startTokenPos": 159,
+              "startFilePos": 381,
+              "endLine": 8,
+              "endTokenPos": 166,
+              "endFilePos": 401
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 159,
+                "startFilePos": 381,
+                "endLine": 8,
+                "endTokenPos": 162,
+                "endFilePos": 393
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 159,
+                  "startFilePos": 381,
+                  "endLine": 8,
+                  "endTokenPos": 159,
+                  "endFilePos": 387
+                },
+                "name": "people"
+              },
+              "dim": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 8,
+                  "startTokenPos": 161,
+                  "startFilePos": 389,
+                  "endLine": 8,
+                  "endTokenPos": 161,
+                  "endFilePos": 392
+                },
+                "name": "idx"
+              }
+            },
+            "expr": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 8,
+                "startTokenPos": 166,
+                "startFilePos": 397,
+                "endLine": 8,
+                "endTokenPos": 166,
+                "endFilePos": 401
+              },
+              "name": "item"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 10,
+        "startTokenPos": 172,
+        "startFilePos": 407,
+        "endLine": 10,
+        "endTokenPos": 178,
+        "endFilePos": 425
+      },
+      "exprs": [
+        {
+          "nodeType": "Scalar_String",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 174,
+            "startFilePos": 412,
+            "endLine": 10,
+            "endTokenPos": 174,
+            "endFilePos": 415,
+            "kind": 2,
+            "rawValue": "\"ok\""
+          },
+          "value": "ok"
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 10,
+            "startTokenPos": 177,
+            "startFilePos": 418,
+            "endLine": 10,
+            "endTokenPos": 177,
+            "endFilePos": 424
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 10,
+              "startTokenPos": 177,
+              "startFilePos": 418,
+              "endLine": 10,
+              "endTokenPos": 177,
+              "endFilePos": 424
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/user_type_literal.php.json
+++ b/tests/json-ast/x/php/user_type_literal.php.json
@@ -1,0 +1,555 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 32,
+        "endFilePos": 75
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 31,
+          "endFilePos": 74
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 10
+          },
+          "name": "book"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 14,
+            "endLine": 2,
+            "endTokenPos": 31,
+            "endFilePos": 74,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 15,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 15,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 21,
+                  "kind": 2,
+                  "rawValue": "\"title\""
+                },
+                "value": "title"
+              },
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 26,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 29,
+                  "kind": 2,
+                  "rawValue": "\"Go\""
+                },
+                "value": "Go"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 32,
+                "endLine": 2,
+                "endTokenPos": 30,
+                "endFilePos": 73
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 32,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 39,
+                  "kind": 2,
+                  "rawValue": "\"author\""
+                },
+                "value": "author"
+              },
+              "value": {
+                "nodeType": "Expr_Array",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 44,
+                  "endLine": 2,
+                  "endTokenPos": 30,
+                  "endFilePos": 73,
+                  "kind": 2
+                },
+                "items": [
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 18,
+                      "startFilePos": 45,
+                      "endLine": 2,
+                      "endTokenPos": 22,
+                      "endFilePos": 59
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 18,
+                        "startFilePos": 45,
+                        "endLine": 2,
+                        "endTokenPos": 18,
+                        "endFilePos": 50,
+                        "kind": 2,
+                        "rawValue": "\"name\""
+                      },
+                      "value": "name"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 22,
+                        "startFilePos": 55,
+                        "endLine": 2,
+                        "endTokenPos": 22,
+                        "endFilePos": 59,
+                        "kind": 2,
+                        "rawValue": "\"Bob\""
+                      },
+                      "value": "Bob"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "ArrayItem",
+                    "attributes": {
+                      "startLine": 2,
+                      "startTokenPos": 25,
+                      "startFilePos": 62,
+                      "endLine": 2,
+                      "endTokenPos": 29,
+                      "endFilePos": 72
+                    },
+                    "key": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 25,
+                        "startFilePos": 62,
+                        "endLine": 2,
+                        "endTokenPos": 25,
+                        "endFilePos": 66,
+                        "kind": 2,
+                        "rawValue": "\"age\""
+                      },
+                      "value": "age"
+                    },
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 2,
+                        "startTokenPos": 29,
+                        "startFilePos": 71,
+                        "endLine": 2,
+                        "endTokenPos": 29,
+                        "endFilePos": 72,
+                        "rawValue": "42",
+                        "kind": 10
+                      },
+                      "value": 42
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 34,
+        "startFilePos": 77,
+        "endLine": 3,
+        "endTokenPos": 77,
+        "endFilePos": 197
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 37,
+            "startFilePos": 83,
+            "endLine": 3,
+            "endTokenPos": 72,
+            "endFilePos": 186
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 37,
+              "startFilePos": 83,
+              "endLine": 3,
+              "endTokenPos": 46,
+              "endFilePos": 115
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 37,
+                "startFilePos": 83,
+                "endLine": 3,
+                "endTokenPos": 37,
+                "endFilePos": 90
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 39,
+                  "startFilePos": 92,
+                  "endLine": 3,
+                  "endTokenPos": 45,
+                  "endFilePos": 114
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 39,
+                    "startFilePos": 92,
+                    "endLine": 3,
+                    "endTokenPos": 45,
+                    "endFilePos": 114
+                  },
+                  "var": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 39,
+                      "startFilePos": 92,
+                      "endLine": 3,
+                      "endTokenPos": 42,
+                      "endFilePos": 106
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 39,
+                        "startFilePos": 92,
+                        "endLine": 3,
+                        "endTokenPos": 39,
+                        "endFilePos": 96
+                      },
+                      "name": "book"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 41,
+                        "startFilePos": 98,
+                        "endLine": 3,
+                        "endTokenPos": 41,
+                        "endFilePos": 105,
+                        "kind": 2,
+                        "rawValue": "\"author\""
+                      },
+                      "value": "author"
+                    }
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 44,
+                      "startFilePos": 108,
+                      "endLine": 3,
+                      "endTokenPos": 44,
+                      "endFilePos": 113,
+                      "kind": 2,
+                      "rawValue": "\"name\""
+                    },
+                    "value": "name"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 50,
+              "startFilePos": 119,
+              "endLine": 3,
+              "endTokenPos": 62,
+              "endFilePos": 160
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 50,
+                "startFilePos": 119,
+                "endLine": 3,
+                "endTokenPos": 50,
+                "endFilePos": 129
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 52,
+                  "startFilePos": 131,
+                  "endLine": 3,
+                  "endTokenPos": 58,
+                  "endFilePos": 153
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_ArrayDimFetch",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 52,
+                    "startFilePos": 131,
+                    "endLine": 3,
+                    "endTokenPos": 58,
+                    "endFilePos": 153
+                  },
+                  "var": {
+                    "nodeType": "Expr_ArrayDimFetch",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 52,
+                      "startFilePos": 131,
+                      "endLine": 3,
+                      "endTokenPos": 55,
+                      "endFilePos": 145
+                    },
+                    "var": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 52,
+                        "startFilePos": 131,
+                        "endLine": 3,
+                        "endTokenPos": 52,
+                        "endFilePos": 135
+                      },
+                      "name": "book"
+                    },
+                    "dim": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 54,
+                        "startFilePos": 137,
+                        "endLine": 3,
+                        "endTokenPos": 54,
+                        "endFilePos": 144,
+                        "kind": 2,
+                        "rawValue": "\"author\""
+                      },
+                      "value": "author"
+                    }
+                  },
+                  "dim": {
+                    "nodeType": "Scalar_String",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 57,
+                      "startFilePos": 147,
+                      "endLine": 3,
+                      "endTokenPos": 57,
+                      "endFilePos": 152,
+                      "kind": 2,
+                      "rawValue": "\"name\""
+                    },
+                    "value": "name"
+                  }
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 61,
+                  "startFilePos": 156,
+                  "endLine": 3,
+                  "endTokenPos": 61,
+                  "endFilePos": 159
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 61,
+                    "startFilePos": 156,
+                    "endLine": 3,
+                    "endTokenPos": 61,
+                    "endFilePos": 159,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_ArrayDimFetch",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 66,
+              "startFilePos": 164,
+              "endLine": 3,
+              "endTokenPos": 72,
+              "endFilePos": 186
+            },
+            "var": {
+              "nodeType": "Expr_ArrayDimFetch",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 66,
+                "startFilePos": 164,
+                "endLine": 3,
+                "endTokenPos": 69,
+                "endFilePos": 178
+              },
+              "var": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 66,
+                  "startFilePos": 164,
+                  "endLine": 3,
+                  "endTokenPos": 66,
+                  "endFilePos": 168
+                },
+                "name": "book"
+              },
+              "dim": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 68,
+                  "startFilePos": 170,
+                  "endLine": 3,
+                  "endTokenPos": 68,
+                  "endFilePos": 177,
+                  "kind": 2,
+                  "rawValue": "\"author\""
+                },
+                "value": "author"
+              }
+            },
+            "dim": {
+              "nodeType": "Scalar_String",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 71,
+                "startFilePos": 180,
+                "endLine": 3,
+                "endTokenPos": 71,
+                "endFilePos": 185,
+                "kind": 2,
+                "rawValue": "\"name\""
+              },
+              "value": "name"
+            }
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 76,
+            "startFilePos": 190,
+            "endLine": 3,
+            "endTokenPos": 76,
+            "endFilePos": 196
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 76,
+              "startFilePos": 190,
+              "endLine": 3,
+              "endTokenPos": 76,
+              "endFilePos": 196
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/values_builtin.php.json
+++ b/tests/json-ast/x/php/values_builtin.php.json
@@ -1,0 +1,804 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 26,
+        "endFilePos": 41
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 25,
+          "endFilePos": 40
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "m"
+        },
+        "expr": {
+          "nodeType": "Expr_Array",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 25,
+            "endFilePos": 40,
+            "kind": 2
+          },
+          "items": [
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 6,
+                "startFilePos": 12,
+                "endLine": 2,
+                "endTokenPos": 10,
+                "endFilePos": 19
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 6,
+                  "startFilePos": 12,
+                  "endLine": 2,
+                  "endTokenPos": 6,
+                  "endFilePos": 14,
+                  "kind": 2,
+                  "rawValue": "\"a\""
+                },
+                "value": "a"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 10,
+                  "startFilePos": 19,
+                  "endLine": 2,
+                  "endTokenPos": 10,
+                  "endFilePos": 19,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 13,
+                "startFilePos": 22,
+                "endLine": 2,
+                "endTokenPos": 17,
+                "endFilePos": 29
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 13,
+                  "startFilePos": 22,
+                  "endLine": 2,
+                  "endTokenPos": 13,
+                  "endFilePos": 24,
+                  "kind": 2,
+                  "rawValue": "\"b\""
+                },
+                "value": "b"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 17,
+                  "startFilePos": 29,
+                  "endLine": 2,
+                  "endTokenPos": 17,
+                  "endFilePos": 29,
+                  "rawValue": "2",
+                  "kind": 10
+                },
+                "value": 2
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "ArrayItem",
+              "attributes": {
+                "startLine": 2,
+                "startTokenPos": 20,
+                "startFilePos": 32,
+                "endLine": 2,
+                "endTokenPos": 24,
+                "endFilePos": 39
+              },
+              "key": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 20,
+                  "startFilePos": 32,
+                  "endLine": 2,
+                  "endTokenPos": 20,
+                  "endFilePos": 34,
+                  "kind": 2,
+                  "rawValue": "\"c\""
+                },
+                "value": "c"
+              },
+              "value": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 2,
+                  "startTokenPos": 24,
+                  "startFilePos": 39,
+                  "endLine": 2,
+                  "endTokenPos": 24,
+                  "endFilePos": 39,
+                  "rawValue": "3",
+                  "kind": 10
+                },
+                "value": 3
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 28,
+        "startFilePos": 43,
+        "endLine": 3,
+        "endTokenPos": 88,
+        "endFilePos": 224
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_FuncCall",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 30,
+            "startFilePos": 48,
+            "endLine": 3,
+            "endTokenPos": 84,
+            "endFilePos": 214
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 30,
+              "startFilePos": 48,
+              "endLine": 3,
+              "endTokenPos": 30,
+              "endFilePos": 58
+            },
+            "name": "str_replace"
+          },
+          "args": [
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 32,
+                "startFilePos": 60,
+                "endLine": 3,
+                "endTokenPos": 32,
+                "endFilePos": 66
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 32,
+                  "startFilePos": 60,
+                  "endLine": 3,
+                  "endTokenPos": 32,
+                  "endFilePos": 66,
+                  "kind": 2,
+                  "rawValue": "\"false\""
+                },
+                "value": "false"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 35,
+                "startFilePos": 69,
+                "endLine": 3,
+                "endTokenPos": 35,
+                "endFilePos": 75
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Scalar_String",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 35,
+                  "startFilePos": 69,
+                  "endLine": 3,
+                  "endTokenPos": 35,
+                  "endFilePos": 75,
+                  "kind": 2,
+                  "rawValue": "\"False\""
+                },
+                "value": "False"
+              },
+              "byRef": false,
+              "unpack": false
+            },
+            {
+              "nodeType": "Arg",
+              "attributes": {
+                "startLine": 3,
+                "startTokenPos": 38,
+                "startFilePos": 78,
+                "endLine": 3,
+                "endTokenPos": 83,
+                "endFilePos": 213
+              },
+              "name": null,
+              "value": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 3,
+                  "startTokenPos": 38,
+                  "startFilePos": 78,
+                  "endLine": 3,
+                  "endTokenPos": 83,
+                  "endFilePos": 213
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 3,
+                    "startTokenPos": 38,
+                    "startFilePos": 78,
+                    "endLine": 3,
+                    "endTokenPos": 38,
+                    "endFilePos": 88
+                  },
+                  "name": "str_replace"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 40,
+                      "startFilePos": 90,
+                      "endLine": 3,
+                      "endTokenPos": 40,
+                      "endFilePos": 95
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 40,
+                        "startFilePos": 90,
+                        "endLine": 3,
+                        "endTokenPos": 40,
+                        "endFilePos": 95,
+                        "kind": 2,
+                        "rawValue": "\"true\""
+                      },
+                      "value": "true"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 43,
+                      "startFilePos": 98,
+                      "endLine": 3,
+                      "endTokenPos": 43,
+                      "endFilePos": 103
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_String",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 43,
+                        "startFilePos": 98,
+                        "endLine": 3,
+                        "endTokenPos": 43,
+                        "endFilePos": 103,
+                        "kind": 2,
+                        "rawValue": "\"True\""
+                      },
+                      "value": "True"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 3,
+                      "startTokenPos": 46,
+                      "startFilePos": 106,
+                      "endLine": 3,
+                      "endTokenPos": 82,
+                      "endFilePos": 212
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_FuncCall",
+                      "attributes": {
+                        "startLine": 3,
+                        "startTokenPos": 46,
+                        "startFilePos": 106,
+                        "endLine": 3,
+                        "endTokenPos": 82,
+                        "endFilePos": 212
+                      },
+                      "name": {
+                        "nodeType": "Name",
+                        "attributes": {
+                          "startLine": 3,
+                          "startTokenPos": 46,
+                          "startFilePos": 106,
+                          "endLine": 3,
+                          "endTokenPos": 46,
+                          "endFilePos": 116
+                        },
+                        "name": "str_replace"
+                      },
+                      "args": [
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 48,
+                            "startFilePos": 118,
+                            "endLine": 3,
+                            "endTokenPos": 48,
+                            "endFilePos": 121
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 48,
+                              "startFilePos": 118,
+                              "endLine": 3,
+                              "endTokenPos": 48,
+                              "endFilePos": 121,
+                              "kind": 2,
+                              "rawValue": "\"\\\"\""
+                            },
+                            "value": "\""
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 51,
+                            "startFilePos": 124,
+                            "endLine": 3,
+                            "endTokenPos": 51,
+                            "endFilePos": 126
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Scalar_String",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 51,
+                              "startFilePos": 124,
+                              "endLine": 3,
+                              "endTokenPos": 51,
+                              "endFilePos": 126,
+                              "kind": 2,
+                              "rawValue": "\"'\""
+                            },
+                            "value": "'"
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        },
+                        {
+                          "nodeType": "Arg",
+                          "attributes": {
+                            "startLine": 3,
+                            "startTokenPos": 54,
+                            "startFilePos": 129,
+                            "endLine": 3,
+                            "endTokenPos": 81,
+                            "endFilePos": 211
+                          },
+                          "name": null,
+                          "value": {
+                            "nodeType": "Expr_FuncCall",
+                            "attributes": {
+                              "startLine": 3,
+                              "startTokenPos": 54,
+                              "startFilePos": 129,
+                              "endLine": 3,
+                              "endTokenPos": 81,
+                              "endFilePos": 211
+                            },
+                            "name": {
+                              "nodeType": "Name",
+                              "attributes": {
+                                "startLine": 3,
+                                "startTokenPos": 54,
+                                "startFilePos": 129,
+                                "endLine": 3,
+                                "endTokenPos": 54,
+                                "endFilePos": 139
+                              },
+                              "name": "str_replace"
+                            },
+                            "args": [
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 56,
+                                  "startFilePos": 141,
+                                  "endLine": 3,
+                                  "endTokenPos": 56,
+                                  "endFilePos": 143
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 56,
+                                    "startFilePos": 141,
+                                    "endLine": 3,
+                                    "endTokenPos": 56,
+                                    "endFilePos": 143,
+                                    "kind": 2,
+                                    "rawValue": "\":\""
+                                  },
+                                  "value": ":"
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 59,
+                                  "startFilePos": 146,
+                                  "endLine": 3,
+                                  "endTokenPos": 59,
+                                  "endFilePos": 149
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Scalar_String",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 59,
+                                    "startFilePos": 146,
+                                    "endLine": 3,
+                                    "endTokenPos": 59,
+                                    "endFilePos": 149,
+                                    "kind": 2,
+                                    "rawValue": "\": \""
+                                  },
+                                  "value": ": "
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              },
+                              {
+                                "nodeType": "Arg",
+                                "attributes": {
+                                  "startLine": 3,
+                                  "startTokenPos": 62,
+                                  "startFilePos": 152,
+                                  "endLine": 3,
+                                  "endTokenPos": 80,
+                                  "endFilePos": 210
+                                },
+                                "name": null,
+                                "value": {
+                                  "nodeType": "Expr_FuncCall",
+                                  "attributes": {
+                                    "startLine": 3,
+                                    "startTokenPos": 62,
+                                    "startFilePos": 152,
+                                    "endLine": 3,
+                                    "endTokenPos": 80,
+                                    "endFilePos": 210
+                                  },
+                                  "name": {
+                                    "nodeType": "Name",
+                                    "attributes": {
+                                      "startLine": 3,
+                                      "startTokenPos": 62,
+                                      "startFilePos": 152,
+                                      "endLine": 3,
+                                      "endTokenPos": 62,
+                                      "endFilePos": 162
+                                    },
+                                    "name": "str_replace"
+                                  },
+                                  "args": [
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 64,
+                                        "startFilePos": 164,
+                                        "endLine": 3,
+                                        "endTokenPos": 64,
+                                        "endFilePos": 166
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 64,
+                                          "startFilePos": 164,
+                                          "endLine": 3,
+                                          "endTokenPos": 64,
+                                          "endFilePos": 166,
+                                          "kind": 2,
+                                          "rawValue": "\",\""
+                                        },
+                                        "value": ","
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 67,
+                                        "startFilePos": 169,
+                                        "endLine": 3,
+                                        "endTokenPos": 67,
+                                        "endFilePos": 172
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Scalar_String",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 67,
+                                          "startFilePos": 169,
+                                          "endLine": 3,
+                                          "endTokenPos": 67,
+                                          "endFilePos": 172,
+                                          "kind": 2,
+                                          "rawValue": "\", \""
+                                        },
+                                        "value": ", "
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    },
+                                    {
+                                      "nodeType": "Arg",
+                                      "attributes": {
+                                        "startLine": 3,
+                                        "startTokenPos": 70,
+                                        "startFilePos": 175,
+                                        "endLine": 3,
+                                        "endTokenPos": 79,
+                                        "endFilePos": 209
+                                      },
+                                      "name": null,
+                                      "value": {
+                                        "nodeType": "Expr_FuncCall",
+                                        "attributes": {
+                                          "startLine": 3,
+                                          "startTokenPos": 70,
+                                          "startFilePos": 175,
+                                          "endLine": 3,
+                                          "endTokenPos": 79,
+                                          "endFilePos": 209
+                                        },
+                                        "name": {
+                                          "nodeType": "Name",
+                                          "attributes": {
+                                            "startLine": 3,
+                                            "startTokenPos": 70,
+                                            "startFilePos": 175,
+                                            "endLine": 3,
+                                            "endTokenPos": 70,
+                                            "endFilePos": 185
+                                          },
+                                          "name": "json_encode"
+                                        },
+                                        "args": [
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 72,
+                                              "startFilePos": 187,
+                                              "endLine": 3,
+                                              "endTokenPos": 75,
+                                              "endFilePos": 202
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Expr_FuncCall",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 72,
+                                                "startFilePos": 187,
+                                                "endLine": 3,
+                                                "endTokenPos": 75,
+                                                "endFilePos": 202
+                                              },
+                                              "name": {
+                                                "nodeType": "Name",
+                                                "attributes": {
+                                                  "startLine": 3,
+                                                  "startTokenPos": 72,
+                                                  "startFilePos": 187,
+                                                  "endLine": 3,
+                                                  "endTokenPos": 72,
+                                                  "endFilePos": 198
+                                                },
+                                                "name": "array_values"
+                                              },
+                                              "args": [
+                                                {
+                                                  "nodeType": "Arg",
+                                                  "attributes": {
+                                                    "startLine": 3,
+                                                    "startTokenPos": 74,
+                                                    "startFilePos": 200,
+                                                    "endLine": 3,
+                                                    "endTokenPos": 74,
+                                                    "endFilePos": 201
+                                                  },
+                                                  "name": null,
+                                                  "value": {
+                                                    "nodeType": "Expr_Variable",
+                                                    "attributes": {
+                                                      "startLine": 3,
+                                                      "startTokenPos": 74,
+                                                      "startFilePos": 200,
+                                                      "endLine": 3,
+                                                      "endTokenPos": 74,
+                                                      "endFilePos": 201
+                                                    },
+                                                    "name": "m"
+                                                  },
+                                                  "byRef": false,
+                                                  "unpack": false
+                                                }
+                                              ]
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          },
+                                          {
+                                            "nodeType": "Arg",
+                                            "attributes": {
+                                              "startLine": 3,
+                                              "startTokenPos": 78,
+                                              "startFilePos": 205,
+                                              "endLine": 3,
+                                              "endTokenPos": 78,
+                                              "endFilePos": 208
+                                            },
+                                            "name": null,
+                                            "value": {
+                                              "nodeType": "Scalar_Int",
+                                              "attributes": {
+                                                "startLine": 3,
+                                                "startTokenPos": 78,
+                                                "startFilePos": 205,
+                                                "endLine": 3,
+                                                "endTokenPos": 78,
+                                                "endFilePos": 208,
+                                                "rawValue": "1344",
+                                                "kind": 10
+                                              },
+                                              "value": 1344
+                                            },
+                                            "byRef": false,
+                                            "unpack": false
+                                          }
+                                        ]
+                                      },
+                                      "byRef": false,
+                                      "unpack": false
+                                    }
+                                  ]
+                                },
+                                "byRef": false,
+                                "unpack": false
+                              }
+                            ]
+                          },
+                          "byRef": false,
+                          "unpack": false
+                        }
+                      ]
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "byRef": false,
+              "unpack": false
+            }
+          ]
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 87,
+            "startFilePos": 217,
+            "endLine": 3,
+            "endTokenPos": 87,
+            "endFilePos": 223
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 3,
+              "startTokenPos": 87,
+              "startFilePos": 217,
+              "endLine": 3,
+              "endTokenPos": 87,
+              "endFilePos": 223
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/var_assignment.php.json
+++ b/tests/json-ast/x/php/var_assignment.php.json
@@ -1,0 +1,289 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "1",
+            "kind": 10
+          },
+          "value": 1
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 3,
+        "endTokenPos": 13,
+        "endFilePos": 20
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 8,
+          "startFilePos": 14,
+          "endLine": 3,
+          "endTokenPos": 12,
+          "endFilePos": 19
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 8,
+            "startFilePos": 14,
+            "endLine": 3,
+            "endTokenPos": 8,
+            "endFilePos": 15
+          },
+          "name": "x"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 12,
+            "startFilePos": 19,
+            "endLine": 3,
+            "endTokenPos": 12,
+            "endFilePos": 19,
+            "rawValue": "2",
+            "kind": 10
+          },
+          "value": 2
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_Echo",
+      "attributes": {
+        "startLine": 4,
+        "startTokenPos": 15,
+        "startFilePos": 22,
+        "endLine": 4,
+        "endTokenPos": 40,
+        "endFilePos": 79
+      },
+      "exprs": [
+        {
+          "nodeType": "Expr_Ternary",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 18,
+            "startFilePos": 28,
+            "endLine": 4,
+            "endTokenPos": 35,
+            "endFilePos": 68
+          },
+          "cond": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 18,
+              "startFilePos": 28,
+              "endLine": 4,
+              "endTokenPos": 21,
+              "endFilePos": 39
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 18,
+                "startFilePos": 28,
+                "endLine": 4,
+                "endTokenPos": 18,
+                "endFilePos": 35
+              },
+              "name": "is_float"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 20,
+                  "startFilePos": 37,
+                  "endLine": 4,
+                  "endTokenPos": 20,
+                  "endFilePos": 38
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 20,
+                    "startFilePos": 37,
+                    "endLine": 4,
+                    "endTokenPos": 20,
+                    "endFilePos": 38
+                  },
+                  "name": "x"
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "if": {
+            "nodeType": "Expr_FuncCall",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 25,
+              "startFilePos": 43,
+              "endLine": 4,
+              "endTokenPos": 31,
+              "endFilePos": 63
+            },
+            "name": {
+              "nodeType": "Name",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 25,
+                "startFilePos": 43,
+                "endLine": 4,
+                "endTokenPos": 25,
+                "endFilePos": 53
+              },
+              "name": "json_encode"
+            },
+            "args": [
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 27,
+                  "startFilePos": 55,
+                  "endLine": 4,
+                  "endTokenPos": 27,
+                  "endFilePos": 56
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Expr_Variable",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 27,
+                    "startFilePos": 55,
+                    "endLine": 4,
+                    "endTokenPos": 27,
+                    "endFilePos": 56
+                  },
+                  "name": "x"
+                },
+                "byRef": false,
+                "unpack": false
+              },
+              {
+                "nodeType": "Arg",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 30,
+                  "startFilePos": 59,
+                  "endLine": 4,
+                  "endTokenPos": 30,
+                  "endFilePos": 62
+                },
+                "name": null,
+                "value": {
+                  "nodeType": "Scalar_Int",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 30,
+                    "startFilePos": 59,
+                    "endLine": 4,
+                    "endTokenPos": 30,
+                    "endFilePos": 62,
+                    "rawValue": "1344",
+                    "kind": 10
+                  },
+                  "value": 1344
+                },
+                "byRef": false,
+                "unpack": false
+              }
+            ]
+          },
+          "else": {
+            "nodeType": "Expr_Variable",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 35,
+              "startFilePos": 67,
+              "endLine": 4,
+              "endTokenPos": 35,
+              "endFilePos": 68
+            },
+            "name": "x"
+          }
+        },
+        {
+          "nodeType": "Expr_ConstFetch",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 39,
+            "startFilePos": 72,
+            "endLine": 4,
+            "endTokenPos": 39,
+            "endFilePos": 78
+          },
+          "name": {
+            "nodeType": "Name",
+            "attributes": {
+              "startLine": 4,
+              "startTokenPos": 39,
+              "startFilePos": 72,
+              "endLine": 4,
+              "endTokenPos": 39,
+              "endFilePos": 78
+            },
+            "name": "PHP_EOL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/php/while_loop.php.json
+++ b/tests/json-ast/x/php/while_loop.php.json
@@ -1,0 +1,362 @@
+{
+  "root": [
+    {
+      "nodeType": "Stmt_Expression",
+      "attributes": {
+        "startLine": 2,
+        "startTokenPos": 1,
+        "startFilePos": 6,
+        "endLine": 2,
+        "endTokenPos": 6,
+        "endFilePos": 12
+      },
+      "expr": {
+        "nodeType": "Expr_Assign",
+        "attributes": {
+          "startLine": 2,
+          "startTokenPos": 1,
+          "startFilePos": 6,
+          "endLine": 2,
+          "endTokenPos": 5,
+          "endFilePos": 11
+        },
+        "var": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 1,
+            "startFilePos": 6,
+            "endLine": 2,
+            "endTokenPos": 1,
+            "endFilePos": 7
+          },
+          "name": "i"
+        },
+        "expr": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 2,
+            "startTokenPos": 5,
+            "startFilePos": 11,
+            "endLine": 2,
+            "endTokenPos": 5,
+            "endFilePos": 11,
+            "rawValue": "0",
+            "kind": 10
+          },
+          "value": 0
+        }
+      }
+    },
+    {
+      "nodeType": "Stmt_While",
+      "attributes": {
+        "startLine": 3,
+        "startTokenPos": 8,
+        "startFilePos": 14,
+        "endLine": 6,
+        "endTokenPos": 58,
+        "endFilePos": 107
+      },
+      "cond": {
+        "nodeType": "Expr_BinaryOp_Smaller",
+        "attributes": {
+          "startLine": 3,
+          "startTokenPos": 11,
+          "startFilePos": 21,
+          "endLine": 3,
+          "endTokenPos": 15,
+          "endFilePos": 26
+        },
+        "left": {
+          "nodeType": "Expr_Variable",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 11,
+            "startFilePos": 21,
+            "endLine": 3,
+            "endTokenPos": 11,
+            "endFilePos": 22
+          },
+          "name": "i"
+        },
+        "right": {
+          "nodeType": "Scalar_Int",
+          "attributes": {
+            "startLine": 3,
+            "startTokenPos": 15,
+            "startFilePos": 26,
+            "endLine": 3,
+            "endTokenPos": 15,
+            "endFilePos": 26,
+            "rawValue": "3",
+            "kind": 10
+          },
+          "value": 3
+        }
+      },
+      "stmts": [
+        {
+          "nodeType": "Stmt_Echo",
+          "attributes": {
+            "startLine": 4,
+            "startTokenPos": 20,
+            "startFilePos": 33,
+            "endLine": 4,
+            "endTokenPos": 45,
+            "endFilePos": 90
+          },
+          "exprs": [
+            {
+              "nodeType": "Expr_Ternary",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 23,
+                "startFilePos": 39,
+                "endLine": 4,
+                "endTokenPos": 40,
+                "endFilePos": 79
+              },
+              "cond": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 23,
+                  "startFilePos": 39,
+                  "endLine": 4,
+                  "endTokenPos": 26,
+                  "endFilePos": 50
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 23,
+                    "startFilePos": 39,
+                    "endLine": 4,
+                    "endTokenPos": 23,
+                    "endFilePos": 46
+                  },
+                  "name": "is_float"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 25,
+                      "startFilePos": 48,
+                      "endLine": 4,
+                      "endTokenPos": 25,
+                      "endFilePos": 49
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 25,
+                        "startFilePos": 48,
+                        "endLine": 4,
+                        "endTokenPos": 25,
+                        "endFilePos": 49
+                      },
+                      "name": "i"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "if": {
+                "nodeType": "Expr_FuncCall",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 30,
+                  "startFilePos": 54,
+                  "endLine": 4,
+                  "endTokenPos": 36,
+                  "endFilePos": 74
+                },
+                "name": {
+                  "nodeType": "Name",
+                  "attributes": {
+                    "startLine": 4,
+                    "startTokenPos": 30,
+                    "startFilePos": 54,
+                    "endLine": 4,
+                    "endTokenPos": 30,
+                    "endFilePos": 64
+                  },
+                  "name": "json_encode"
+                },
+                "args": [
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 32,
+                      "startFilePos": 66,
+                      "endLine": 4,
+                      "endTokenPos": 32,
+                      "endFilePos": 67
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Expr_Variable",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 32,
+                        "startFilePos": 66,
+                        "endLine": 4,
+                        "endTokenPos": 32,
+                        "endFilePos": 67
+                      },
+                      "name": "i"
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  },
+                  {
+                    "nodeType": "Arg",
+                    "attributes": {
+                      "startLine": 4,
+                      "startTokenPos": 35,
+                      "startFilePos": 70,
+                      "endLine": 4,
+                      "endTokenPos": 35,
+                      "endFilePos": 73
+                    },
+                    "name": null,
+                    "value": {
+                      "nodeType": "Scalar_Int",
+                      "attributes": {
+                        "startLine": 4,
+                        "startTokenPos": 35,
+                        "startFilePos": 70,
+                        "endLine": 4,
+                        "endTokenPos": 35,
+                        "endFilePos": 73,
+                        "rawValue": "1344",
+                        "kind": 10
+                      },
+                      "value": 1344
+                    },
+                    "byRef": false,
+                    "unpack": false
+                  }
+                ]
+              },
+              "else": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 40,
+                  "startFilePos": 78,
+                  "endLine": 4,
+                  "endTokenPos": 40,
+                  "endFilePos": 79
+                },
+                "name": "i"
+              }
+            },
+            {
+              "nodeType": "Expr_ConstFetch",
+              "attributes": {
+                "startLine": 4,
+                "startTokenPos": 44,
+                "startFilePos": 83,
+                "endLine": 4,
+                "endTokenPos": 44,
+                "endFilePos": 89
+              },
+              "name": {
+                "nodeType": "Name",
+                "attributes": {
+                  "startLine": 4,
+                  "startTokenPos": 44,
+                  "startFilePos": 83,
+                  "endLine": 4,
+                  "endTokenPos": 44,
+                  "endFilePos": 89
+                },
+                "name": "PHP_EOL"
+              }
+            }
+          ]
+        },
+        {
+          "nodeType": "Stmt_Expression",
+          "attributes": {
+            "startLine": 5,
+            "startTokenPos": 47,
+            "startFilePos": 94,
+            "endLine": 5,
+            "endTokenPos": 56,
+            "endFilePos": 105
+          },
+          "expr": {
+            "nodeType": "Expr_Assign",
+            "attributes": {
+              "startLine": 5,
+              "startTokenPos": 47,
+              "startFilePos": 94,
+              "endLine": 5,
+              "endTokenPos": 55,
+              "endFilePos": 104
+            },
+            "var": {
+              "nodeType": "Expr_Variable",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 47,
+                "startFilePos": 94,
+                "endLine": 5,
+                "endTokenPos": 47,
+                "endFilePos": 95
+              },
+              "name": "i"
+            },
+            "expr": {
+              "nodeType": "Expr_BinaryOp_Plus",
+              "attributes": {
+                "startLine": 5,
+                "startTokenPos": 51,
+                "startFilePos": 99,
+                "endLine": 5,
+                "endTokenPos": 55,
+                "endFilePos": 104
+              },
+              "left": {
+                "nodeType": "Expr_Variable",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 51,
+                  "startFilePos": 99,
+                  "endLine": 5,
+                  "endTokenPos": 51,
+                  "endFilePos": 100
+                },
+                "name": "i"
+              },
+              "right": {
+                "nodeType": "Scalar_Int",
+                "attributes": {
+                  "startLine": 5,
+                  "startTokenPos": 55,
+                  "startFilePos": 104,
+                  "endLine": 5,
+                  "endTokenPos": 55,
+                  "endFilePos": 104,
+                  "rawValue": "1",
+                  "kind": 10
+                },
+                "value": 1
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/json-ast/x/php/inspect.go
+++ b/tools/json-ast/x/php/inspect.go
@@ -1,0 +1,56 @@
+package php
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Program represents a parsed PHP file.
+type Program struct {
+	Root json.RawMessage `json:"root"`
+}
+
+// Inspect parses the given PHP source code using the official php-parser
+// library and returns a Program describing its AST.
+var (
+	parserOnce sync.Once
+	parserPath string
+	parserErr  error
+)
+
+func ensureParser() error {
+	parserOnce.Do(func() {
+		dir := filepath.Join(os.TempDir(), "php-parser")
+		parserPath = filepath.Join(dir, "bin", "php-parse")
+		if _, err := os.Stat(parserPath); err == nil {
+			return
+		}
+		cmd := exec.Command("composer", "create-project", "--no-interaction", "--quiet", "nikic/php-parser", dir)
+		parserErr = cmd.Run()
+	})
+	return parserErr
+}
+
+func Inspect(src string) (*Program, error) {
+	if err := ensureParser(); err != nil {
+		return nil, fmt.Errorf("install parser: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "php", parserPath, "--json-dump", "-")
+	cmd.Stdin = bytes.NewBufferString(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return &Program{Root: json.RawMessage(out.Bytes())}, nil
+}

--- a/tools/json-ast/x/php/inspect_test.go
+++ b/tools/json-ast/x/php/inspect_test.go
@@ -1,0 +1,92 @@
+//go:build slow
+
+package php_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	php "mochi/tools/json-ast/x/php"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensurePHP(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php not installed")
+	}
+	if _, err := exec.LookPath("composer"); err != nil {
+		t.Skip("composer not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensurePHP(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "php")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "php")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.php"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".php")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := php.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".php.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement PHP inspection using nikic/php-parser via composer
- generate golden JSON AST files for PHP tests

## Testing
- `go vet ./...`
- `go test -tags slow ./tools/json-ast/x/php -update`


------
https://chatgpt.com/codex/tasks/task_e_68891631aee4832086eec1ce6aaeef32