### PR TITLE
Add Zig AST inspect stub

### DIFF
--- a/tools/json-ast/x/zig/inspect.go
+++ b/tools/json-ast/x/zig/inspect.go
@@ -1,0 +1,88 @@
+package zig
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Program represents a parsed Zig source file.
+type Program struct {
+	Vars      []Variable `json:"vars"`
+	Structs   []Struct   `json:"structs"`
+	Functions []Function `json:"functions"`
+}
+
+type Variable struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Value string `json:"value,omitempty"`
+	Const bool   `json:"const,omitempty"`
+	Pub   bool   `json:"pub,omitempty"`
+	Line  int    `json:"line"`
+}
+
+type Function struct {
+	Name    string   `json:"name"`
+	Params  string   `json:"params"`
+	Ret     string   `json:"ret"`
+	Pub     bool     `json:"pub,omitempty"`
+	Line    int      `json:"line"`
+	EndLine int      `json:"endLine"`
+	Lines   []string `json:"lines"`
+}
+
+type Struct struct {
+	Name    string  `json:"name"`
+	Pub     bool    `json:"pub,omitempty"`
+	Line    int     `json:"line"`
+	EndLine int     `json:"endLine"`
+	Fields  []Field `json:"fields"`
+}
+
+type Field struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Line int    `json:"line"`
+}
+
+// Inspect parses the given Zig source code and returns its program structure.
+func Inspect(src string) (*Program, error) {
+	if _, err := exec.LookPath("zig"); err != nil {
+		return nil, fmt.Errorf("zig not installed")
+	}
+	tmp, err := os.CreateTemp("", "zigsrc_*.zig")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tmp.WriteString(src); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, err
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "zig", "ast-check", "--format", "json", tmp.Name())
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if msg := errBuf.String(); msg != "" {
+			return nil, fmt.Errorf("%v: %s", err, msg)
+		}
+		return nil, err
+	}
+	var prog Program
+	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
+}

--- a/tools/json-ast/x/zig/inspect_test.go
+++ b/tools/json-ast/x/zig/inspect_test.go
@@ -1,0 +1,89 @@
+//go:build slow
+
+package zig_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	z "mochi/tools/json-ast/x/zig"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureZig(t *testing.T) {
+	if _, err := exec.LookPath("zig"); err != nil {
+		t.Skip("zig not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureZig(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "zig")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "zig")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.zig"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".zig")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := z.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".zig.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add stub implementation for Zig AST inspection
- parse Zig sources via `zig ast-check --format json`
- provide golden test scaffolding for Zig AST extraction
- apply context timeout to zig command

## Testing
- `go test ./tools/json-ast/x/zig -tags slow -run TestInspect_Golden -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889168cdec08320a634f6c443bc6891