### PR TITLE
Update Ruby AST inspector

### DIFF
--- a/tests/json-ast/x/rb/for_loop.rb.json
+++ b/tests/json-ast/x/rb/for_loop.rb.json
@@ -1,137 +1,321 @@
 {
-  "program": [
-    "program",
-    [
-      "stmts_add",
-      [
-        "stmts_new"
-      ],
-      [
-        "method_add_block",
-        [
-          "call",
-          [
-            "paren",
-            [
-              "stmts_add",
-              [
-                "stmts_new"
-              ],
-              [
-                "dot3",
-                [
-                  "@int",
-                  "1",
-                  [
-                    2,
-                    1
-                  ]
-                ],
-                [
-                  "@int",
-                  "4",
-                  [
-                    2,
-                    5
-                  ]
-                ]
-              ]
-            ]
-          ],
-          [
-            "@period",
-            ".",
-            [
-              2,
-              7
-            ]
-          ],
-          [
-            "@ident",
-            "each",
-            [
-              2,
-              8
-            ]
-          ]
-        ],
-        [
-          "do_block",
-          [
-            "block_var",
-            [
-              "params",
-              [
-                [
-                  "@ident",
-                  "i",
-                  [
-                    2,
-                    17
-                  ]
-                ]
-              ],
-              null,
-              null,
-              null,
-              null,
-              null,
-              null
-            ],
-            false
-          ],
-          [
-            "bodystmt",
-            [
-              "stmts_add",
-              [
-                "stmts_new"
-              ],
-              [
-                "method_add_arg",
-                [
-                  "fcall",
-                  [
-                    "@ident",
-                    "puts",
-                    [
-                      3,
-                      2
-                    ]
-                  ]
-                ],
-                [
-                  "arg_paren",
-                  [
-                    "args_add_block",
-                    [
-                      "args_add",
-                      [
-                        "args_new"
-                      ],
-                      [
-                        "var_ref",
-                        [
-                          "@ident",
-                          "i",
-                          [
-                            3,
-                            7
-                          ]
-                        ]
-                      ]
+  "ast": {
+    "Type": "program",
+    "Value": "",
+    "Line": 2,
+    "Col": 1,
+    "Children": [
+      {
+        "Type": "stmts_add",
+        "Value": "",
+        "Line": 2,
+        "Col": 1,
+        "Children": [
+          {
+            "Type": "stmts_new",
+            "Value": "",
+            "Line": 0,
+            "Col": 0,
+            "Children": null,
+            "EndLine": 0,
+            "EndCol": 0,
+            "Source": ""
+          },
+          {
+            "Type": "method_add_block",
+            "Value": "",
+            "Line": 2,
+            "Col": 1,
+            "Children": [
+              {
+                "Type": "call",
+                "Value": "",
+                "Line": 2,
+                "Col": 1,
+                "Children": [
+                  {
+                    "Type": "paren",
+                    "Value": "",
+                    "Line": 2,
+                    "Col": 1,
+                    "Children": [
+                      {
+                        "Type": "stmts_add",
+                        "Value": "",
+                        "Line": 2,
+                        "Col": 1,
+                        "Children": [
+                          {
+                            "Type": "stmts_new",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          },
+                          {
+                            "Type": "dot3",
+                            "Value": "",
+                            "Line": 2,
+                            "Col": 1,
+                            "Children": [
+                              {
+                                "Type": "@int",
+                                "Value": "1",
+                                "Line": 2,
+                                "Col": 1,
+                                "Children": null,
+                                "EndLine": 2,
+                                "EndCol": 1,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "@int",
+                                "Value": "4",
+                                "Line": 2,
+                                "Col": 5,
+                                "Children": null,
+                                "EndLine": 2,
+                                "EndCol": 5,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 2,
+                            "EndCol": 5,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 2,
+                        "EndCol": 5,
+                        "Source": ""
+                      }
                     ],
-                    false
-                  ]
-                ]
-              ]
+                    "EndLine": 2,
+                    "EndCol": 5,
+                    "Source": ""
+                  },
+                  {
+                    "Type": "@period",
+                    "Value": ".",
+                    "Line": 2,
+                    "Col": 7,
+                    "Children": null,
+                    "EndLine": 2,
+                    "EndCol": 7,
+                    "Source": ""
+                  },
+                  {
+                    "Type": "@ident",
+                    "Value": "each",
+                    "Line": 2,
+                    "Col": 8,
+                    "Children": null,
+                    "EndLine": 2,
+                    "EndCol": 8,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 2,
+                "EndCol": 8,
+                "Source": ""
+              },
+              {
+                "Type": "do_block",
+                "Value": "",
+                "Line": 3,
+                "Col": 2,
+                "Children": [
+                  {
+                    "Type": "block_var",
+                    "Value": "",
+                    "Line": 0,
+                    "Col": 0,
+                    "Children": [
+                      {
+                        "Type": "params",
+                        "Value": "",
+                        "Line": 0,
+                        "Col": 0,
+                        "Children": [
+                          {
+                            "Type": "list",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": [
+                              {
+                                "Type": "@ident",
+                                "Value": "i",
+                                "Line": 2,
+                                "Col": 17,
+                                "Children": null,
+                                "EndLine": 2,
+                                "EndCol": 17,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 0,
+                        "EndCol": 0,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 0,
+                    "EndCol": 0,
+                    "Source": ""
+                  },
+                  {
+                    "Type": "bodystmt",
+                    "Value": "",
+                    "Line": 3,
+                    "Col": 2,
+                    "Children": [
+                      {
+                        "Type": "stmts_add",
+                        "Value": "",
+                        "Line": 3,
+                        "Col": 2,
+                        "Children": [
+                          {
+                            "Type": "stmts_new",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          },
+                          {
+                            "Type": "method_add_arg",
+                            "Value": "",
+                            "Line": 3,
+                            "Col": 2,
+                            "Children": [
+                              {
+                                "Type": "fcall",
+                                "Value": "",
+                                "Line": 3,
+                                "Col": 2,
+                                "Children": [
+                                  {
+                                    "Type": "@ident",
+                                    "Value": "puts",
+                                    "Line": 3,
+                                    "Col": 2,
+                                    "Children": null,
+                                    "EndLine": 3,
+                                    "EndCol": 2,
+                                    "Source": ""
+                                  }
+                                ],
+                                "EndLine": 3,
+                                "EndCol": 2,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "arg_paren",
+                                "Value": "",
+                                "Line": 3,
+                                "Col": 7,
+                                "Children": [
+                                  {
+                                    "Type": "args_add_block",
+                                    "Value": "",
+                                    "Line": 3,
+                                    "Col": 7,
+                                    "Children": [
+                                      {
+                                        "Type": "args_add",
+                                        "Value": "",
+                                        "Line": 3,
+                                        "Col": 7,
+                                        "Children": [
+                                          {
+                                            "Type": "args_new",
+                                            "Value": "",
+                                            "Line": 0,
+                                            "Col": 0,
+                                            "Children": null,
+                                            "EndLine": 0,
+                                            "EndCol": 0,
+                                            "Source": ""
+                                          },
+                                          {
+                                            "Type": "var_ref",
+                                            "Value": "",
+                                            "Line": 3,
+                                            "Col": 7,
+                                            "Children": [
+                                              {
+                                                "Type": "@ident",
+                                                "Value": "i",
+                                                "Line": 3,
+                                                "Col": 7,
+                                                "Children": null,
+                                                "EndLine": 3,
+                                                "EndCol": 7,
+                                                "Source": ""
+                                              }
+                                            ],
+                                            "EndLine": 3,
+                                            "EndCol": 7,
+                                            "Source": ""
+                                          }
+                                        ],
+                                        "EndLine": 3,
+                                        "EndCol": 7,
+                                        "Source": ""
+                                      }
+                                    ],
+                                    "EndLine": 3,
+                                    "EndCol": 7,
+                                    "Source": ""
+                                  }
+                                ],
+                                "EndLine": 3,
+                                "EndCol": 7,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 3,
+                            "EndCol": 7,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 3,
+                        "EndCol": 7,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 3,
+                    "EndCol": 7,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 3,
+                "EndCol": 7,
+                "Source": ""
+              }
             ],
-            null,
-            null,
-            null
-          ]
-        ]
-      ]
-    ]
-  ]
+            "EndLine": 3,
+            "EndCol": 7,
+            "Source": ""
+          }
+        ],
+        "EndLine": 3,
+        "EndCol": 7,
+        "Source": ""
+      }
+    ],
+    "EndLine": 3,
+    "EndCol": 7,
+    "Source": ""
+  }
 }

--- a/tests/json-ast/x/rb/len_builtin.rb.json
+++ b/tests/json-ast/x/rb/len_builtin.rb.json
@@ -1,96 +1,224 @@
 {
-  "program": [
-    "program",
-    [
-      "stmts_add",
-      [
-        "stmts_new"
-      ],
-      [
-        "method_add_arg",
-        [
-          "fcall",
-          [
-            "@ident",
-            "puts",
-            [
-              2,
-              0
-            ]
-          ]
-        ],
-        [
-          "arg_paren",
-          [
-            "args_add_block",
-            [
-              "args_add",
-              [
-                "args_new"
-              ],
-              [
-                "call",
-                [
-                  "array",
-                  [
-                    "args_add",
-                    [
-                      "args_add",
-                      [
-                        "args_add",
-                        [
-                          "args_new"
+  "ast": {
+    "Type": "program",
+    "Value": "",
+    "Line": 2,
+    "Col": 0,
+    "Children": [
+      {
+        "Type": "stmts_add",
+        "Value": "",
+        "Line": 2,
+        "Col": 0,
+        "Children": [
+          {
+            "Type": "stmts_new",
+            "Value": "",
+            "Line": 0,
+            "Col": 0,
+            "Children": null,
+            "EndLine": 0,
+            "EndCol": 0,
+            "Source": ""
+          },
+          {
+            "Type": "method_add_arg",
+            "Value": "",
+            "Line": 2,
+            "Col": 0,
+            "Children": [
+              {
+                "Type": "fcall",
+                "Value": "",
+                "Line": 2,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "@ident",
+                    "Value": "puts",
+                    "Line": 2,
+                    "Col": 0,
+                    "Children": null,
+                    "EndLine": 2,
+                    "EndCol": 0,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 2,
+                "EndCol": 0,
+                "Source": ""
+              },
+              {
+                "Type": "arg_paren",
+                "Value": "",
+                "Line": 2,
+                "Col": 6,
+                "Children": [
+                  {
+                    "Type": "args_add_block",
+                    "Value": "",
+                    "Line": 2,
+                    "Col": 6,
+                    "Children": [
+                      {
+                        "Type": "args_add",
+                        "Value": "",
+                        "Line": 2,
+                        "Col": 6,
+                        "Children": [
+                          {
+                            "Type": "args_new",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          },
+                          {
+                            "Type": "call",
+                            "Value": "",
+                            "Line": 2,
+                            "Col": 6,
+                            "Children": [
+                              {
+                                "Type": "array",
+                                "Value": "",
+                                "Line": 2,
+                                "Col": 6,
+                                "Children": [
+                                  {
+                                    "Type": "args_add",
+                                    "Value": "",
+                                    "Line": 2,
+                                    "Col": 6,
+                                    "Children": [
+                                      {
+                                        "Type": "args_add",
+                                        "Value": "",
+                                        "Line": 2,
+                                        "Col": 6,
+                                        "Children": [
+                                          {
+                                            "Type": "args_add",
+                                            "Value": "",
+                                            "Line": 2,
+                                            "Col": 6,
+                                            "Children": [
+                                              {
+                                                "Type": "args_new",
+                                                "Value": "",
+                                                "Line": 0,
+                                                "Col": 0,
+                                                "Children": null,
+                                                "EndLine": 0,
+                                                "EndCol": 0,
+                                                "Source": ""
+                                              },
+                                              {
+                                                "Type": "@int",
+                                                "Value": "1",
+                                                "Line": 2,
+                                                "Col": 6,
+                                                "Children": null,
+                                                "EndLine": 2,
+                                                "EndCol": 6,
+                                                "Source": ""
+                                              }
+                                            ],
+                                            "EndLine": 2,
+                                            "EndCol": 6,
+                                            "Source": ""
+                                          },
+                                          {
+                                            "Type": "@int",
+                                            "Value": "2",
+                                            "Line": 2,
+                                            "Col": 9,
+                                            "Children": null,
+                                            "EndLine": 2,
+                                            "EndCol": 9,
+                                            "Source": ""
+                                          }
+                                        ],
+                                        "EndLine": 2,
+                                        "EndCol": 9,
+                                        "Source": ""
+                                      },
+                                      {
+                                        "Type": "@int",
+                                        "Value": "3",
+                                        "Line": 2,
+                                        "Col": 12,
+                                        "Children": null,
+                                        "EndLine": 2,
+                                        "EndCol": 12,
+                                        "Source": ""
+                                      }
+                                    ],
+                                    "EndLine": 2,
+                                    "EndCol": 12,
+                                    "Source": ""
+                                  }
+                                ],
+                                "EndLine": 2,
+                                "EndCol": 12,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "@period",
+                                "Value": ".",
+                                "Line": 2,
+                                "Col": 14,
+                                "Children": null,
+                                "EndLine": 2,
+                                "EndCol": 14,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "@ident",
+                                "Value": "length",
+                                "Line": 2,
+                                "Col": 15,
+                                "Children": null,
+                                "EndLine": 2,
+                                "EndCol": 15,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 2,
+                            "EndCol": 15,
+                            "Source": ""
+                          }
                         ],
-                        [
-                          "@int",
-                          "1",
-                          [
-                            2,
-                            6
-                          ]
-                        ]
-                      ],
-                      [
-                        "@int",
-                        "2",
-                        [
-                          2,
-                          9
-                        ]
-                      ]
+                        "EndLine": 2,
+                        "EndCol": 15,
+                        "Source": ""
+                      }
                     ],
-                    [
-                      "@int",
-                      "3",
-                      [
-                        2,
-                        12
-                      ]
-                    ]
-                  ]
+                    "EndLine": 2,
+                    "EndCol": 15,
+                    "Source": ""
+                  }
                 ],
-                [
-                  "@period",
-                  ".",
-                  [
-                    2,
-                    14
-                  ]
-                ],
-                [
-                  "@ident",
-                  "length",
-                  [
-                    2,
-                    15
-                  ]
-                ]
-              ]
+                "EndLine": 2,
+                "EndCol": 15,
+                "Source": ""
+              }
             ],
-            false
-          ]
-        ]
-      ]
-    ]
-  ]
+            "EndLine": 2,
+            "EndCol": 15,
+            "Source": ""
+          }
+        ],
+        "EndLine": 2,
+        "EndCol": 15,
+        "Source": ""
+      }
+    ],
+    "EndLine": 2,
+    "EndCol": 15,
+    "Source": ""
+  }
 }

--- a/tests/json-ast/x/rb/print_hello.rb.json
+++ b/tests/json-ast/x/rb/print_hello.rb.json
@@ -1,55 +1,151 @@
 {
-  "program": [
-    "program",
-    [
-      "stmts_add",
-      [
-        "stmts_new"
-      ],
-      [
-        "method_add_arg",
-        [
-          "fcall",
-          [
-            "@ident",
-            "puts",
-            [
-              2,
-              0
-            ]
-          ]
-        ],
-        [
-          "arg_paren",
-          [
-            "args_add_block",
-            [
-              "args_add",
-              [
-                "args_new"
-              ],
-              [
-                "string_literal",
-                [
-                  "string_add",
-                  [
-                    "string_content"
-                  ],
-                  [
-                    "@tstring_content",
-                    "hello",
-                    [
-                      2,
-                      6
-                    ]
-                  ]
-                ]
-              ]
+  "ast": {
+    "Type": "program",
+    "Value": "",
+    "Line": 2,
+    "Col": 0,
+    "Children": [
+      {
+        "Type": "stmts_add",
+        "Value": "",
+        "Line": 2,
+        "Col": 0,
+        "Children": [
+          {
+            "Type": "stmts_new",
+            "Value": "",
+            "Line": 0,
+            "Col": 0,
+            "Children": null,
+            "EndLine": 0,
+            "EndCol": 0,
+            "Source": ""
+          },
+          {
+            "Type": "method_add_arg",
+            "Value": "",
+            "Line": 2,
+            "Col": 0,
+            "Children": [
+              {
+                "Type": "fcall",
+                "Value": "",
+                "Line": 2,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "@ident",
+                    "Value": "puts",
+                    "Line": 2,
+                    "Col": 0,
+                    "Children": null,
+                    "EndLine": 2,
+                    "EndCol": 0,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 2,
+                "EndCol": 0,
+                "Source": ""
+              },
+              {
+                "Type": "arg_paren",
+                "Value": "",
+                "Line": 2,
+                "Col": 6,
+                "Children": [
+                  {
+                    "Type": "args_add_block",
+                    "Value": "",
+                    "Line": 2,
+                    "Col": 6,
+                    "Children": [
+                      {
+                        "Type": "args_add",
+                        "Value": "",
+                        "Line": 2,
+                        "Col": 6,
+                        "Children": [
+                          {
+                            "Type": "args_new",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          },
+                          {
+                            "Type": "string_literal",
+                            "Value": "",
+                            "Line": 2,
+                            "Col": 6,
+                            "Children": [
+                              {
+                                "Type": "string_add",
+                                "Value": "",
+                                "Line": 2,
+                                "Col": 6,
+                                "Children": [
+                                  {
+                                    "Type": "string_content",
+                                    "Value": "",
+                                    "Line": 0,
+                                    "Col": 0,
+                                    "Children": null,
+                                    "EndLine": 0,
+                                    "EndCol": 0,
+                                    "Source": ""
+                                  },
+                                  {
+                                    "Type": "@tstring_content",
+                                    "Value": "hello",
+                                    "Line": 2,
+                                    "Col": 6,
+                                    "Children": null,
+                                    "EndLine": 2,
+                                    "EndCol": 6,
+                                    "Source": ""
+                                  }
+                                ],
+                                "EndLine": 2,
+                                "EndCol": 6,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 2,
+                            "EndCol": 6,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 2,
+                        "EndCol": 6,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 2,
+                    "EndCol": 6,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 2,
+                "EndCol": 6,
+                "Source": ""
+              }
             ],
-            false
-          ]
-        ]
-      ]
-    ]
-  ]
+            "EndLine": 2,
+            "EndCol": 6,
+            "Source": ""
+          }
+        ],
+        "EndLine": 2,
+        "EndCol": 6,
+        "Source": ""
+      }
+    ],
+    "EndLine": 2,
+    "EndCol": 6,
+    "Source": ""
+  }
 }

--- a/tests/json-ast/x/rb/unary_neg.rb.json
+++ b/tests/json-ast/x/rb/unary_neg.rb.json
@@ -1,113 +1,320 @@
 {
-  "program": [
-    "program",
-    [
-      "stmts_add",
-      [
-        "stmts_add",
-        [
-          "stmts_new"
-        ],
-        [
-          "method_add_arg",
-          [
-            "fcall",
-            [
-              "@ident",
-              "puts",
-              [
-                2,
-                0
-              ]
-            ]
-          ],
-          [
-            "arg_paren",
-            [
-              "args_add_block",
-              [
-                "args_add",
-                [
-                  "args_new"
-                ],
-                [
-                  "unary",
-                  "-@",
-                  [
-                    "@int",
-                    "3",
-                    [
-                      2,
-                      6
-                    ]
-                  ]
-                ]
-              ],
-              false
-            ]
-          ]
-        ]
-      ],
-      [
-        "method_add_arg",
-        [
-          "fcall",
-          [
-            "@ident",
-            "puts",
-            [
-              3,
-              0
-            ]
-          ]
-        ],
-        [
-          "arg_paren",
-          [
-            "args_add_block",
-            [
-              "args_add",
-              [
-                "args_new"
-              ],
-              [
-                "binary",
-                [
-                  "@int",
-                  "5",
-                  [
-                    3,
-                    5
-                  ]
-                ],
-                "+",
-                [
-                  "paren",
-                  [
-                    "stmts_add",
-                    [
-                      "stmts_new"
+  "ast": {
+    "Type": "program",
+    "Value": "",
+    "Line": 2,
+    "Col": 0,
+    "Children": [
+      {
+        "Type": "stmts_add",
+        "Value": "",
+        "Line": 2,
+        "Col": 0,
+        "Children": [
+          {
+            "Type": "stmts_add",
+            "Value": "",
+            "Line": 2,
+            "Col": 0,
+            "Children": [
+              {
+                "Type": "stmts_new",
+                "Value": "",
+                "Line": 0,
+                "Col": 0,
+                "Children": null,
+                "EndLine": 0,
+                "EndCol": 0,
+                "Source": ""
+              },
+              {
+                "Type": "method_add_arg",
+                "Value": "",
+                "Line": 2,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "fcall",
+                    "Value": "",
+                    "Line": 2,
+                    "Col": 0,
+                    "Children": [
+                      {
+                        "Type": "@ident",
+                        "Value": "puts",
+                        "Line": 2,
+                        "Col": 0,
+                        "Children": null,
+                        "EndLine": 2,
+                        "EndCol": 0,
+                        "Source": ""
+                      }
                     ],
-                    [
-                      "unary",
-                      "-@",
-                      [
-                        "@int",
-                        "2",
-                        [
-                          3,
-                          11
-                        ]
-                      ]
-                    ]
-                  ]
-                ]
-              ]
+                    "EndLine": 2,
+                    "EndCol": 0,
+                    "Source": ""
+                  },
+                  {
+                    "Type": "arg_paren",
+                    "Value": "",
+                    "Line": 2,
+                    "Col": 6,
+                    "Children": [
+                      {
+                        "Type": "args_add_block",
+                        "Value": "",
+                        "Line": 2,
+                        "Col": 6,
+                        "Children": [
+                          {
+                            "Type": "args_add",
+                            "Value": "",
+                            "Line": 2,
+                            "Col": 6,
+                            "Children": [
+                              {
+                                "Type": "args_new",
+                                "Value": "",
+                                "Line": 0,
+                                "Col": 0,
+                                "Children": null,
+                                "EndLine": 0,
+                                "EndCol": 0,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "unary",
+                                "Value": "",
+                                "Line": 2,
+                                "Col": 6,
+                                "Children": [
+                                  {
+                                    "Type": "@tok",
+                                    "Value": "-@",
+                                    "Line": 0,
+                                    "Col": 0,
+                                    "Children": null,
+                                    "EndLine": 0,
+                                    "EndCol": 0,
+                                    "Source": ""
+                                  },
+                                  {
+                                    "Type": "@int",
+                                    "Value": "3",
+                                    "Line": 2,
+                                    "Col": 6,
+                                    "Children": null,
+                                    "EndLine": 2,
+                                    "EndCol": 6,
+                                    "Source": ""
+                                  }
+                                ],
+                                "EndLine": 2,
+                                "EndCol": 6,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 2,
+                            "EndCol": 6,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 2,
+                        "EndCol": 6,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 2,
+                    "EndCol": 6,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 2,
+                "EndCol": 6,
+                "Source": ""
+              }
             ],
-            false
-          ]
-        ]
-      ]
-    ]
-  ]
+            "EndLine": 2,
+            "EndCol": 6,
+            "Source": ""
+          },
+          {
+            "Type": "method_add_arg",
+            "Value": "",
+            "Line": 3,
+            "Col": 0,
+            "Children": [
+              {
+                "Type": "fcall",
+                "Value": "",
+                "Line": 3,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "@ident",
+                    "Value": "puts",
+                    "Line": 3,
+                    "Col": 0,
+                    "Children": null,
+                    "EndLine": 3,
+                    "EndCol": 0,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 3,
+                "EndCol": 0,
+                "Source": ""
+              },
+              {
+                "Type": "arg_paren",
+                "Value": "",
+                "Line": 3,
+                "Col": 5,
+                "Children": [
+                  {
+                    "Type": "args_add_block",
+                    "Value": "",
+                    "Line": 3,
+                    "Col": 5,
+                    "Children": [
+                      {
+                        "Type": "args_add",
+                        "Value": "",
+                        "Line": 3,
+                        "Col": 5,
+                        "Children": [
+                          {
+                            "Type": "args_new",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          },
+                          {
+                            "Type": "binary",
+                            "Value": "",
+                            "Line": 3,
+                            "Col": 5,
+                            "Children": [
+                              {
+                                "Type": "@int",
+                                "Value": "5",
+                                "Line": 3,
+                                "Col": 5,
+                                "Children": null,
+                                "EndLine": 3,
+                                "EndCol": 5,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "@tok",
+                                "Value": "+",
+                                "Line": 0,
+                                "Col": 0,
+                                "Children": null,
+                                "EndLine": 0,
+                                "EndCol": 0,
+                                "Source": ""
+                              },
+                              {
+                                "Type": "paren",
+                                "Value": "",
+                                "Line": 3,
+                                "Col": 11,
+                                "Children": [
+                                  {
+                                    "Type": "stmts_add",
+                                    "Value": "",
+                                    "Line": 3,
+                                    "Col": 11,
+                                    "Children": [
+                                      {
+                                        "Type": "stmts_new",
+                                        "Value": "",
+                                        "Line": 0,
+                                        "Col": 0,
+                                        "Children": null,
+                                        "EndLine": 0,
+                                        "EndCol": 0,
+                                        "Source": ""
+                                      },
+                                      {
+                                        "Type": "unary",
+                                        "Value": "",
+                                        "Line": 3,
+                                        "Col": 11,
+                                        "Children": [
+                                          {
+                                            "Type": "@tok",
+                                            "Value": "-@",
+                                            "Line": 0,
+                                            "Col": 0,
+                                            "Children": null,
+                                            "EndLine": 0,
+                                            "EndCol": 0,
+                                            "Source": ""
+                                          },
+                                          {
+                                            "Type": "@int",
+                                            "Value": "2",
+                                            "Line": 3,
+                                            "Col": 11,
+                                            "Children": null,
+                                            "EndLine": 3,
+                                            "EndCol": 11,
+                                            "Source": ""
+                                          }
+                                        ],
+                                        "EndLine": 3,
+                                        "EndCol": 11,
+                                        "Source": ""
+                                      }
+                                    ],
+                                    "EndLine": 3,
+                                    "EndCol": 11,
+                                    "Source": ""
+                                  }
+                                ],
+                                "EndLine": 3,
+                                "EndCol": 11,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 3,
+                            "EndCol": 11,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 3,
+                        "EndCol": 11,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 3,
+                    "EndCol": 11,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 3,
+                "EndCol": 11,
+                "Source": ""
+              }
+            ],
+            "EndLine": 3,
+            "EndCol": 11,
+            "Source": ""
+          }
+        ],
+        "EndLine": 3,
+        "EndCol": 11,
+        "Source": ""
+      }
+    ],
+    "EndLine": 3,
+    "EndCol": 11,
+    "Source": ""
+  }
 }

--- a/tests/json-ast/x/rb/var_assignment.rb.json
+++ b/tests/json-ast/x/rb/var_assignment.rb.json
@@ -1,99 +1,236 @@
 {
-  "program": [
-    "program",
-    [
-      "stmts_add",
-      [
-        "stmts_add",
-        [
-          "stmts_add",
-          [
-            "stmts_new"
-          ],
-          [
-            "assign",
-            [
-              "var_field",
-              [
-                "@ident",
-                "x",
-                [
-                  2,
-                  0
-                ]
-              ]
+  "ast": {
+    "Type": "program",
+    "Value": "",
+    "Line": 2,
+    "Col": 0,
+    "Children": [
+      {
+        "Type": "stmts_add",
+        "Value": "",
+        "Line": 2,
+        "Col": 0,
+        "Children": [
+          {
+            "Type": "stmts_add",
+            "Value": "",
+            "Line": 2,
+            "Col": 0,
+            "Children": [
+              {
+                "Type": "stmts_add",
+                "Value": "",
+                "Line": 2,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "stmts_new",
+                    "Value": "",
+                    "Line": 0,
+                    "Col": 0,
+                    "Children": null,
+                    "EndLine": 0,
+                    "EndCol": 0,
+                    "Source": ""
+                  },
+                  {
+                    "Type": "assign",
+                    "Value": "",
+                    "Line": 2,
+                    "Col": 0,
+                    "Children": [
+                      {
+                        "Type": "var_field",
+                        "Value": "",
+                        "Line": 2,
+                        "Col": 0,
+                        "Children": [
+                          {
+                            "Type": "@ident",
+                            "Value": "x",
+                            "Line": 2,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 2,
+                            "EndCol": 0,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 2,
+                        "EndCol": 0,
+                        "Source": ""
+                      },
+                      {
+                        "Type": "@int",
+                        "Value": "1",
+                        "Line": 2,
+                        "Col": 4,
+                        "Children": null,
+                        "EndLine": 2,
+                        "EndCol": 4,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 2,
+                    "EndCol": 4,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 2,
+                "EndCol": 4,
+                "Source": ""
+              },
+              {
+                "Type": "assign",
+                "Value": "",
+                "Line": 3,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "var_field",
+                    "Value": "",
+                    "Line": 3,
+                    "Col": 0,
+                    "Children": [
+                      {
+                        "Type": "@ident",
+                        "Value": "x",
+                        "Line": 3,
+                        "Col": 0,
+                        "Children": null,
+                        "EndLine": 3,
+                        "EndCol": 0,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 3,
+                    "EndCol": 0,
+                    "Source": ""
+                  },
+                  {
+                    "Type": "@int",
+                    "Value": "2",
+                    "Line": 3,
+                    "Col": 4,
+                    "Children": null,
+                    "EndLine": 3,
+                    "EndCol": 4,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 3,
+                "EndCol": 4,
+                "Source": ""
+              }
             ],
-            [
-              "@int",
-              "1",
-              [
-                2,
-                4
-              ]
-            ]
-          ]
-        ],
-        [
-          "assign",
-          [
-            "var_field",
-            [
-              "@ident",
-              "x",
-              [
-                3,
-                0
-              ]
-            ]
-          ],
-          [
-            "@int",
-            "2",
-            [
-              3,
-              4
-            ]
-          ]
-        ]
-      ],
-      [
-        "method_add_arg",
-        [
-          "fcall",
-          [
-            "@ident",
-            "puts",
-            [
-              4,
-              0
-            ]
-          ]
-        ],
-        [
-          "arg_paren",
-          [
-            "args_add_block",
-            [
-              "args_add",
-              [
-                "args_new"
-              ],
-              [
-                "var_ref",
-                [
-                  "@ident",
-                  "x",
-                  [
-                    4,
-                    5
-                  ]
-                ]
-              ]
+            "EndLine": 3,
+            "EndCol": 4,
+            "Source": ""
+          },
+          {
+            "Type": "method_add_arg",
+            "Value": "",
+            "Line": 4,
+            "Col": 0,
+            "Children": [
+              {
+                "Type": "fcall",
+                "Value": "",
+                "Line": 4,
+                "Col": 0,
+                "Children": [
+                  {
+                    "Type": "@ident",
+                    "Value": "puts",
+                    "Line": 4,
+                    "Col": 0,
+                    "Children": null,
+                    "EndLine": 4,
+                    "EndCol": 0,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 4,
+                "EndCol": 0,
+                "Source": ""
+              },
+              {
+                "Type": "arg_paren",
+                "Value": "",
+                "Line": 4,
+                "Col": 5,
+                "Children": [
+                  {
+                    "Type": "args_add_block",
+                    "Value": "",
+                    "Line": 4,
+                    "Col": 5,
+                    "Children": [
+                      {
+                        "Type": "args_add",
+                        "Value": "",
+                        "Line": 4,
+                        "Col": 5,
+                        "Children": [
+                          {
+                            "Type": "args_new",
+                            "Value": "",
+                            "Line": 0,
+                            "Col": 0,
+                            "Children": null,
+                            "EndLine": 0,
+                            "EndCol": 0,
+                            "Source": ""
+                          },
+                          {
+                            "Type": "var_ref",
+                            "Value": "",
+                            "Line": 4,
+                            "Col": 5,
+                            "Children": [
+                              {
+                                "Type": "@ident",
+                                "Value": "x",
+                                "Line": 4,
+                                "Col": 5,
+                                "Children": null,
+                                "EndLine": 4,
+                                "EndCol": 5,
+                                "Source": ""
+                              }
+                            ],
+                            "EndLine": 4,
+                            "EndCol": 5,
+                            "Source": ""
+                          }
+                        ],
+                        "EndLine": 4,
+                        "EndCol": 5,
+                        "Source": ""
+                      }
+                    ],
+                    "EndLine": 4,
+                    "EndCol": 5,
+                    "Source": ""
+                  }
+                ],
+                "EndLine": 4,
+                "EndCol": 5,
+                "Source": ""
+              }
             ],
-            false
-          ]
-        ]
-      ]
-    ]
-  ]
+            "EndLine": 4,
+            "EndCol": 5,
+            "Source": ""
+          }
+        ],
+        "EndLine": 4,
+        "EndCol": 5,
+        "Source": ""
+      }
+    ],
+    "EndLine": 4,
+    "EndCol": 5,
+    "Source": ""
+  }
 }

--- a/tools/json-ast/x/rb/inspect.go
+++ b/tools/json-ast/x/rb/inspect.go
@@ -1,40 +1,28 @@
 package rb
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"os/exec"
-	"strings"
+	rubyparser "mochi/tools/a2mochi/x/ruby"
 )
 
 // Program represents a parsed Ruby source file.
+//
+// The structure mirrors the Node type from the a2mochi Ruby parser which
+// provides a more typed representation of Ruby's AST compared to the generic
+// S-expression returned by ripper.
 type Program struct {
-	Program any `json:"program"`
+	AST *rubyparser.Node `json:"ast"`
 }
 
-const ripperScript = `require 'json';require 'ripper';src=STDIN.read;b=Ripper::SexpBuilder.new(src);ast=b.parse;if b.error?; STDERR.puts b.error; exit 1; end;puts JSON.generate(ast)`
-
-// Inspect parses the given Ruby source code and returns a Program describing its AST.
+// Inspect parses the given Ruby source code and returns a Program describing
+// its AST. It relies on the a2mochi Ruby parser which internally uses the
+// official "ripper" library.
 func Inspect(src string) (*Program, error) {
-	if _, err := exec.LookPath("ruby"); err != nil {
-		return nil, fmt.Errorf("ruby not installed: %w", err)
-	}
-	cmd := exec.Command("ruby", "-e", ripperScript)
-	cmd.Stdin = strings.NewReader(src)
-	var out bytes.Buffer
-	var errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err := cmd.Run(); err != nil {
-		if errBuf.Len() > 0 {
-			return nil, fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
-		}
+	node, err := rubyparser.Parse(src)
+	if err != nil {
 		return nil, err
 	}
-	var data any
-	if err := json.Unmarshal(out.Bytes(), &data); err != nil {
-		return nil, err
-	}
-	return &Program{Program: data}, nil
+	// The root node stores the full source in the Source field which is not
+	// needed in the JSON output. Clear it to reduce noise.
+	node.Source = ""
+	return &Program{AST: node}, nil
 }


### PR DESCRIPTION
## Summary
- improve Ruby AST inspector with typed nodes from a2mochi
- refresh a few golden examples to match the new structure

## Testing
- `go test ./tools/json-ast/x/rb -run 'TestInspect_Golden/(print_hello|for_loop|len_builtin|unary_neg|var_assignment)$' -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6889188667c883209b0b0f128c413d8d