### PR TITLE
Add Haskell AST inspector

### DIFF
--- a/tests/json-ast/x/hs/append_builtin.hs.json
+++ b/tests/json-ast/x/hs/append_builtin.hs.json
@@ -1,0 +1,29 @@
+{
+  "items": [
+    {
+      "kind": "var",
+      "name": "a",
+      "params": [],
+      "body": "[1, 2]",
+      "type": "",
+      "fields": []
+    },
+    {
+      "kind": "sig",
+      "name": "main",
+      "params": [],
+      "body": "",
+      "type": "IO ()",
+      "fields": []
+    },
+    {
+      "kind": "func",
+      "name": "main",
+      "params": [],
+      "body": "print (a ++ [3])",
+      "type": "",
+      "fields": []
+    }
+  ]
+}
+

--- a/tests/json-ast/x/hs/avg_builtin.hs.json
+++ b/tests/json-ast/x/hs/avg_builtin.hs.json
@@ -1,0 +1,21 @@
+{
+  "items": [
+    {
+      "kind": "sig",
+      "name": "main",
+      "params": [],
+      "body": "",
+      "type": "IO ()",
+      "fields": []
+    },
+    {
+      "kind": "func",
+      "name": "main",
+      "params": [],
+      "body": "print (fromIntegral (sum [1, 2, 3]) / fromIntegral (length [1, 2, 3]))",
+      "type": "",
+      "fields": []
+    }
+  ]
+}
+

--- a/tests/json-ast/x/hs/len_builtin.hs.json
+++ b/tests/json-ast/x/hs/len_builtin.hs.json
@@ -1,0 +1,21 @@
+{
+  "items": [
+    {
+      "kind": "sig",
+      "name": "main",
+      "params": [],
+      "body": "",
+      "type": "IO ()",
+      "fields": []
+    },
+    {
+      "kind": "func",
+      "name": "main",
+      "params": [],
+      "body": "print (length [1, 2, 3])",
+      "type": "",
+      "fields": []
+    }
+  ]
+}
+

--- a/tests/json-ast/x/hs/print_hello.hs.json
+++ b/tests/json-ast/x/hs/print_hello.hs.json
@@ -1,0 +1,21 @@
+{
+  "items": [
+    {
+      "kind": "sig",
+      "name": "main",
+      "params": [],
+      "body": "",
+      "type": "IO ()",
+      "fields": []
+    },
+    {
+      "kind": "func",
+      "name": "main",
+      "params": [],
+      "body": "putStrLn \"hello\"",
+      "type": "",
+      "fields": []
+    }
+  ]
+}
+

--- a/tools/json-ast/x/hs/inspect.go
+++ b/tools/json-ast/x/hs/inspect.go
@@ -1,0 +1,22 @@
+//go:build slow
+
+package hs
+
+import (
+	hsparse "mochi/tools/a2mochi/x/hs"
+)
+
+// Program represents a parsed Haskell source file.
+type Program struct {
+	Items []hsparse.Item `json:"items"`
+}
+
+// Inspect parses the provided Haskell source code using the official parser
+// and returns a Program describing its structure.
+func Inspect(src string) (*Program, error) {
+	prog, err := hsparse.Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	return &Program{Items: prog.Items}, nil
+}

--- a/tools/json-ast/x/hs/inspect_test.go
+++ b/tools/json-ast/x/hs/inspect_test.go
@@ -1,0 +1,89 @@
+//go:build slow
+
+package hs_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	hs "mochi/tools/json-ast/x/hs"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureHaskell(t *testing.T) {
+	if _, err := exec.LookPath("runghc"); err != nil {
+		t.Skip("runghc not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureHaskell(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "hs")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "hs")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.hs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".hs")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := hs.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".hs.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add haskell inspector implementation wrapping existing parser
- write golden tests for Haskell
- include example golden files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688916073c10832087da0798f2e581b5