### PR TITLE
Add Lua AST inspection tool

### DIFF
--- a/tests/json-ast/x/lua/append_builtin.lua.json
+++ b/tests/json-ast/x/lua/append_builtin.lua.json
@@ -1,0 +1,127 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "a"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst",
+                  "item"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "res"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": [
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Func": {
+                              "Object": {
+                                "Value": "table"
+                              },
+                              "Key": {
+                                "Value": "unpack"
+                              }
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "lst"
+                              }
+                            ],
+                            "AdjustRet": false
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "res"
+                      },
+                      {
+                        "Value": "item"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "res"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "a"
+              },
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/avg_builtin.lua.json
+++ b/tests/json-ast/x/lua/avg_builtin.lua.json
@@ -1,0 +1,223 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "sum"
+                  ],
+                  "Exprs": [
+                    {
+                      "Value": "0"
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Value": "sum"
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Operator": "+",
+                          "Lhs": {
+                            "Value": "sum"
+                          },
+                          "Rhs": {
+                            "Value": "v"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Condition": {
+                    "Operator": "==",
+                    "Lhs": {
+                      "Expr": {
+                        "Value": "lst"
+                      }
+                    },
+                    "Rhs": {
+                      "Value": "0"
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Value": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": null
+                },
+                {
+                  "Names": [
+                    "r"
+                  ],
+                  "Exprs": [
+                    {
+                      "Operator": "/",
+                      "Lhs": {
+                        "Value": "sum"
+                      },
+                      "Rhs": {
+                        "Expr": {
+                          "Value": "lst"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Condition": {
+                    "Operator": "==",
+                    "Lhs": {
+                      "Value": "r"
+                    },
+                    "Rhs": {
+                      "Func": {
+                        "Object": {
+                          "Value": "math"
+                        },
+                        "Key": {
+                          "Value": "floor"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "r"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Object": {
+                              "Value": "math"
+                            },
+                            "Key": {
+                              "Value": "floor"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "r"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": null
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Object": {
+                          "Value": "string"
+                        },
+                        "Key": {
+                          "Value": "format"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "%.15f"
+                        },
+                        {
+                          "Value": "r"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/basic_compare.lua.json
+++ b/tests/json-ast/x/lua/basic_compare.lua.json
@@ -1,0 +1,97 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "a"
+        }
+      ],
+      "Rhs": [
+        {
+          "Operator": "-",
+          "Lhs": {
+            "Value": "10"
+          },
+          "Rhs": {
+            "Value": "3"
+          }
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "b"
+        }
+      ],
+      "Rhs": [
+        {
+          "Operator": "+",
+          "Lhs": {
+            "Value": "2"
+          },
+          "Rhs": {
+            "Value": "2"
+          }
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "a"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "==",
+            "Lhs": {
+              "Value": "a"
+            },
+            "Rhs": {
+              "Value": "7"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "\u003c",
+            "Lhs": {
+              "Value": "b"
+            },
+            "Rhs": {
+              "Value": "5"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/bench_block.lua.json
+++ b/tests/json-ast/x/lua/bench_block.lua.json
@@ -1,0 +1,2018 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "input"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": []
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "io"
+                  },
+                  "Key": {
+                    "Value": "read"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "*l"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Names": [
+        "_nil"
+      ],
+      "Exprs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_now_seed"
+      ],
+      "Exprs": [
+        {
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_now_seeded"
+      ],
+      "Exprs": [
+        {}
+      ]
+    },
+    {
+      "Stmts": [
+        {
+          "Names": [
+            "s"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Object": {
+                  "Value": "os"
+                },
+                "Key": {
+                  "Value": "getenv"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "MOCHI_NOW_SEED"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ]
+        },
+        {
+          "Condition": {
+            "Operator": "and",
+            "Lhs": {
+              "Value": "s"
+            },
+            "Rhs": {
+              "Operator": "~=",
+              "Lhs": {
+                "Value": "s"
+              },
+              "Rhs": {
+                "Value": ""
+              }
+            }
+          },
+          "Then": [
+            {
+              "Names": [
+                "v"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "tonumber"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "s"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Condition": {
+                "Value": "v"
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "_now_seed"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Value": "v"
+                    }
+                  ]
+                },
+                {
+                  "Lhs": [
+                    {
+                      "Value": "_now_seeded"
+                    }
+                  ],
+                  "Rhs": [
+                    {}
+                  ]
+                }
+              ],
+              "Else": null
+            }
+          ],
+          "Else": null
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_now"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": []
+          },
+          "Stmts": [
+            {
+              "Condition": {
+                "Value": "_now_seeded"
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "_now_seed"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Operator": "%",
+                      "Lhs": {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Operator": "*",
+                          "Lhs": {
+                            "Value": "_now_seed"
+                          },
+                          "Rhs": {
+                            "Value": "1664525"
+                          }
+                        },
+                        "Rhs": {
+                          "Value": "1013904223"
+                        }
+                      },
+                      "Rhs": {
+                        "Value": "2147483647"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "_now_seed"
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Exprs": [
+                {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Operator": "*",
+                    "Lhs": {
+                      "Func": {
+                        "Object": {
+                          "Value": "os"
+                        },
+                        "Key": {
+                          "Value": "time"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [],
+                      "AdjustRet": false
+                    },
+                    "Rhs": {
+                      "Value": "1000000000"
+                    }
+                  },
+                  "Rhs": {
+                    "Func": {
+                      "Object": {
+                        "Value": "math"
+                      },
+                      "Key": {
+                        "Value": "floor"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Operator": "*",
+                        "Lhs": {
+                          "Func": {
+                            "Object": {
+                              "Value": "os"
+                            },
+                            "Key": {
+                              "Value": "clock"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "1000000000"
+                        }
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_padStart"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "s",
+              "len",
+              "ch"
+            ]
+          },
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "or",
+                "Lhs": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "ch"
+                  },
+                  "Rhs": {}
+                },
+                "Rhs": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "ch"
+                  },
+                  "Rhs": {
+                    "Value": ""
+                  }
+                }
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "ch"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Value": " "
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Condition": {
+                "Operator": "\u003e=",
+                "Lhs": {
+                  "Expr": {
+                    "Value": "s"
+                  }
+                },
+                "Rhs": {
+                  "Value": "len"
+                }
+              },
+              "Then": [
+                {
+                  "Exprs": [
+                    {
+                      "Value": "s"
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Names": [
+                "fill"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "string"
+                    },
+                    "Key": {
+                      "Value": "sub"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "ch"
+                    },
+                    {
+                      "Value": "1"
+                    },
+                    {
+                      "Value": "1"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Exprs": [
+                {
+                  "Lhs": {
+                    "Func": {
+                      "Object": {
+                        "Value": "string"
+                      },
+                      "Key": {
+                        "Value": "rep"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "fill"
+                      },
+                      {
+                        "Operator": "-",
+                        "Lhs": {
+                          "Value": "len"
+                        },
+                        "Rhs": {
+                          "Expr": {
+                            "Value": "s"
+                          }
+                        }
+                      }
+                    ],
+                    "AdjustRet": false
+                  },
+                  "Rhs": {
+                    "Value": "s"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_gcd"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "a",
+              "b"
+            ]
+          },
+          "Stmts": [
+            {
+              "Lhs": [
+                {
+                  "Value": "a"
+                }
+              ],
+              "Rhs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "math"
+                    },
+                    "Key": {
+                      "Value": "abs"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "a"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Lhs": [
+                {
+                  "Value": "b"
+                }
+              ],
+              "Rhs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "math"
+                    },
+                    "Key": {
+                      "Value": "abs"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "b"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Condition": {
+                "Operator": "~=",
+                "Lhs": {
+                  "Value": "b"
+                },
+                "Rhs": {
+                  "Value": "0"
+                }
+              },
+              "Stmts": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "a"
+                    },
+                    {
+                      "Value": "b"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Value": "b"
+                    },
+                    {
+                      "Operator": "%",
+                      "Lhs": {
+                        "Value": "a"
+                      },
+                      "Rhs": {
+                        "Value": "b"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Exprs": [
+                {
+                  "Value": "a"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_bigrat"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "n",
+              "d"
+            ]
+          },
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "and",
+                "Lhs": {
+                  "Operator": "and",
+                  "Lhs": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Func": {
+                          "Value": "type"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "n"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "table"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "~=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "n"
+                        },
+                        "Key": {
+                          "Value": "num"
+                        }
+                      },
+                      "Rhs": {}
+                    }
+                  },
+                  "Rhs": {
+                    "Operator": "~=",
+                    "Lhs": {
+                      "Object": {
+                        "Value": "n"
+                      },
+                      "Key": {
+                        "Value": "den"
+                      }
+                    },
+                    "Rhs": {}
+                  }
+                },
+                "Rhs": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "d"
+                  },
+                  "Rhs": {}
+                }
+              },
+              "Then": [
+                {
+                  "Exprs": [
+                    {
+                      "Value": "n"
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Value": "d"
+                },
+                "Rhs": {}
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "d"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Value": "1"
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Condition": {
+                "Operator": "\u003c",
+                "Lhs": {
+                  "Value": "d"
+                },
+                "Rhs": {
+                  "Value": "0"
+                }
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "n"
+                    },
+                    {
+                      "Value": "d"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Expr": {
+                        "Value": "n"
+                      }
+                    },
+                    {
+                      "Expr": {
+                        "Value": "d"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Names": [
+                "g"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "_gcd"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "n"
+                    },
+                    {
+                      "Value": "d"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Exprs": [
+                {
+                  "Fields": [
+                    {
+                      "Key": {
+                        "Value": "num"
+                      },
+                      "Value": {
+                        "Operator": "/",
+                        "Lhs": {
+                          "Value": "n"
+                        },
+                        "Rhs": {
+                          "Value": "g"
+                        }
+                      }
+                    },
+                    {
+                      "Key": {
+                        "Value": "den"
+                      },
+                      "Value": {
+                        "Operator": "/",
+                        "Lhs": {
+                          "Value": "d"
+                        },
+                        "Rhs": {
+                          "Value": "g"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_add"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "a",
+              "b"
+            ]
+          },
+          "Stmts": [
+            {
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "_bigrat"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Operator": "+",
+                      "Lhs": {
+                        "Operator": "*",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "a"
+                          },
+                          "Key": {
+                            "Value": "num"
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "b"
+                          },
+                          "Key": {
+                            "Value": "den"
+                          }
+                        }
+                      },
+                      "Rhs": {
+                        "Operator": "*",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "b"
+                          },
+                          "Key": {
+                            "Value": "num"
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "a"
+                          },
+                          "Key": {
+                            "Value": "den"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "Operator": "*",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "a"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "b"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      }
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_sub"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "a",
+              "b"
+            ]
+          },
+          "Stmts": [
+            {
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "_bigrat"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Operator": "-",
+                      "Lhs": {
+                        "Operator": "*",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "a"
+                          },
+                          "Key": {
+                            "Value": "num"
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "b"
+                          },
+                          "Key": {
+                            "Value": "den"
+                          }
+                        }
+                      },
+                      "Rhs": {
+                        "Operator": "*",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "b"
+                          },
+                          "Key": {
+                            "Value": "num"
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "a"
+                          },
+                          "Key": {
+                            "Value": "den"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "Operator": "*",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "a"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "b"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      }
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_mul"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "a",
+              "b"
+            ]
+          },
+          "Stmts": [
+            {
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "_bigrat"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Operator": "*",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "a"
+                        },
+                        "Key": {
+                          "Value": "num"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "b"
+                        },
+                        "Key": {
+                          "Value": "num"
+                        }
+                      }
+                    },
+                    {
+                      "Operator": "*",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "a"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "b"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      }
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_div"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "a",
+              "b"
+            ]
+          },
+          "Stmts": [
+            {
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "_bigrat"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Operator": "*",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "a"
+                        },
+                        "Key": {
+                          "Value": "num"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "b"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      }
+                    },
+                    {
+                      "Operator": "*",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "a"
+                        },
+                        "Key": {
+                          "Value": "den"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "b"
+                        },
+                        "Key": {
+                          "Value": "num"
+                        }
+                      }
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": {
+        "Func": {
+          "Value": "num"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "x"
+          ]
+        },
+        "Stmts": [
+          {
+            "Condition": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "==",
+                "Lhs": {
+                  "Func": {
+                    "Value": "type"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "x"
+                    }
+                  ],
+                  "AdjustRet": false
+                },
+                "Rhs": {
+                  "Value": "table"
+                }
+              },
+              "Rhs": {
+                "Operator": "~=",
+                "Lhs": {
+                  "Object": {
+                    "Value": "x"
+                  },
+                  "Key": {
+                    "Value": "num"
+                  }
+                },
+                "Rhs": {}
+              }
+            },
+            "Then": [
+              {
+                "Exprs": [
+                  {
+                    "Object": {
+                      "Value": "x"
+                    },
+                    "Key": {
+                      "Value": "num"
+                    }
+                  }
+                ]
+              }
+            ],
+            "Else": null
+          },
+          {
+            "Exprs": [
+              {
+                "Value": "x"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Name": {
+        "Func": {
+          "Value": "denom"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "x"
+          ]
+        },
+        "Stmts": [
+          {
+            "Condition": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "==",
+                "Lhs": {
+                  "Func": {
+                    "Value": "type"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "x"
+                    }
+                  ],
+                  "AdjustRet": false
+                },
+                "Rhs": {
+                  "Value": "table"
+                }
+              },
+              "Rhs": {
+                "Operator": "~=",
+                "Lhs": {
+                  "Object": {
+                    "Value": "x"
+                  },
+                  "Key": {
+                    "Value": "den"
+                  }
+                },
+                "Rhs": {}
+              }
+            },
+            "Then": [
+              {
+                "Exprs": [
+                  {
+                    "Object": {
+                      "Value": "x"
+                    },
+                    "Key": {
+                      "Value": "den"
+                    }
+                  }
+                ]
+              }
+            ],
+            "Else": null
+          },
+          {
+            "Exprs": [
+              {
+                "Value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Names": [
+        "_sha256"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "bs"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "tmp"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "os"
+                    },
+                    "Key": {
+                      "Value": "tmpname"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Names": [
+                "f"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "assert"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Func": {
+                        "Object": {
+                          "Value": "io"
+                        },
+                        "Key": {
+                          "Value": "open"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "tmp"
+                        },
+                        {
+                          "Value": "wb"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Name": "i",
+              "Init": {
+                "Value": "1"
+              },
+              "Limit": {
+                "Expr": {
+                  "Value": "bs"
+                }
+              },
+              "Step": null,
+              "Stmts": [
+                {
+                  "Expr": {
+                    "Func": null,
+                    "Receiver": {
+                      "Value": "f"
+                    },
+                    "Method": "write",
+                    "Args": [
+                      {
+                        "Func": {
+                          "Object": {
+                            "Value": "string"
+                          },
+                          "Key": {
+                            "Value": "char"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Object": {
+                              "Value": "bs"
+                            },
+                            "Key": {
+                              "Value": "i"
+                            }
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": null,
+                "Receiver": {
+                  "Value": "f"
+                },
+                "Method": "close",
+                "Args": [],
+                "AdjustRet": false
+              }
+            },
+            {
+              "Names": [
+                "p"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "io"
+                    },
+                    "Key": {
+                      "Value": "popen"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Lhs": {
+                        "Value": "sha256sum "
+                      },
+                      "Rhs": {
+                        "Value": "tmp"
+                      }
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Names": [
+                "out"
+              ],
+              "Exprs": [
+                {
+                  "Operator": "or",
+                  "Lhs": {
+                    "Func": null,
+                    "Receiver": {
+                      "Value": "p"
+                    },
+                    "Method": "read",
+                    "Args": [
+                      {
+                        "Value": "*l"
+                      }
+                    ],
+                    "AdjustRet": false
+                  },
+                  "Rhs": {
+                    "Value": ""
+                  }
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": null,
+                "Receiver": {
+                  "Value": "p"
+                },
+                "Method": "close",
+                "Args": [],
+                "AdjustRet": false
+              }
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Object": {
+                    "Value": "os"
+                  },
+                  "Key": {
+                    "Value": "remove"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "tmp"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            },
+            {
+              "Names": [
+                "hex"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "string"
+                    },
+                    "Key": {
+                      "Value": "sub"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "out"
+                    },
+                    {
+                      "Value": "1"
+                    },
+                    {
+                      "Value": "64"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Names": [
+                "res"
+              ],
+              "Exprs": [
+                {
+                  "Fields": []
+                }
+              ]
+            },
+            {
+              "Name": "i",
+              "Init": {
+                "Value": "1"
+              },
+              "Limit": {
+                "Expr": {
+                  "Value": "hex"
+                }
+              },
+              "Step": {
+                "Value": "2"
+              },
+              "Stmts": [
+                {
+                  "Lhs": [
+                    {
+                      "Object": {
+                        "Value": "res"
+                      },
+                      "Key": {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Expr": {
+                            "Value": "res"
+                          }
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      }
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Func": {
+                        "Value": "tonumber"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Func": {
+                            "Object": {
+                              "Value": "string"
+                            },
+                            "Key": {
+                              "Value": "sub"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "hex"
+                            },
+                            {
+                              "Value": "i"
+                            },
+                            {
+                              "Operator": "+",
+                              "Lhs": {
+                                "Value": "i"
+                              },
+                              "Rhs": {
+                                "Value": "1"
+                              }
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        {
+                          "Value": "16"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Exprs": [
+                {
+                  "Value": "res"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_indexOf"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "s",
+              "ch"
+            ]
+          },
+          "Stmts": [
+            {
+              "Name": "i",
+              "Init": {
+                "Value": "1"
+              },
+              "Limit": {
+                "Expr": {
+                  "Value": "s"
+                }
+              },
+              "Step": null,
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "==",
+                    "Lhs": {
+                      "Func": {
+                        "Object": {
+                          "Value": "string"
+                        },
+                        "Key": {
+                          "Value": "sub"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "s"
+                        },
+                        {
+                          "Value": "i"
+                        },
+                        {
+                          "Value": "i"
+                        }
+                      ],
+                      "AdjustRet": false
+                    },
+                    "Rhs": {
+                      "Value": "ch"
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Operator": "-",
+                          "Lhs": {
+                            "Value": "i"
+                          },
+                          "Rhs": {
+                            "Value": "1"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": null
+                }
+              ]
+            },
+            {
+              "Exprs": [
+                {
+                  "Expr": {
+                    "Value": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_parseIntStr"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "str"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "n"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "tonumber"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "str"
+                    },
+                    {
+                      "Value": "10"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            },
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Value": "n"
+                },
+                "Rhs": {}
+              },
+              "Then": [
+                {
+                  "Exprs": [
+                    {
+                      "Value": "0"
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Exprs": [
+                {
+                  "Func": {
+                    "Object": {
+                      "Value": "math"
+                    },
+                    "Key": {
+                      "Value": "floor"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "n"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "slice"
+      ],
+      "Exprs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "lst",
+              "s",
+              "e"
+            ]
+          },
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "\u003c",
+                "Lhs": {
+                  "Value": "s"
+                },
+                "Rhs": {
+                  "Value": "0"
+                }
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "s"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Operator": "+",
+                      "Lhs": {
+                        "Expr": {
+                          "Value": "lst"
+                        }
+                      },
+                      "Rhs": {
+                        "Value": "s"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Value": "e"
+                },
+                "Rhs": {}
+              },
+              "Then": [
+                {
+                  "Lhs": [
+                    {
+                      "Value": "e"
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Expr": {
+                        "Value": "lst"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Else": null
+            },
+            {
+              "Names": [
+                "r"
+              ],
+              "Exprs": [
+                {
+                  "Fields": []
+                }
+              ]
+            },
+            {
+              "Name": "i",
+              "Init": {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "s"
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              },
+              "Limit": {
+                "Value": "e"
+              },
+              "Step": null,
+              "Stmts": [
+                {
+                  "Lhs": [
+                    {
+                      "Object": {
+                        "Value": "r"
+                      },
+                      "Key": {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Expr": {
+                            "Value": "r"
+                          }
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      }
+                    }
+                  ],
+                  "Rhs": [
+                    {
+                      "Object": {
+                        "Value": "lst"
+                      },
+                      "Key": {
+                        "Value": "i"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Exprs": [
+                {
+                  "Value": "r"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Stmts": [
+        {
+          "Names": [
+            "_bench_start"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "_now"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [],
+              "AdjustRet": false
+            }
+          ]
+        },
+        {
+          "Lhs": [
+            {
+              "Value": "n"
+            }
+          ],
+          "Rhs": [
+            {
+              "Value": "1000"
+            }
+          ]
+        },
+        {
+          "Lhs": [
+            {
+              "Value": "s"
+            }
+          ],
+          "Rhs": [
+            {
+              "Value": "0"
+            }
+          ]
+        },
+        {
+          "Name": "i",
+          "Init": {
+            "Value": "1"
+          },
+          "Limit": {
+            "Operator": "-",
+            "Lhs": {
+              "Value": "n"
+            },
+            "Rhs": {
+              "Value": "1"
+            }
+          },
+          "Step": null,
+          "Stmts": [
+            {
+              "Lhs": [
+                {
+                  "Value": "s"
+                }
+              ],
+              "Rhs": [
+                {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Value": "s"
+                  },
+                  "Rhs": {
+                    "Value": "i"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Names": [
+            "_bench_end"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "_now"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [],
+              "AdjustRet": false
+            }
+          ]
+        },
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "{\n  \"duration_us\": 571223,\n  \"memory_bytes\": 0,\n  \"name\": \"simple\"\n}"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/binary_precedence.lua.json
+++ b/tests/json-ast/x/lua/binary_precedence.lua.json
@@ -1,0 +1,112 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "+",
+            "Lhs": {
+              "Value": "1"
+            },
+            "Rhs": {
+              "Operator": "*",
+              "Lhs": {
+                "Value": "2"
+              },
+              "Rhs": {
+                "Value": "3"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "*",
+            "Lhs": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "1"
+              },
+              "Rhs": {
+                "Value": "2"
+              }
+            },
+            "Rhs": {
+              "Value": "3"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "+",
+            "Lhs": {
+              "Operator": "*",
+              "Lhs": {
+                "Value": "2"
+              },
+              "Rhs": {
+                "Value": "3"
+              }
+            },
+            "Rhs": {
+              "Value": "1"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "*",
+            "Lhs": {
+              "Value": "2"
+            },
+            "Rhs": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "3"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/bool_chain.lua.json
+++ b/tests/json-ast/x/lua/bool_chain.lua.json
@@ -1,0 +1,224 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "boom"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": []
+        },
+        "Stmts": [
+          {
+            "Expr": {
+              "Func": {
+                "Value": "print"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "boom"
+                }
+              ],
+              "AdjustRet": false
+            }
+          },
+          {
+            "Exprs": [
+              {}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "and",
+                "Lhs": {
+                  "Operator": "and",
+                  "Lhs": {
+                    "Operator": "\u003c",
+                    "Lhs": {
+                      "Value": "1"
+                    },
+                    "Rhs": {
+                      "Value": "2"
+                    }
+                  },
+                  "Rhs": {
+                    "Operator": "\u003c",
+                    "Lhs": {
+                      "Value": "2"
+                    },
+                    "Rhs": {
+                      "Value": "3"
+                    }
+                  }
+                },
+                "Rhs": {
+                  "Operator": "\u003c",
+                  "Lhs": {
+                    "Value": "3"
+                  },
+                  "Rhs": {
+                    "Value": "4"
+                  }
+                }
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            },
+            "Rhs": {
+              "Value": "0"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "and",
+                "Lhs": {
+                  "Operator": "and",
+                  "Lhs": {
+                    "Operator": "\u003c",
+                    "Lhs": {
+                      "Value": "1"
+                    },
+                    "Rhs": {
+                      "Value": "2"
+                    }
+                  },
+                  "Rhs": {
+                    "Operator": "\u003e",
+                    "Lhs": {
+                      "Value": "2"
+                    },
+                    "Rhs": {
+                      "Value": "3"
+                    }
+                  }
+                },
+                "Rhs": {
+                  "Func": {
+                    "Value": "boom"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [],
+                  "AdjustRet": false
+                }
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            },
+            "Rhs": {
+              "Value": "0"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "and",
+                "Lhs": {
+                  "Operator": "and",
+                  "Lhs": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "\u003c",
+                      "Lhs": {
+                        "Value": "1"
+                      },
+                      "Rhs": {
+                        "Value": "2"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "\u003c",
+                      "Lhs": {
+                        "Value": "2"
+                      },
+                      "Rhs": {
+                        "Value": "3"
+                      }
+                    }
+                  },
+                  "Rhs": {
+                    "Operator": "\u003e",
+                    "Lhs": {
+                      "Value": "3"
+                    },
+                    "Rhs": {
+                      "Value": "4"
+                    }
+                  }
+                },
+                "Rhs": {
+                  "Func": {
+                    "Value": "boom"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [],
+                  "AdjustRet": false
+                }
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            },
+            "Rhs": {
+              "Value": "0"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/break_continue.lua.json
+++ b/tests/json-ast/x/lua/break_continue.lua.json
@@ -1,0 +1,168 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "numbers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "4"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "5"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "6"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "7"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "8"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "9"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "n"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "numbers"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Condition": {
+            "Operator": "==",
+            "Lhs": {
+              "Operator": "%",
+              "Lhs": {
+                "Value": "n"
+              },
+              "Rhs": {
+                "Value": "2"
+              }
+            },
+            "Rhs": {
+              "Value": "0"
+            }
+          },
+          "Then": [
+            {
+              "Label": "__cont_1"
+            }
+          ],
+          "Else": null
+        },
+        {
+          "Condition": {
+            "Operator": "\u003e",
+            "Lhs": {
+              "Value": "n"
+            },
+            "Rhs": {
+              "Value": "7"
+            }
+          },
+          "Then": [
+            {}
+          ],
+          "Else": null
+        },
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "odd number: %s"
+                  },
+                  {
+                    "Value": "n"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        },
+        {
+          "Name": "__cont_1"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/cast_string_to_int.lua.json
+++ b/tests/json-ast/x/lua/cast_string_to_int.lua.json
@@ -1,0 +1,19 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "1995"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/cast_struct.lua.json
+++ b/tests/json-ast/x/lua/cast_struct.lua.json
@@ -1,0 +1,45 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "todo"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "title"
+              },
+              "Value": {
+                "Value": "hi"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "todo"
+            },
+            "Key": {
+              "Value": "title"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/closure.lua.json
+++ b/tests/json-ast/x/lua/closure.lua.json
@@ -1,0 +1,97 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "makeAdder"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "n"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "ParList": {
+                  "HasVargs": false,
+                  "Names": [
+                    "x"
+                  ]
+                },
+                "Stmts": [
+                  {
+                    "Exprs": [
+                      {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Value": "x"
+                        },
+                        "Rhs": {
+                          "Value": "n"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "add10"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "Value": "makeAdder"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "10"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "add10"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "7"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/count_builtin.lua.json
+++ b/tests/json-ast/x/lua/count_builtin.lua.json
@@ -1,0 +1,215 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Func": {
+                          "Value": "type"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "v"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "table"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "~=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "v"
+                        },
+                        "Key": {
+                          "Value": "items"
+                        }
+                      },
+                      "Rhs": {}
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Expr": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "items"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": [
+                    {
+                      "Condition": {
+                        "Operator": "and",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Func": {
+                              "Value": "type"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "v"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Rhs": {
+                            "Value": "table"
+                          }
+                        },
+                        "Rhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "1"
+                            }
+                          },
+                          "Rhs": {}
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Names": [
+                            "c"
+                          ],
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "Names": [
+                            "_"
+                          ],
+                          "Exprs": [
+                            {
+                              "Func": {
+                                "Value": "pairs"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          ],
+                          "Stmts": [
+                            {
+                              "Lhs": [
+                                {
+                                  "Value": "c"
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Value": "c"
+                                  },
+                                  "Rhs": {
+                                    "Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "c"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Exprs": [
+                            {
+                              "Expr": {
+                                "Value": "v"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/cross_join.lua.json
+++ b/tests/json-ast/x/lua/cross_join.lua.json
@@ -1,0 +1,426 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "250"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "125"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "102"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "300"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Expr": {
+                "Func": {
+                  "Object": {
+                    "Value": "table"
+                  },
+                  "Key": {
+                    "Value": "insert"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "result"
+                  },
+                  {
+                    "Fields": [
+                      {
+                        "Key": {
+                          "Value": "orderId"
+                        },
+                        "Value": {
+                          "Object": {
+                            "Value": "o"
+                          },
+                          "Key": {
+                            "Value": "id"
+                          }
+                        }
+                      },
+                      {
+                        "Key": {
+                          "Value": "orderCustomerId"
+                        },
+                        "Value": {
+                          "Object": {
+                            "Value": "o"
+                          },
+                          "Key": {
+                            "Value": "customerId"
+                          }
+                        }
+                      },
+                      {
+                        "Key": {
+                          "Value": "pairedCustomerName"
+                        },
+                        "Value": {
+                          "Object": {
+                            "Value": "c"
+                          },
+                          "Key": {
+                            "Value": "name"
+                          }
+                        }
+                      },
+                      {
+                        "Key": {
+                          "Value": "orderTotal"
+                        },
+                        "Value": {
+                          "Object": {
+                            "Value": "o"
+                          },
+                          "Key": {
+                            "Value": "total"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Cross Join: All order-customer pairs ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "entry"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "Order %s (customerId: %s , total: $ %s ) paired with %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "orderId"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "orderCustomerId"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "orderTotal"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "pairedCustomerName"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/cross_join_filter.lua.json
+++ b/tests/json-ast/x/lua/cross_join_filter.lua.json
@@ -1,0 +1,262 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nums"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "letters"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "A"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "B"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "pairs"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "n"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "nums"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "l"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "letters"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Operator": "%",
+                  "Lhs": {
+                    "Value": "n"
+                  },
+                  "Rhs": {
+                    "Value": "2"
+                  }
+                },
+                "Rhs": {
+                  "Value": "0"
+                }
+              },
+              "Then": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "pairs"
+                      },
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "n"
+                            },
+                            "Value": {
+                              "Value": "n"
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "l"
+                            },
+                            "Value": {
+                              "Value": "l"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ],
+              "Else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Even pairs ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "p"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "pairs"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "p"
+                    },
+                    "Key": {
+                      "Value": "n"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "p"
+                    },
+                    "Key": {
+                      "Value": "l"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/cross_join_triple.lua.json
+++ b/tests/json-ast/x/lua/cross_join_triple.lua.json
@@ -1,0 +1,296 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nums"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "letters"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "A"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "B"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "bools"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {}
+            },
+            {
+              "Key": null,
+              "Value": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "combos"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "n"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "nums"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "l"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "letters"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Names": [
+                "_",
+                "b"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "ipairs"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "bools"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ],
+              "Stmts": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "combos"
+                      },
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "n"
+                            },
+                            "Value": {
+                              "Value": "n"
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "l"
+                            },
+                            "Value": {
+                              "Value": "l"
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "b"
+                            },
+                            "Value": {
+                              "Value": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Cross Join of three lists ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "c"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "combos"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s %s %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "c"
+                    },
+                    "Key": {
+                      "Value": "n"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "c"
+                    },
+                    "Key": {
+                      "Value": "l"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "c"
+                    },
+                    "Key": {
+                      "Value": "b"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/dataset_sort_take_limit.lua.json
+++ b/tests/json-ast/x/lua/dataset_sort_take_limit.lua.json
@@ -1,0 +1,627 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "products"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Laptop"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "1500"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Smartphone"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "900"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Tablet"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "600"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Monitor"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "300"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Keyboard"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Mouse"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "50"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Headphones"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "price"
+                    },
+                    "Value": {
+                      "Value": "200"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "expensive"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "products"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Operator": "-",
+                                "Lhs": {
+                                  "Value": "0"
+                                },
+                                "Rhs": {
+                                  "Object": {
+                                    "Value": "p"
+                                  },
+                                  "Key": {
+                                    "Value": "price"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Value": "p"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Exprs": [
+                            {
+                              "Operator": "\u003c",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Rhs": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "_res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_slice"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_start"
+                ],
+                "Exprs": [
+                  {
+                    "Operator": "+",
+                    "Lhs": {
+                      "Value": "1"
+                    },
+                    "Rhs": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_stop"
+                ],
+                "Exprs": [
+                  {
+                    "Expr": {
+                      "Value": "_res"
+                    }
+                  }
+                ]
+              },
+              {
+                "Condition": {
+                  "Operator": "\u003c",
+                  "Lhs": {
+                    "Value": "3"
+                  },
+                  "Rhs": {
+                    "Operator": "+",
+                    "Lhs": {
+                      "Operator": "-",
+                      "Lhs": {
+                        "Value": "_stop"
+                      },
+                      "Rhs": {
+                        "Value": "_start"
+                      }
+                    },
+                    "Rhs": {
+                      "Value": "1"
+                    }
+                  }
+                },
+                "Then": [
+                  {
+                    "Lhs": [
+                      {
+                        "Value": "_stop"
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Operator": "-",
+                        "Lhs": {
+                          "Operator": "+",
+                          "Lhs": {
+                            "Value": "_start"
+                          },
+                          "Rhs": {
+                            "Value": "3"
+                          }
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "Else": null
+              },
+              {
+                "Name": "i",
+                "Init": {
+                  "Value": "_start"
+                },
+                "Limit": {
+                  "Value": "_stop"
+                },
+                "Step": null,
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "_slice"
+                        },
+                        "Key": {
+                          "Operator": "+",
+                          "Lhs": {
+                            "Expr": {
+                              "Value": "_slice"
+                            }
+                          },
+                          "Rhs": {
+                            "Value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "_res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Lhs": [
+                  {
+                    "Value": "_res"
+                  }
+                ],
+                "Rhs": [
+                  {
+                    "Value": "_slice"
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Top products (excluding most expensive) ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "item"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "expensive"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s costs $ %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "item"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "item"
+                    },
+                    "Key": {
+                      "Value": "price"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/dataset_where_filter.lua.json
+++ b/tests/json-ast/x/lua/dataset_where_filter.lua.json
@@ -1,0 +1,336 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "30"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "15"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "65"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Diana"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "45"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "adults"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "person"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "people"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Condition": {
+            "Operator": "\u003e=",
+            "Lhs": {
+              "Object": {
+                "Value": "person"
+              },
+              "Key": {
+                "Value": "age"
+              }
+            },
+            "Rhs": {
+              "Value": "18"
+            }
+          },
+          "Then": [
+            {
+              "Expr": {
+                "Func": {
+                  "Object": {
+                    "Value": "table"
+                  },
+                  "Key": {
+                    "Value": "insert"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "adults"
+                  },
+                  {
+                    "Fields": [
+                      {
+                        "Key": {
+                          "Value": "name"
+                        },
+                        "Value": {
+                          "Object": {
+                            "Value": "person"
+                          },
+                          "Key": {
+                            "Value": "name"
+                          }
+                        }
+                      },
+                      {
+                        "Key": {
+                          "Value": "age"
+                        },
+                        "Value": {
+                          "Object": {
+                            "Value": "person"
+                          },
+                          "Key": {
+                            "Value": "age"
+                          }
+                        }
+                      },
+                      {
+                        "Key": {
+                          "Value": "is_senior"
+                        },
+                        "Value": {
+                          "Operator": "\u003e=",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "person"
+                            },
+                            "Key": {
+                              "Value": "age"
+                            }
+                          },
+                          "Rhs": {
+                            "Value": "60"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ],
+          "Else": null
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Adults ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "person"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "adults"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s is %s %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "person"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "person"
+                    },
+                    "Key": {
+                      "Value": "age"
+                    }
+                  },
+                  {
+                    "Operator": "or",
+                    "Lhs": {
+                      "Operator": "and",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "person"
+                        },
+                        "Key": {
+                          "Value": "is_senior"
+                        }
+                      },
+                      "Rhs": {
+                        "Value": " (senior)"
+                      }
+                    },
+                    "Rhs": {
+                      "Value": ""
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/exists_builtin.lua.json
+++ b/tests/json-ast/x/lua/exists_builtin.lua.json
@@ -1,0 +1,152 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "data"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "flag"
+        }
+      ],
+      "Rhs": [
+        {
+          "Operator": "\u003e",
+          "Lhs": {
+            "Expr": {
+              "Func": {
+                "ParList": {
+                  "HasVargs": false,
+                  "Names": []
+                },
+                "Stmts": [
+                  {
+                    "Names": [
+                      "_res"
+                    ],
+                    "Exprs": [
+                      {
+                        "Fields": []
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "_",
+                      "x"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "ipairs"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "data"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "Stmts": [
+                      {
+                        "Condition": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Value": "x"
+                          },
+                          "Rhs": {
+                            "Value": "1"
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Expr": {
+                              "Func": {
+                                "Object": {
+                                  "Value": "table"
+                                },
+                                "Key": {
+                                  "Value": "insert"
+                                }
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "_res"
+                                },
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          }
+                        ],
+                        "Else": null
+                      }
+                    ]
+                  },
+                  {
+                    "Exprs": [
+                      {
+                        "Value": "_res"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [],
+              "AdjustRet": true
+            }
+          },
+          "Rhs": {
+            "Value": "0"
+          }
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "flag"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/for_list_collection.lua.json
+++ b/tests/json-ast/x/lua/for_list_collection.lua.json
@@ -1,0 +1,61 @@
+{
+  "stmts": [
+    {
+      "Names": [
+        "_",
+        "n"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Fields": [
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "1"
+                  }
+                },
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "2"
+                  }
+                },
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "3"
+                  }
+                }
+              ]
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "n"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/for_loop.lua.json
+++ b/tests/json-ast/x/lua/for_loop.lua.json
@@ -1,0 +1,37 @@
+{
+  "stmts": [
+    {
+      "Name": "i",
+      "Init": {
+        "Value": "1"
+      },
+      "Limit": {
+        "Operator": "-",
+        "Lhs": {
+          "Value": "4"
+        },
+        "Rhs": {
+          "Value": "1"
+        }
+      },
+      "Step": null,
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "i"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/for_map_collection.lua.json
+++ b/tests/json-ast/x/lua/for_map_collection.lua.json
@@ -1,0 +1,70 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "k"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "pairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "m"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "k"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/fun_call.lua.json
+++ b/tests/json-ast/x/lua/fun_call.lua.json
@@ -1,0 +1,65 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "add"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "a",
+            "b"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "a"
+                },
+                "Rhs": {
+                  "Value": "b"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "add"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "2"
+              },
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/fun_expr_in_let.lua.json
+++ b/tests/json-ast/x/lua/fun_expr_in_let.lua.json
@@ -1,0 +1,61 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "square"
+        }
+      ],
+      "Rhs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "x"
+            ]
+          },
+          "Stmts": [
+            {
+              "Exprs": [
+                {
+                  "Operator": "*",
+                  "Lhs": {
+                    "Value": "x"
+                  },
+                  "Rhs": {
+                    "Value": "x"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "square"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "6"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/fun_three_args.lua.json
+++ b/tests/json-ast/x/lua/fun_three_args.lua.json
@@ -1,0 +1,75 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "sum3"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Value": "a"
+                  },
+                  "Rhs": {
+                    "Value": "b"
+                  }
+                },
+                "Rhs": {
+                  "Value": "c"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "sum3"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "1"
+              },
+              {
+                "Value": "2"
+              },
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/go_auto.lua.json
+++ b/tests/json-ast/x/lua/go_auto.lua.json
@@ -1,0 +1,135 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "testpkg"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "Add"
+              },
+              "Value": {
+                "ParList": {
+                  "HasVargs": false,
+                  "Names": [
+                    "a",
+                    "b"
+                  ]
+                },
+                "Stmts": [
+                  {
+                    "Exprs": [
+                      {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Value": "a"
+                        },
+                        "Rhs": {
+                          "Value": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "Key": {
+                "Value": "Pi"
+              },
+              "Value": {
+                "Value": "3.14"
+              }
+            },
+            {
+              "Key": {
+                "Value": "Answer"
+              },
+              "Value": {
+                "Value": "42"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "testpkg"
+              },
+              "Key": {
+                "Value": "Add"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "2"
+              },
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "testpkg"
+            },
+            "Key": {
+              "Value": "Pi"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "testpkg"
+            },
+            "Key": {
+              "Value": "Answer"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by.lua.json
+++ b/tests/json-ast/x/lua/group_by.lua.json
@@ -1,0 +1,1079 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "30"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "15"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Hanoi"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "65"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Diana"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "45"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Hanoi"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Eve"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "70"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Frank"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "22"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Hanoi"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "stats"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "person"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "people"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "person"
+                        },
+                        "Key": {
+                          "Value": "city"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "person"
+                                  },
+                                  "Key": {
+                                    "Value": "city"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "person"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "res"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "city"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "g"
+                                },
+                                "Key": {
+                                  "Value": "key"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "count"
+                              },
+                              "Value": {
+                                "Func": {
+                                  "ParList": {
+                                    "HasVargs": false,
+                                    "Names": [
+                                      "v"
+                                    ]
+                                  },
+                                  "Stmts": [
+                                    {
+                                      "Condition": {
+                                        "Operator": "and",
+                                        "Lhs": {
+                                          "Operator": "==",
+                                          "Lhs": {
+                                            "Func": {
+                                              "Value": "type"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "v"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Value": "table"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Operator": "~=",
+                                          "Lhs": {
+                                            "Object": {
+                                              "Value": "v"
+                                            },
+                                            "Key": {
+                                              "Value": "items"
+                                            }
+                                          },
+                                          "Rhs": {}
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Expr": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "items"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": [
+                                        {
+                                          "Condition": {
+                                            "Operator": "and",
+                                            "Lhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Func": {
+                                                  "Value": "type"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "v"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              },
+                                              "Rhs": {
+                                                "Value": "table"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "1"
+                                                }
+                                              },
+                                              "Rhs": {}
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Names": [
+                                                "c"
+                                              ],
+                                              "Exprs": [
+                                                {
+                                                  "Value": "0"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "Names": [
+                                                "_"
+                                              ],
+                                              "Exprs": [
+                                                {
+                                                  "Func": {
+                                                    "Value": "pairs"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "v"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              ],
+                                              "Stmts": [
+                                                {
+                                                  "Lhs": [
+                                                    {
+                                                      "Value": "c"
+                                                    }
+                                                  ],
+                                                  "Rhs": [
+                                                    {
+                                                      "Operator": "+",
+                                                      "Lhs": {
+                                                        "Value": "c"
+                                                      },
+                                                      "Rhs": {
+                                                        "Value": "1"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Value": "c"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "Else": [
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Expr": {
+                                                    "Value": "v"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "g"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "avg_age"
+                              },
+                              "Value": {
+                                "Func": {
+                                  "ParList": {
+                                    "HasVargs": false,
+                                    "Names": [
+                                      "lst"
+                                    ]
+                                  },
+                                  "Stmts": [
+                                    {
+                                      "Names": [
+                                        "sum"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Value": "0"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Names": [
+                                        "_",
+                                        "v"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Value": "ipairs"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "lst"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "Stmts": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Value": "sum"
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "sum"
+                                              },
+                                              "Rhs": {
+                                                "Value": "v"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Condition": {
+                                        "Operator": "==",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "lst"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "0"
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Value": "0"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    },
+                                    {
+                                      "Names": [
+                                        "r"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Operator": "/",
+                                          "Lhs": {
+                                            "Value": "sum"
+                                          },
+                                          "Rhs": {
+                                            "Expr": {
+                                              "Value": "lst"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Condition": {
+                                        "Operator": "==",
+                                        "Lhs": {
+                                          "Value": "r"
+                                        },
+                                        "Rhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "math"
+                                            },
+                                            "Key": {
+                                              "Value": "floor"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "r"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Func": {
+                                                "Object": {
+                                                  "Value": "math"
+                                                },
+                                                "Key": {
+                                                  "Value": "floor"
+                                                }
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "r"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    },
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "format"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "%.15f"
+                                            },
+                                            {
+                                              "Value": "r"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Func": {
+                                      "ParList": {
+                                        "HasVargs": false,
+                                        "Names": []
+                                      },
+                                      "Stmts": [
+                                        {
+                                          "Names": [
+                                            "_res"
+                                          ],
+                                          "Exprs": [
+                                            {
+                                              "Fields": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Names": [
+                                            "_",
+                                            "p"
+                                          ],
+                                          "Exprs": [
+                                            {
+                                              "Func": {
+                                                "Value": "ipairs"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "g"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "items"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          ],
+                                          "Stmts": [
+                                            {
+                                              "Expr": {
+                                                "Func": {
+                                                  "Object": {
+                                                    "Value": "table"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "insert"
+                                                  }
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "_res"
+                                                  },
+                                                  {
+                                                    "Object": {
+                                                      "Value": "p"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "age"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Value": "_res"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [],
+                                    "AdjustRet": false
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- People grouped by city ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "s"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "stats"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s : count = %s , avg_age = %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "city"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "count"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "avg_age"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_conditional_sum.lua.json
+++ b/tests/json-ast/x/lua/group_by_conditional_sum.lua.json
@@ -1,0 +1,1410 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "items"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "10"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "flag"
+                    },
+                    "Value": {}
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "5"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "flag"
+                    },
+                    "Value": {}
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "b"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "20"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "flag"
+                    },
+                    "Value": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "i"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "items"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "i"
+                        },
+                        "Key": {
+                          "Value": "cat"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Value": "key"
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "i"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "_res"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "cat"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "g"
+                                },
+                                "Key": {
+                                  "Value": "key"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "share"
+                              },
+                              "Value": {
+                                "Operator": "/",
+                                "Lhs": {
+                                  "Func": {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "lst"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Names": [
+                                          "s"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Value": "0"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Names": [
+                                          "_",
+                                          "v"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Func": {
+                                              "Value": "ipairs"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "lst"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        ],
+                                        "Stmts": [
+                                          {
+                                            "Lhs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ],
+                                            "Rhs": [
+                                              {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Value": "s"
+                                                },
+                                                "Rhs": {
+                                                  "Value": "v"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Value": "s"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": []
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "_res"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Fields": []
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "x"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "g"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "items"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Expr": {
+                                                  "Func": {
+                                                    "Object": {
+                                                      "Value": "table"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "insert"
+                                                    }
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "_res"
+                                                    },
+                                                    {
+                                                      "Operator": "or",
+                                                      "Lhs": {
+                                                        "Operator": "and",
+                                                        "Lhs": {
+                                                          "Object": {
+                                                            "Value": "x"
+                                                          },
+                                                          "Key": {
+                                                            "Value": "flag"
+                                                          }
+                                                        },
+                                                        "Rhs": {
+                                                          "Object": {
+                                                            "Value": "x"
+                                                          },
+                                                          "Key": {
+                                                            "Value": "val"
+                                                          }
+                                                        }
+                                                      },
+                                                      "Rhs": {
+                                                        "Value": "0"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "_res"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                },
+                                "Rhs": {
+                                  "Func": {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "lst"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Names": [
+                                          "s"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Value": "0"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Names": [
+                                          "_",
+                                          "v"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Func": {
+                                              "Value": "ipairs"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "lst"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        ],
+                                        "Stmts": [
+                                          {
+                                            "Lhs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ],
+                                            "Rhs": [
+                                              {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Value": "s"
+                                                },
+                                                "Rhs": {
+                                                  "Value": "v"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Value": "s"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": []
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "_res"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Fields": []
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "x"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "g"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "items"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Expr": {
+                                                  "Func": {
+                                                    "Object": {
+                                                      "Value": "table"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "insert"
+                                                    }
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "_res"
+                                                    },
+                                                    {
+                                                      "Object": {
+                                                        "Value": "x"
+                                                      },
+                                                      "Key": {
+                                                        "Value": "val"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "_res"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "result"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_having.lua.json
+++ b/tests/json-ast/x/lua/group_by_having.lua.json
@@ -1,0 +1,1923 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Hanoi"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Diana"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Hanoi"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Eve"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Frank"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Hanoi"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "George"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "city"
+                    },
+                    "Value": {
+                      "Value": "Paris"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "big"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "people"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "city"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "p"
+                                  },
+                                  "Key": {
+                                    "Value": "city"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "p"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "\u003e=",
+                      "Lhs": {
+                        "Func": {
+                          "ParList": {
+                            "HasVargs": false,
+                            "Names": [
+                              "v"
+                            ]
+                          },
+                          "Stmts": [
+                            {
+                              "Condition": {
+                                "Operator": "and",
+                                "Lhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "v"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "table"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Operator": "~=",
+                                  "Lhs": {
+                                    "Object": {
+                                      "Value": "v"
+                                    },
+                                    "Key": {
+                                      "Value": "items"
+                                    }
+                                  },
+                                  "Rhs": {}
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Expr": {
+                                        "Object": {
+                                          "Value": "v"
+                                        },
+                                        "Key": {
+                                          "Value": "items"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Condition": {
+                                    "Operator": "and",
+                                    "Lhs": {
+                                      "Operator": "==",
+                                      "Lhs": {
+                                        "Func": {
+                                          "Value": "type"
+                                        },
+                                        "Receiver": null,
+                                        "Method": "",
+                                        "Args": [
+                                          {
+                                            "Value": "v"
+                                          }
+                                        ],
+                                        "AdjustRet": false
+                                      },
+                                      "Rhs": {
+                                        "Value": "table"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Operator": "==",
+                                      "Lhs": {
+                                        "Object": {
+                                          "Value": "v"
+                                        },
+                                        "Key": {
+                                          "Value": "1"
+                                        }
+                                      },
+                                      "Rhs": {}
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Names": [
+                                        "c"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Value": "0"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Names": [
+                                        "_"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Value": "pairs"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "v"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "Stmts": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Value": "c"
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "c"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "c"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Expr": {
+                                            "Value": "v"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "4"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "res"
+                            },
+                            {
+                              "Fields": [
+                                {
+                                  "Key": {
+                                    "Value": "city"
+                                  },
+                                  "Value": {
+                                    "Object": {
+                                      "Value": "g"
+                                    },
+                                    "Key": {
+                                      "Value": "key"
+                                    }
+                                  }
+                                },
+                                {
+                                  "Key": {
+                                    "Value": "num"
+                                  },
+                                  "Value": {
+                                    "Func": {
+                                      "ParList": {
+                                        "HasVargs": false,
+                                        "Names": [
+                                          "v"
+                                        ]
+                                      },
+                                      "Stmts": [
+                                        {
+                                          "Condition": {
+                                            "Operator": "and",
+                                            "Lhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Func": {
+                                                  "Value": "type"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "v"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              },
+                                              "Rhs": {
+                                                "Value": "table"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Operator": "~=",
+                                              "Lhs": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "items"
+                                                }
+                                              },
+                                              "Rhs": {}
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Expr": {
+                                                    "Object": {
+                                                      "Value": "v"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "items"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "Else": [
+                                            {
+                                              "Condition": {
+                                                "Operator": "and",
+                                                "Lhs": {
+                                                  "Operator": "==",
+                                                  "Lhs": {
+                                                    "Func": {
+                                                      "Value": "type"
+                                                    },
+                                                    "Receiver": null,
+                                                    "Method": "",
+                                                    "Args": [
+                                                      {
+                                                        "Value": "v"
+                                                      }
+                                                    ],
+                                                    "AdjustRet": false
+                                                  },
+                                                  "Rhs": {
+                                                    "Value": "table"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Operator": "==",
+                                                  "Lhs": {
+                                                    "Object": {
+                                                      "Value": "v"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "1"
+                                                    }
+                                                  },
+                                                  "Rhs": {}
+                                                }
+                                              },
+                                              "Then": [
+                                                {
+                                                  "Names": [
+                                                    "c"
+                                                  ],
+                                                  "Exprs": [
+                                                    {
+                                                      "Value": "0"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "Names": [
+                                                    "_"
+                                                  ],
+                                                  "Exprs": [
+                                                    {
+                                                      "Func": {
+                                                        "Value": "pairs"
+                                                      },
+                                                      "Receiver": null,
+                                                      "Method": "",
+                                                      "Args": [
+                                                        {
+                                                          "Value": "v"
+                                                        }
+                                                      ],
+                                                      "AdjustRet": false
+                                                    }
+                                                  ],
+                                                  "Stmts": [
+                                                    {
+                                                      "Lhs": [
+                                                        {
+                                                          "Value": "c"
+                                                        }
+                                                      ],
+                                                      "Rhs": [
+                                                        {
+                                                          "Operator": "+",
+                                                          "Lhs": {
+                                                            "Value": "c"
+                                                          },
+                                                          "Rhs": {
+                                                            "Value": "1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "Exprs": [
+                                                    {
+                                                      "Value": "c"
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "Else": [
+                                                {
+                                                  "Exprs": [
+                                                    {
+                                                      "Expr": {
+                                                        "Value": "v"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "g"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "is_array"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "t"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "i"
+                      ],
+                      "Exprs": [
+                        {
+                          "Value": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "k",
+                        "_"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "pairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "t"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Value": "k"
+                            },
+                            "Rhs": {
+                              "Value": "i"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {}
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Lhs": [
+                            {
+                              "Value": "i"
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Operator": "+",
+                              "Lhs": {
+                                "Value": "i"
+                              },
+                              "Rhs": {
+                                "Value": "1"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {}
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x",
+                      "ind"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Value": "ind"
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Operator": "or",
+                          "Lhs": {
+                            "Value": "ind"
+                          },
+                          "Rhs": {
+                            "Value": "0"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "pad"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Object": {
+                              "Value": "string"
+                            },
+                            "Key": {
+                              "Value": "rep"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "  "
+                            },
+                            {
+                              "Value": "ind"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ]
+                    },
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Func": {
+                              "Value": "is_array"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "x"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Func": {
+                                            "Value": "encode"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "val"
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "x"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Func": {
+                                              "Object": {
+                                                "Value": "string"
+                                              },
+                                              "Key": {
+                                                "Value": "format"
+                                              }
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "%q"
+                                              },
+                                              {
+                                                "Value": "k"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Value": ": "
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "encode"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "x"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "k"
+                                                  }
+                                                },
+                                                {
+                                                  "Operator": "+",
+                                                  "Lhs": {
+                                                    "Value": "ind"
+                                                  },
+                                                  "Rhs": {
+                                                    "Value": "1"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "keys"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "string"
+                                    },
+                                    "Key": {
+                                      "Value": "format"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "%q"
+                                    },
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "or",
+                                "Lhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "boolean"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "number"
+                                  }
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Condition": {
+                                    "Operator": "==",
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {}
+                                  },
+                                  "Then": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      },
+                      {
+                        "Value": "0"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "big"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_join.lua.json
+++ b/tests/json-ast/x/lua/group_by_join.lua.json
@@ -1,0 +1,783 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "102"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "stats"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "o"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orders"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "_",
+                      "c"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "ipairs"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "customers"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "Stmts": [
+                      {
+                        "Condition": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "o"
+                            },
+                            "Key": {
+                              "Value": "customerId"
+                            }
+                          },
+                          "Rhs": {
+                            "Object": {
+                              "Value": "c"
+                            },
+                            "Key": {
+                              "Value": "id"
+                            }
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Names": [
+                              "key"
+                            ],
+                            "Exprs": [
+                              {
+                                "Object": {
+                                  "Value": "c"
+                                },
+                                "Key": {
+                                  "Value": "name"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Names": [
+                              "ks"
+                            ],
+                            "Exprs": [
+                              {
+                                "Func": {
+                                  "Value": "tostring"
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "key"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            ]
+                          },
+                          {
+                            "Names": [
+                              "g"
+                            ],
+                            "Exprs": [
+                              {
+                                "Object": {
+                                  "Value": "groups"
+                                },
+                                "Key": {
+                                  "Value": "ks"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Condition": {
+                              "Operator": "==",
+                              "Lhs": {
+                                "Value": "g"
+                              },
+                              "Rhs": {}
+                            },
+                            "Then": [
+                              {
+                                "Lhs": [
+                                  {
+                                    "Value": "g"
+                                  }
+                                ],
+                                "Rhs": [
+                                  {
+                                    "Fields": [
+                                      {
+                                        "Key": {
+                                          "Value": "key"
+                                        },
+                                        "Value": {
+                                          "Object": {
+                                            "Value": "c"
+                                          },
+                                          "Key": {
+                                            "Value": "name"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Key": {
+                                          "Value": "items"
+                                        },
+                                        "Value": {
+                                          "Fields": []
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Lhs": [
+                                  {
+                                    "Object": {
+                                      "Value": "groups"
+                                    },
+                                    "Key": {
+                                      "Value": "ks"
+                                    }
+                                  }
+                                ],
+                                "Rhs": [
+                                  {
+                                    "Value": "g"
+                                  }
+                                ]
+                              },
+                              {
+                                "Expr": {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "insert"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "orderKeys"
+                                    },
+                                    {
+                                      "Value": "ks"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              }
+                            ],
+                            "Else": null
+                          },
+                          {
+                            "Expr": {
+                              "Func": {
+                                "Object": {
+                                  "Value": "table"
+                                },
+                                "Key": {
+                                  "Value": "insert"
+                                }
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Object": {
+                                    "Value": "g"
+                                  },
+                                  "Key": {
+                                    "Value": "items"
+                                  }
+                                },
+                                {
+                                  "Value": "o"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          }
+                        ],
+                        "Else": null
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "res"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "name"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "g"
+                                },
+                                "Key": {
+                                  "Value": "key"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "count"
+                              },
+                              "Value": {
+                                "Func": {
+                                  "ParList": {
+                                    "HasVargs": false,
+                                    "Names": [
+                                      "v"
+                                    ]
+                                  },
+                                  "Stmts": [
+                                    {
+                                      "Condition": {
+                                        "Operator": "and",
+                                        "Lhs": {
+                                          "Operator": "==",
+                                          "Lhs": {
+                                            "Func": {
+                                              "Value": "type"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "v"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Value": "table"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Operator": "~=",
+                                          "Lhs": {
+                                            "Object": {
+                                              "Value": "v"
+                                            },
+                                            "Key": {
+                                              "Value": "items"
+                                            }
+                                          },
+                                          "Rhs": {}
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Expr": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "items"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": [
+                                        {
+                                          "Condition": {
+                                            "Operator": "and",
+                                            "Lhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Func": {
+                                                  "Value": "type"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "v"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              },
+                                              "Rhs": {
+                                                "Value": "table"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "1"
+                                                }
+                                              },
+                                              "Rhs": {}
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Names": [
+                                                "c"
+                                              ],
+                                              "Exprs": [
+                                                {
+                                                  "Value": "0"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "Names": [
+                                                "_"
+                                              ],
+                                              "Exprs": [
+                                                {
+                                                  "Func": {
+                                                    "Value": "pairs"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "v"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              ],
+                                              "Stmts": [
+                                                {
+                                                  "Lhs": [
+                                                    {
+                                                      "Value": "c"
+                                                    }
+                                                  ],
+                                                  "Rhs": [
+                                                    {
+                                                      "Operator": "+",
+                                                      "Lhs": {
+                                                        "Value": "c"
+                                                      },
+                                                      "Rhs": {
+                                                        "Value": "1"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Value": "c"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "Else": [
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Expr": {
+                                                    "Value": "v"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "g"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Orders per customer ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "s"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "stats"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s orders: %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "count"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_left_join.lua.json
+++ b/tests/json-ast/x/lua/group_by_left_join.lua.json
@@ -1,0 +1,898 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "102"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "stats"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "c"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "customers"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "_",
+                      "o"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "ipairs"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "orders"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "Stmts": [
+                      {
+                        "Condition": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "o"
+                            },
+                            "Key": {
+                              "Value": "customerId"
+                            }
+                          },
+                          "Rhs": {
+                            "Object": {
+                              "Value": "c"
+                            },
+                            "Key": {
+                              "Value": "id"
+                            }
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Names": [
+                              "key"
+                            ],
+                            "Exprs": [
+                              {
+                                "Object": {
+                                  "Value": "c"
+                                },
+                                "Key": {
+                                  "Value": "name"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Names": [
+                              "ks"
+                            ],
+                            "Exprs": [
+                              {
+                                "Func": {
+                                  "Value": "tostring"
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "key"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            ]
+                          },
+                          {
+                            "Names": [
+                              "g"
+                            ],
+                            "Exprs": [
+                              {
+                                "Object": {
+                                  "Value": "groups"
+                                },
+                                "Key": {
+                                  "Value": "ks"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Condition": {
+                              "Operator": "==",
+                              "Lhs": {
+                                "Value": "g"
+                              },
+                              "Rhs": {}
+                            },
+                            "Then": [
+                              {
+                                "Lhs": [
+                                  {
+                                    "Value": "g"
+                                  }
+                                ],
+                                "Rhs": [
+                                  {
+                                    "Fields": [
+                                      {
+                                        "Key": {
+                                          "Value": "key"
+                                        },
+                                        "Value": {
+                                          "Object": {
+                                            "Value": "c"
+                                          },
+                                          "Key": {
+                                            "Value": "name"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Key": {
+                                          "Value": "items"
+                                        },
+                                        "Value": {
+                                          "Fields": []
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Lhs": [
+                                  {
+                                    "Object": {
+                                      "Value": "groups"
+                                    },
+                                    "Key": {
+                                      "Value": "ks"
+                                    }
+                                  }
+                                ],
+                                "Rhs": [
+                                  {
+                                    "Value": "g"
+                                  }
+                                ]
+                              },
+                              {
+                                "Expr": {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "insert"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "orderKeys"
+                                    },
+                                    {
+                                      "Value": "ks"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              }
+                            ],
+                            "Else": null
+                          },
+                          {
+                            "Expr": {
+                              "Func": {
+                                "Object": {
+                                  "Value": "table"
+                                },
+                                "Key": {
+                                  "Value": "insert"
+                                }
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Object": {
+                                    "Value": "g"
+                                  },
+                                  "Key": {
+                                    "Value": "items"
+                                  }
+                                },
+                                {
+                                  "Value": "c"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          }
+                        ],
+                        "Else": null
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "res"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "name"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "g"
+                                },
+                                "Key": {
+                                  "Value": "key"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "count"
+                              },
+                              "Value": {
+                                "Func": {
+                                  "ParList": {
+                                    "HasVargs": false,
+                                    "Names": [
+                                      "v"
+                                    ]
+                                  },
+                                  "Stmts": [
+                                    {
+                                      "Condition": {
+                                        "Operator": "and",
+                                        "Lhs": {
+                                          "Operator": "==",
+                                          "Lhs": {
+                                            "Func": {
+                                              "Value": "type"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "v"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Value": "table"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Operator": "~=",
+                                          "Lhs": {
+                                            "Object": {
+                                              "Value": "v"
+                                            },
+                                            "Key": {
+                                              "Value": "items"
+                                            }
+                                          },
+                                          "Rhs": {}
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Expr": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "items"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": [
+                                        {
+                                          "Condition": {
+                                            "Operator": "and",
+                                            "Lhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Func": {
+                                                  "Value": "type"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "v"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              },
+                                              "Rhs": {
+                                                "Value": "table"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Operator": "==",
+                                              "Lhs": {
+                                                "Object": {
+                                                  "Value": "v"
+                                                },
+                                                "Key": {
+                                                  "Value": "1"
+                                                }
+                                              },
+                                              "Rhs": {}
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Names": [
+                                                "c"
+                                              ],
+                                              "Exprs": [
+                                                {
+                                                  "Value": "0"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "Names": [
+                                                "_"
+                                              ],
+                                              "Exprs": [
+                                                {
+                                                  "Func": {
+                                                    "Value": "pairs"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "v"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              ],
+                                              "Stmts": [
+                                                {
+                                                  "Lhs": [
+                                                    {
+                                                      "Value": "c"
+                                                    }
+                                                  ],
+                                                  "Rhs": [
+                                                    {
+                                                      "Operator": "+",
+                                                      "Lhs": {
+                                                        "Value": "c"
+                                                      },
+                                                      "Rhs": {
+                                                        "Value": "1"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Value": "c"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "Else": [
+                                            {
+                                              "Exprs": [
+                                                {
+                                                  "Expr": {
+                                                    "Value": "v"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Func": {
+                                      "ParList": {
+                                        "HasVargs": false,
+                                        "Names": []
+                                      },
+                                      "Stmts": [
+                                        {
+                                          "Names": [
+                                            "_res"
+                                          ],
+                                          "Exprs": [
+                                            {
+                                              "Fields": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Names": [
+                                            "_",
+                                            "r"
+                                          ],
+                                          "Exprs": [
+                                            {
+                                              "Func": {
+                                                "Value": "ipairs"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "g"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "items"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          ],
+                                          "Stmts": [
+                                            {
+                                              "Condition": {
+                                                "Object": {
+                                                  "Value": "r"
+                                                },
+                                                "Key": {
+                                                  "Value": "o"
+                                                }
+                                              },
+                                              "Then": [
+                                                {
+                                                  "Expr": {
+                                                    "Func": {
+                                                      "Object": {
+                                                        "Value": "table"
+                                                      },
+                                                      "Key": {
+                                                        "Value": "insert"
+                                                      }
+                                                    },
+                                                    "Receiver": null,
+                                                    "Method": "",
+                                                    "Args": [
+                                                      {
+                                                        "Value": "_res"
+                                                      },
+                                                      {
+                                                        "Value": "r"
+                                                      }
+                                                    ],
+                                                    "AdjustRet": false
+                                                  }
+                                                }
+                                              ],
+                                              "Else": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Value": "_res"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [],
+                                    "AdjustRet": false
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Group Left Join ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "s"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "stats"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s orders: %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "s"
+                    },
+                    "Key": {
+                      "Value": "count"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_multi_join.lua.json
+++ b/tests/json-ast/x/lua/group_by_multi_join.lua.json
@@ -1,0 +1,1993 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nations"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "A"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "B"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "suppliers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "nation"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "nation"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "partsupp"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "part"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "supplier"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "cost"
+                    },
+                    "Value": {
+                      "Value": "10"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "qty"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "part"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "supplier"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "cost"
+                    },
+                    "Value": {
+                      "Value": "20"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "qty"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "part"
+                    },
+                    "Value": {
+                      "Value": "200"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "supplier"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "cost"
+                    },
+                    "Value": {
+                      "Value": "5"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "qty"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "filtered"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "ps"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "partsupp"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "s"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "suppliers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Names": [
+                "_",
+                "n"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "ipairs"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "nations"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ],
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "and",
+                      "Lhs": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "s"
+                          },
+                          "Key": {
+                            "Value": "id"
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "ps"
+                          },
+                          "Key": {
+                            "Value": "supplier"
+                          }
+                        }
+                      },
+                      "Rhs": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "n"
+                          },
+                          "Key": {
+                            "Value": "id"
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "s"
+                          },
+                          "Key": {
+                            "Value": "nation"
+                          }
+                        }
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "n"
+                        },
+                        "Key": {
+                          "Value": "name"
+                        }
+                      },
+                      "Rhs": {
+                        "Value": "A"
+                      }
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Expr": {
+                        "Func": {
+                          "Object": {
+                            "Value": "table"
+                          },
+                          "Key": {
+                            "Value": "insert"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "filtered"
+                          },
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "part"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "ps"
+                                  },
+                                  "Key": {
+                                    "Value": "part"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "value"
+                                },
+                                "Value": {
+                                  "Operator": "*",
+                                  "Lhs": {
+                                    "Object": {
+                                      "Value": "ps"
+                                    },
+                                    "Key": {
+                                      "Value": "cost"
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Object": {
+                                      "Value": "ps"
+                                    },
+                                    "Key": {
+                                      "Value": "qty"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    }
+                  ],
+                  "Else": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "grouped"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "x"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "filtered"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "x"
+                        },
+                        "Key": {
+                          "Value": "part"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "x"
+                                  },
+                                  "Key": {
+                                    "Value": "part"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "x"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "res"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "part"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "g"
+                                },
+                                "Key": {
+                                  "Value": "key"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "total"
+                              },
+                              "Value": {
+                                "Func": {
+                                  "ParList": {
+                                    "HasVargs": false,
+                                    "Names": [
+                                      "lst"
+                                    ]
+                                  },
+                                  "Stmts": [
+                                    {
+                                      "Names": [
+                                        "s"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Value": "0"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Names": [
+                                        "_",
+                                        "v"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Value": "ipairs"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "lst"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "Stmts": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Value": "s"
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "s"
+                                              },
+                                              "Rhs": {
+                                                "Value": "v"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "s"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Func": {
+                                      "ParList": {
+                                        "HasVargs": false,
+                                        "Names": []
+                                      },
+                                      "Stmts": [
+                                        {
+                                          "Names": [
+                                            "_res"
+                                          ],
+                                          "Exprs": [
+                                            {
+                                              "Fields": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Names": [
+                                            "_",
+                                            "r"
+                                          ],
+                                          "Exprs": [
+                                            {
+                                              "Func": {
+                                                "Value": "ipairs"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "g"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "items"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          ],
+                                          "Stmts": [
+                                            {
+                                              "Expr": {
+                                                "Func": {
+                                                  "Object": {
+                                                    "Value": "table"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "insert"
+                                                  }
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "_res"
+                                                  },
+                                                  {
+                                                    "Object": {
+                                                      "Value": "r"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "value"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Exprs": [
+                                            {
+                                              "Value": "_res"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [],
+                                    "AdjustRet": false
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "is_array"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "t"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "i"
+                      ],
+                      "Exprs": [
+                        {
+                          "Value": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "k",
+                        "_"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "pairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "t"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Value": "k"
+                            },
+                            "Rhs": {
+                              "Value": "i"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {}
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Lhs": [
+                            {
+                              "Value": "i"
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Operator": "+",
+                              "Lhs": {
+                                "Value": "i"
+                              },
+                              "Rhs": {
+                                "Value": "1"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {}
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x",
+                      "ind"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Value": "ind"
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Operator": "or",
+                          "Lhs": {
+                            "Value": "ind"
+                          },
+                          "Rhs": {
+                            "Value": "0"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "pad"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Object": {
+                              "Value": "string"
+                            },
+                            "Key": {
+                              "Value": "rep"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "  "
+                            },
+                            {
+                              "Value": "ind"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ]
+                    },
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Func": {
+                              "Value": "is_array"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "x"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Func": {
+                                            "Value": "encode"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "val"
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "x"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Func": {
+                                              "Object": {
+                                                "Value": "string"
+                                              },
+                                              "Key": {
+                                                "Value": "format"
+                                              }
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "%q"
+                                              },
+                                              {
+                                                "Value": "k"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Value": ": "
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "encode"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "x"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "k"
+                                                  }
+                                                },
+                                                {
+                                                  "Operator": "+",
+                                                  "Lhs": {
+                                                    "Value": "ind"
+                                                  },
+                                                  "Rhs": {
+                                                    "Value": "1"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "keys"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "string"
+                                    },
+                                    "Key": {
+                                      "Value": "format"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "%q"
+                                    },
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "or",
+                                "Lhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "boolean"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "number"
+                                  }
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Condition": {
+                                    "Operator": "==",
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {}
+                                  },
+                                  "Then": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      },
+                      {
+                        "Value": "0"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "grouped"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_multi_join_sort.lua.json
+++ b/tests/json-ast/x/lua/group_by_multi_join_sort.lua.json
@@ -1,0 +1,2740 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nation"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "n_nationkey"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "n_name"
+                    },
+                    "Value": {
+                      "Value": "BRAZIL"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "customer"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "c_custkey"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "c_name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "c_acctbal"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "c_nationkey"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "c_address"
+                    },
+                    "Value": {
+                      "Value": "123 St"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "c_phone"
+                    },
+                    "Value": {
+                      "Value": "123-456"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "c_comment"
+                    },
+                    "Value": {
+                      "Value": "Loyal"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "o_orderkey"
+                    },
+                    "Value": {
+                      "Value": "1000"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "o_custkey"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "o_orderdate"
+                    },
+                    "Value": {
+                      "Value": "1993-10-15"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "o_orderkey"
+                    },
+                    "Value": {
+                      "Value": "2000"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "o_custkey"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "o_orderdate"
+                    },
+                    "Value": {
+                      "Value": "1994-01-02"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "lineitem"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "l_orderkey"
+                    },
+                    "Value": {
+                      "Value": "1000"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "l_returnflag"
+                    },
+                    "Value": {
+                      "Value": "R"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "l_extendedprice"
+                    },
+                    "Value": {
+                      "Value": "1000"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "l_discount"
+                    },
+                    "Value": {
+                      "Value": "0.1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "l_orderkey"
+                    },
+                    "Value": {
+                      "Value": "2000"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "l_returnflag"
+                    },
+                    "Value": {
+                      "Value": "N"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "l_extendedprice"
+                    },
+                    "Value": {
+                      "Value": "500"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "l_discount"
+                    },
+                    "Value": {
+                      "Value": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "start_date"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "1993-10-01"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "end_date"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "1994-01-01"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "c"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "customer"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "_",
+                      "o"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "ipairs"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "orders"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "Stmts": [
+                      {
+                        "Names": [
+                          "_",
+                          "l"
+                        ],
+                        "Exprs": [
+                          {
+                            "Func": {
+                              "Value": "ipairs"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "lineitem"
+                              }
+                            ],
+                            "AdjustRet": false
+                          }
+                        ],
+                        "Stmts": [
+                          {
+                            "Names": [
+                              "_",
+                              "n"
+                            ],
+                            "Exprs": [
+                              {
+                                "Func": {
+                                  "Value": "ipairs"
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "nation"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            ],
+                            "Stmts": [
+                              {
+                                "Condition": {
+                                  "Operator": "and",
+                                  "Lhs": {
+                                    "Operator": "and",
+                                    "Lhs": {
+                                      "Operator": "and",
+                                      "Lhs": {
+                                        "Operator": "==",
+                                        "Lhs": {
+                                          "Object": {
+                                            "Value": "o"
+                                          },
+                                          "Key": {
+                                            "Value": "o_custkey"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Object": {
+                                            "Value": "c"
+                                          },
+                                          "Key": {
+                                            "Value": "c_custkey"
+                                          }
+                                        }
+                                      },
+                                      "Rhs": {
+                                        "Operator": "==",
+                                        "Lhs": {
+                                          "Object": {
+                                            "Value": "l"
+                                          },
+                                          "Key": {
+                                            "Value": "l_orderkey"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Object": {
+                                            "Value": "o"
+                                          },
+                                          "Key": {
+                                            "Value": "o_orderkey"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Operator": "==",
+                                      "Lhs": {
+                                        "Object": {
+                                          "Value": "n"
+                                        },
+                                        "Key": {
+                                          "Value": "n_nationkey"
+                                        }
+                                      },
+                                      "Rhs": {
+                                        "Object": {
+                                          "Value": "c"
+                                        },
+                                        "Key": {
+                                          "Value": "c_nationkey"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Operator": "==",
+                                    "Lhs": {
+                                      "Operator": "and",
+                                      "Lhs": {
+                                        "Operator": "\u003c",
+                                        "Lhs": {
+                                          "Operator": "and",
+                                          "Lhs": {
+                                            "Operator": "\u003e=",
+                                            "Lhs": {
+                                              "Object": {
+                                                "Value": "o"
+                                              },
+                                              "Key": {
+                                                "Value": "o_orderdate"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "start_date"
+                                            }
+                                          },
+                                          "Rhs": {
+                                            "Object": {
+                                              "Value": "o"
+                                            },
+                                            "Key": {
+                                              "Value": "o_orderdate"
+                                            }
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "end_date"
+                                        }
+                                      },
+                                      "Rhs": {
+                                        "Object": {
+                                          "Value": "l"
+                                        },
+                                        "Key": {
+                                          "Value": "l_returnflag"
+                                        }
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "R"
+                                    }
+                                  }
+                                },
+                                "Then": [
+                                  {
+                                    "Names": [
+                                      "key"
+                                    ],
+                                    "Exprs": [
+                                      {
+                                        "Fields": [
+                                          {
+                                            "Key": {
+                                              "Value": "c_custkey"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "c"
+                                              },
+                                              "Key": {
+                                                "Value": "c_custkey"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Key": {
+                                              "Value": "c_name"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "c"
+                                              },
+                                              "Key": {
+                                                "Value": "c_name"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Key": {
+                                              "Value": "c_acctbal"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "c"
+                                              },
+                                              "Key": {
+                                                "Value": "c_acctbal"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Key": {
+                                              "Value": "c_address"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "c"
+                                              },
+                                              "Key": {
+                                                "Value": "c_address"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Key": {
+                                              "Value": "c_phone"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "c"
+                                              },
+                                              "Key": {
+                                                "Value": "c_phone"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Key": {
+                                              "Value": "c_comment"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "c"
+                                              },
+                                              "Key": {
+                                                "Value": "c_comment"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Key": {
+                                              "Value": "n_name"
+                                            },
+                                            "Value": {
+                                              "Object": {
+                                                "Value": "n"
+                                              },
+                                              "Key": {
+                                                "Value": "n_name"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Names": [
+                                      "ks"
+                                    ],
+                                    "Exprs": [
+                                      {
+                                        "Func": {
+                                          "Value": "tostring"
+                                        },
+                                        "Receiver": null,
+                                        "Method": "",
+                                        "Args": [
+                                          {
+                                            "Value": "key"
+                                          }
+                                        ],
+                                        "AdjustRet": false
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Names": [
+                                      "g"
+                                    ],
+                                    "Exprs": [
+                                      {
+                                        "Object": {
+                                          "Value": "groups"
+                                        },
+                                        "Key": {
+                                          "Value": "ks"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Condition": {
+                                      "Operator": "==",
+                                      "Lhs": {
+                                        "Value": "g"
+                                      },
+                                      "Rhs": {}
+                                    },
+                                    "Then": [
+                                      {
+                                        "Lhs": [
+                                          {
+                                            "Value": "g"
+                                          }
+                                        ],
+                                        "Rhs": [
+                                          {
+                                            "Fields": [
+                                              {
+                                                "Key": {
+                                                  "Value": "key"
+                                                },
+                                                "Value": {
+                                                  "Fields": [
+                                                    {
+                                                      "Key": {
+                                                        "Value": "c_custkey"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "c"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "c_custkey"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Key": {
+                                                        "Value": "c_name"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "c"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "c_name"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Key": {
+                                                        "Value": "c_acctbal"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "c"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "c_acctbal"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Key": {
+                                                        "Value": "c_address"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "c"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "c_address"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Key": {
+                                                        "Value": "c_phone"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "c"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "c_phone"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Key": {
+                                                        "Value": "c_comment"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "c"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "c_comment"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Key": {
+                                                        "Value": "n_name"
+                                                      },
+                                                      "Value": {
+                                                        "Object": {
+                                                          "Value": "n"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "n_name"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "Key": {
+                                                  "Value": "items"
+                                                },
+                                                "Value": {
+                                                  "Fields": []
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Lhs": [
+                                          {
+                                            "Object": {
+                                              "Value": "groups"
+                                            },
+                                            "Key": {
+                                              "Value": "ks"
+                                            }
+                                          }
+                                        ],
+                                        "Rhs": [
+                                          {
+                                            "Value": "g"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Expr": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "table"
+                                            },
+                                            "Key": {
+                                              "Value": "insert"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "orderKeys"
+                                            },
+                                            {
+                                              "Value": "ks"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      }
+                                    ],
+                                    "Else": null
+                                  },
+                                  {
+                                    "Names": [
+                                      "row"
+                                    ],
+                                    "Exprs": [
+                                      {
+                                        "Fields": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Lhs": [
+                                      {
+                                        "Object": {
+                                          "Value": "row"
+                                        },
+                                        "Key": {
+                                          "Value": "c"
+                                        }
+                                      }
+                                    ],
+                                    "Rhs": [
+                                      {
+                                        "Value": "c"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Lhs": [
+                                      {
+                                        "Object": {
+                                          "Value": "row"
+                                        },
+                                        "Key": {
+                                          "Value": "o"
+                                        }
+                                      }
+                                    ],
+                                    "Rhs": [
+                                      {
+                                        "Value": "o"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Lhs": [
+                                      {
+                                        "Object": {
+                                          "Value": "row"
+                                        },
+                                        "Key": {
+                                          "Value": "l"
+                                        }
+                                      }
+                                    ],
+                                    "Rhs": [
+                                      {
+                                        "Value": "l"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Lhs": [
+                                      {
+                                        "Object": {
+                                          "Value": "row"
+                                        },
+                                        "Key": {
+                                          "Value": "n"
+                                        }
+                                      }
+                                    ],
+                                    "Rhs": [
+                                      {
+                                        "Value": "n"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Expr": {
+                                      "Func": {
+                                        "Object": {
+                                          "Value": "table"
+                                        },
+                                        "Key": {
+                                          "Value": "insert"
+                                        }
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Object": {
+                                            "Value": "g"
+                                          },
+                                          "Key": {
+                                            "Value": "items"
+                                          }
+                                        },
+                                        {
+                                          "Value": "row"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  }
+                                ],
+                                "Else": null
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Operator": "-",
+                                "Lhs": {
+                                  "Value": "0"
+                                },
+                                "Rhs": {
+                                  "Func": {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "lst"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Names": [
+                                          "s"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Value": "0"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Names": [
+                                          "_",
+                                          "v"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Func": {
+                                              "Value": "ipairs"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "lst"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        ],
+                                        "Stmts": [
+                                          {
+                                            "Lhs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ],
+                                            "Rhs": [
+                                              {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Value": "s"
+                                                },
+                                                "Rhs": {
+                                                  "Value": "v"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Value": "s"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": []
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "_res"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Fields": []
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "x"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "g"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "items"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Expr": {
+                                                  "Func": {
+                                                    "Object": {
+                                                      "Value": "table"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "insert"
+                                                    }
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "_res"
+                                                    },
+                                                    {
+                                                      "Operator": "*",
+                                                      "Lhs": {
+                                                        "Object": {
+                                                          "Object": {
+                                                            "Value": "x"
+                                                          },
+                                                          "Key": {
+                                                            "Value": "l"
+                                                          }
+                                                        },
+                                                        "Key": {
+                                                          "Value": "l_extendedprice"
+                                                        }
+                                                      },
+                                                      "Rhs": {
+                                                        "Operator": "-",
+                                                        "Lhs": {
+                                                          "Value": "1"
+                                                        },
+                                                        "Rhs": {
+                                                          "Object": {
+                                                            "Object": {
+                                                              "Value": "x"
+                                                            },
+                                                            "Key": {
+                                                              "Value": "l"
+                                                            }
+                                                          },
+                                                          "Key": {
+                                                            "Value": "l_discount"
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "_res"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Fields": [
+                                  {
+                                    "Key": {
+                                      "Value": "c_custkey"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "c_custkey"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "c_name"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "c_name"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "revenue"
+                                    },
+                                    "Value": {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": [
+                                            "lst"
+                                          ]
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "s"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Value": "0"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "v"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "lst"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Lhs": [
+                                                  {
+                                                    "Value": "s"
+                                                  }
+                                                ],
+                                                "Rhs": [
+                                                  {
+                                                    "Operator": "+",
+                                                    "Lhs": {
+                                                      "Value": "s"
+                                                    },
+                                                    "Rhs": {
+                                                      "Value": "v"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Func": {
+                                            "ParList": {
+                                              "HasVargs": false,
+                                              "Names": []
+                                            },
+                                            "Stmts": [
+                                              {
+                                                "Names": [
+                                                  "_res"
+                                                ],
+                                                "Exprs": [
+                                                  {
+                                                    "Fields": []
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "Names": [
+                                                  "_",
+                                                  "x"
+                                                ],
+                                                "Exprs": [
+                                                  {
+                                                    "Func": {
+                                                      "Value": "ipairs"
+                                                    },
+                                                    "Receiver": null,
+                                                    "Method": "",
+                                                    "Args": [
+                                                      {
+                                                        "Object": {
+                                                          "Value": "g"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "items"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "AdjustRet": false
+                                                  }
+                                                ],
+                                                "Stmts": [
+                                                  {
+                                                    "Expr": {
+                                                      "Func": {
+                                                        "Object": {
+                                                          "Value": "table"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "insert"
+                                                        }
+                                                      },
+                                                      "Receiver": null,
+                                                      "Method": "",
+                                                      "Args": [
+                                                        {
+                                                          "Value": "_res"
+                                                        },
+                                                        {
+                                                          "Operator": "*",
+                                                          "Lhs": {
+                                                            "Object": {
+                                                              "Object": {
+                                                                "Value": "x"
+                                                              },
+                                                              "Key": {
+                                                                "Value": "l"
+                                                              }
+                                                            },
+                                                            "Key": {
+                                                              "Value": "l_extendedprice"
+                                                            }
+                                                          },
+                                                          "Rhs": {
+                                                            "Operator": "-",
+                                                            "Lhs": {
+                                                              "Value": "1"
+                                                            },
+                                                            "Rhs": {
+                                                              "Object": {
+                                                                "Object": {
+                                                                  "Value": "x"
+                                                                },
+                                                                "Key": {
+                                                                  "Value": "l"
+                                                                }
+                                                              },
+                                                              "Key": {
+                                                                "Value": "l_discount"
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      ],
+                                                      "AdjustRet": false
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "Exprs": [
+                                                  {
+                                                    "Value": "_res"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "c_acctbal"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "c_acctbal"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "n_name"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "n_name"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "c_address"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "c_address"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "c_phone"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "c_phone"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "c_comment"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "c_comment"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Exprs": [
+                            {
+                              "Operator": "\u003c",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Rhs": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "is_array"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "t"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "i"
+                      ],
+                      "Exprs": [
+                        {
+                          "Value": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "k",
+                        "_"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "pairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "t"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Value": "k"
+                            },
+                            "Rhs": {
+                              "Value": "i"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {}
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Lhs": [
+                            {
+                              "Value": "i"
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Operator": "+",
+                              "Lhs": {
+                                "Value": "i"
+                              },
+                              "Rhs": {
+                                "Value": "1"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {}
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x",
+                      "ind"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Value": "ind"
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Operator": "or",
+                          "Lhs": {
+                            "Value": "ind"
+                          },
+                          "Rhs": {
+                            "Value": "0"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "pad"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Object": {
+                              "Value": "string"
+                            },
+                            "Key": {
+                              "Value": "rep"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "  "
+                            },
+                            {
+                              "Value": "ind"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ]
+                    },
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Func": {
+                              "Value": "is_array"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "x"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Func": {
+                                            "Value": "encode"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "val"
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "x"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Func": {
+                                              "Object": {
+                                                "Value": "string"
+                                              },
+                                              "Key": {
+                                                "Value": "format"
+                                              }
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "%q"
+                                              },
+                                              {
+                                                "Value": "k"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Value": ": "
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "encode"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "x"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "k"
+                                                  }
+                                                },
+                                                {
+                                                  "Operator": "+",
+                                                  "Lhs": {
+                                                    "Value": "ind"
+                                                  },
+                                                  "Rhs": {
+                                                    "Value": "1"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "keys"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "string"
+                                    },
+                                    "Key": {
+                                      "Value": "format"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "%q"
+                                    },
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "or",
+                                "Lhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "boolean"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "number"
+                                  }
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Condition": {
+                                    "Operator": "==",
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {}
+                                  },
+                                  "Then": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      },
+                      {
+                        "Value": "0"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "result"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_multi_sort.lua.json
+++ b/tests/json-ast/x/lua/group_by_multi_sort.lua.json
@@ -1,0 +1,2133 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "items"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "__name"
+                    },
+                    "Value": {
+                      "Value": "GenType1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "__order"
+                    },
+                    "Value": {
+                      "Fields": [
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "a"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "b"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "val"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "x"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "__name"
+                    },
+                    "Value": {
+                      "Value": "GenType1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "__order"
+                    },
+                    "Value": {
+                      "Fields": [
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "a"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "b"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "val"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "x"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "__name"
+                    },
+                    "Value": {
+                      "Value": "GenType1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "__order"
+                    },
+                    "Value": {
+                      "Fields": [
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "a"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "b"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "val"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "y"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "4"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "__name"
+                    },
+                    "Value": {
+                      "Value": "GenType1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "__order"
+                    },
+                    "Value": {
+                      "Fields": [
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "a"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "b"
+                          }
+                        },
+                        {
+                          "Key": null,
+                          "Value": {
+                            "Value": "val"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "y"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "grouped"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "i"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "items"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "__name"
+                            },
+                            "Value": {
+                              "Value": "GenType2"
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "__order"
+                            },
+                            "Value": {
+                              "Fields": [
+                                {
+                                  "Key": null,
+                                  "Value": {
+                                    "Value": "a"
+                                  }
+                                },
+                                {
+                                  "Key": null,
+                                  "Value": {
+                                    "Value": "b"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "a"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "i"
+                              },
+                              "Key": {
+                                "Value": "a"
+                              }
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "b"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "i"
+                              },
+                              "Key": {
+                                "Value": "b"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Value": "key"
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "i"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "__tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_idx"
+                ],
+                "Exprs": [
+                  {
+                    "Value": "0"
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Lhs": [
+                      {
+                        "Value": "_idx"
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Value": "_idx"
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "__tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "i"
+                              },
+                              "Value": {
+                                "Value": "_idx"
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Operator": "-",
+                                "Lhs": {
+                                  "Value": "0"
+                                },
+                                "Rhs": {
+                                  "Func": {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "lst"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Names": [
+                                          "s"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Value": "0"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Names": [
+                                          "_",
+                                          "v"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Func": {
+                                              "Value": "ipairs"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "lst"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        ],
+                                        "Stmts": [
+                                          {
+                                            "Lhs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ],
+                                            "Rhs": [
+                                              {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Value": "s"
+                                                },
+                                                "Rhs": {
+                                                  "Value": "v"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Value": "s"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": []
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "_res"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Fields": []
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "x"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "g"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "items"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Expr": {
+                                                  "Func": {
+                                                    "Object": {
+                                                      "Value": "table"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "insert"
+                                                    }
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "_res"
+                                                    },
+                                                    {
+                                                      "Object": {
+                                                        "Value": "x"
+                                                      },
+                                                      "Key": {
+                                                        "Value": "val"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "_res"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Fields": [
+                                  {
+                                    "Key": {
+                                      "Value": "__name"
+                                    },
+                                    "Value": {
+                                      "Value": "GenType3"
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "__order"
+                                    },
+                                    "Value": {
+                                      "Fields": [
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "a"
+                                          }
+                                        },
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "b"
+                                          }
+                                        },
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "total"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "a"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "a"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "b"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Object": {
+                                          "Value": "g"
+                                        },
+                                        "Key": {
+                                          "Value": "key"
+                                        }
+                                      },
+                                      "Key": {
+                                        "Value": "b"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "total"
+                                    },
+                                    "Value": {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": [
+                                            "lst"
+                                          ]
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "s"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Value": "0"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "v"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "lst"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Lhs": [
+                                                  {
+                                                    "Value": "s"
+                                                  }
+                                                ],
+                                                "Rhs": [
+                                                  {
+                                                    "Operator": "+",
+                                                    "Lhs": {
+                                                      "Value": "s"
+                                                    },
+                                                    "Rhs": {
+                                                      "Value": "v"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Func": {
+                                            "ParList": {
+                                              "HasVargs": false,
+                                              "Names": []
+                                            },
+                                            "Stmts": [
+                                              {
+                                                "Names": [
+                                                  "_res"
+                                                ],
+                                                "Exprs": [
+                                                  {
+                                                    "Fields": []
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "Names": [
+                                                  "_",
+                                                  "x"
+                                                ],
+                                                "Exprs": [
+                                                  {
+                                                    "Func": {
+                                                      "Value": "ipairs"
+                                                    },
+                                                    "Receiver": null,
+                                                    "Method": "",
+                                                    "Args": [
+                                                      {
+                                                        "Object": {
+                                                          "Value": "g"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "items"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "AdjustRet": false
+                                                  }
+                                                ],
+                                                "Stmts": [
+                                                  {
+                                                    "Expr": {
+                                                      "Func": {
+                                                        "Object": {
+                                                          "Value": "table"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "insert"
+                                                        }
+                                                      },
+                                                      "Receiver": null,
+                                                      "Method": "",
+                                                      "Args": [
+                                                        {
+                                                          "Value": "_res"
+                                                        },
+                                                        {
+                                                          "Object": {
+                                                            "Value": "x"
+                                                          },
+                                                          "Key": {
+                                                            "Value": "val"
+                                                          }
+                                                        }
+                                                      ],
+                                                      "AdjustRet": false
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "Exprs": [
+                                                  {
+                                                    "Value": "_res"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "__tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Object": {
+                                "Value": "a"
+                              },
+                              "Key": {
+                                "Value": "k"
+                              }
+                            },
+                            "Rhs": {
+                              "Object": {
+                                "Value": "b"
+                              },
+                              "Key": {
+                                "Value": "k"
+                              }
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Operator": "\u003c",
+                                  "Lhs": {
+                                    "Object": {
+                                      "Value": "a"
+                                    },
+                                    "Key": {
+                                      "Value": "i"
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Object": {
+                                      "Value": "b"
+                                    },
+                                    "Key": {
+                                      "Value": "i"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Operator": "\u003c",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Rhs": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "__tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "encode"
+                  ],
+                  "Exprs": [
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "x"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "table"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Condition": {
+                                "Operator": "and",
+                                "Lhs": {
+                                  "Object": {
+                                    "Value": "x"
+                                  },
+                                  "Key": {
+                                    "Value": "__name"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Object": {
+                                    "Value": "x"
+                                  },
+                                  "Key": {
+                                    "Value": "__order"
+                                  }
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Names": [
+                                    "parts"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": [
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Object": {
+                                              "Value": "x"
+                                            },
+                                            "Key": {
+                                              "Value": "__name"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": " {"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "i",
+                                    "k"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "ipairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Object": {
+                                            "Value": "x"
+                                          },
+                                          "Key": {
+                                            "Value": "__order"
+                                          }
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Condition": {
+                                        "Operator": "\u003e",
+                                        "Lhs": {
+                                          "Value": "i"
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Value": ", "
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    },
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Lhs": {
+                                            "Value": "k"
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Value": " = "
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "encode"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "x"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "k"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Value": "}"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Object": {
+                                          "Value": "table"
+                                        },
+                                        "Key": {
+                                          "Value": "concat"
+                                        }
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "parts"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003e",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "0"
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Names": [
+                                        "parts"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Fields": [
+                                            {
+                                              "Key": null,
+                                              "Value": {
+                                                "Value": "["
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Names": [
+                                        "i",
+                                        "val"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Value": "ipairs"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "x"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "Stmts": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Func": {
+                                                "Value": "encode"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "val"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Condition": {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Value": "i"
+                                            },
+                                            "Rhs": {
+                                              "Expr": {
+                                                "Value": "x"
+                                              }
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Lhs": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "parts"
+                                                  },
+                                                  "Key": {
+                                                    "Operator": "+",
+                                                    "Lhs": {
+                                                      "Expr": {
+                                                        "Value": "parts"
+                                                      }
+                                                    },
+                                                    "Rhs": {
+                                                      "Value": "1"
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "Rhs": [
+                                                {
+                                                  "Value": ", "
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "Else": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "table"
+                                            },
+                                            "Key": {
+                                              "Value": "concat"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "parts"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": [
+                                    {
+                                      "Names": [
+                                        "keys"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Fields": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Names": [
+                                        "k"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Value": "pairs"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "x"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "Stmts": [
+                                        {
+                                          "Condition": {
+                                            "Operator": "and",
+                                            "Lhs": {
+                                              "Operator": "~=",
+                                              "Lhs": {
+                                                "Value": "k"
+                                              },
+                                              "Rhs": {
+                                                "Value": "__name"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Operator": "~=",
+                                              "Lhs": {
+                                                "Value": "k"
+                                              },
+                                              "Rhs": {
+                                                "Value": "__order"
+                                              }
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Expr": {
+                                                "Func": {
+                                                  "Object": {
+                                                    "Value": "table"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "insert"
+                                                  }
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "keys"
+                                                  },
+                                                  {
+                                                    "Value": "k"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            }
+                                          ],
+                                          "Else": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Expr": {
+                                        "Func": {
+                                          "Object": {
+                                            "Value": "table"
+                                          },
+                                          "Key": {
+                                            "Value": "sort"
+                                          }
+                                        },
+                                        "Receiver": null,
+                                        "Method": "",
+                                        "Args": [
+                                          {
+                                            "Value": "keys"
+                                          },
+                                          {
+                                            "ParList": {
+                                              "HasVargs": false,
+                                              "Names": [
+                                                "a",
+                                                "b"
+                                              ]
+                                            },
+                                            "Stmts": [
+                                              {
+                                                "Exprs": [
+                                                  {
+                                                    "Operator": "\u003e",
+                                                    "Lhs": {
+                                                      "Func": {
+                                                        "Value": "tostring"
+                                                      },
+                                                      "Receiver": null,
+                                                      "Method": "",
+                                                      "Args": [
+                                                        {
+                                                          "Value": "a"
+                                                        }
+                                                      ],
+                                                      "AdjustRet": false
+                                                    },
+                                                    "Rhs": {
+                                                      "Func": {
+                                                        "Value": "tostring"
+                                                      },
+                                                      "Receiver": null,
+                                                      "Method": "",
+                                                      "Args": [
+                                                        {
+                                                          "Value": "b"
+                                                        }
+                                                      ],
+                                                      "AdjustRet": false
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        "AdjustRet": false
+                                      }
+                                    },
+                                    {
+                                      "Names": [
+                                        "parts"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Fields": [
+                                            {
+                                              "Key": null,
+                                              "Value": {
+                                                "Value": "{"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Names": [
+                                        "i",
+                                        "k"
+                                      ],
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Value": "ipairs"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "keys"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "Stmts": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Lhs": {
+                                                "Value": "'"
+                                              },
+                                              "Rhs": {
+                                                "Lhs": {
+                                                  "Func": {
+                                                    "Value": "tostring"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "k"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                },
+                                                "Rhs": {
+                                                  "Lhs": {
+                                                    "Value": "': "
+                                                  },
+                                                  "Rhs": {
+                                                    "Func": {
+                                                      "Value": "encode"
+                                                    },
+                                                    "Receiver": null,
+                                                    "Method": "",
+                                                    "Args": [
+                                                      {
+                                                        "Object": {
+                                                          "Value": "x"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "k"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "AdjustRet": false
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Condition": {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Value": "i"
+                                            },
+                                            "Rhs": {
+                                              "Expr": {
+                                                "Value": "keys"
+                                              }
+                                            }
+                                          },
+                                          "Then": [
+                                            {
+                                              "Lhs": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "parts"
+                                                  },
+                                                  "Key": {
+                                                    "Operator": "+",
+                                                    "Lhs": {
+                                                      "Expr": {
+                                                        "Value": "parts"
+                                                      }
+                                                    },
+                                                    "Rhs": {
+                                                      "Value": "1"
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "Rhs": [
+                                                {
+                                                  "Value": ", "
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "Else": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": "}"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "table"
+                                            },
+                                            "Key": {
+                                              "Value": "concat"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "parts"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Func": {
+                                    "Value": "type"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                },
+                                "Rhs": {
+                                  "Value": "string"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\""
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Value": "x"
+                                        },
+                                        "Rhs": {
+                                          "Value": "\""
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "encode"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "v"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "grouped"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_by_sort.lua.json
+++ b/tests/json-ast/x/lua/group_by_sort.lua.json
@@ -1,0 +1,1524 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "items"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "b"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "5"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "cat"
+                    },
+                    "Value": {
+                      "Value": "b"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "grouped"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "i"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "items"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "i"
+                        },
+                        "Key": {
+                          "Value": "cat"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Value": "key"
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "i"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "__tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "__tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Operator": "-",
+                                "Lhs": {
+                                  "Value": "0"
+                                },
+                                "Rhs": {
+                                  "Func": {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "lst"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Names": [
+                                          "s"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Value": "0"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Names": [
+                                          "_",
+                                          "v"
+                                        ],
+                                        "Exprs": [
+                                          {
+                                            "Func": {
+                                              "Value": "ipairs"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "lst"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        ],
+                                        "Stmts": [
+                                          {
+                                            "Lhs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ],
+                                            "Rhs": [
+                                              {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Value": "s"
+                                                },
+                                                "Rhs": {
+                                                  "Value": "v"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Value": "s"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": []
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "_res"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Fields": []
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "x"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "g"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "items"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Expr": {
+                                                  "Func": {
+                                                    "Object": {
+                                                      "Value": "table"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "insert"
+                                                    }
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "_res"
+                                                    },
+                                                    {
+                                                      "Object": {
+                                                        "Value": "x"
+                                                      },
+                                                      "Key": {
+                                                        "Value": "val"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "_res"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Fields": [
+                                  {
+                                    "Key": {
+                                      "Value": "cat"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Value": "g"
+                                      },
+                                      "Key": {
+                                        "Value": "key"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "total"
+                                    },
+                                    "Value": {
+                                      "Func": {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": [
+                                            "lst"
+                                          ]
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Names": [
+                                              "s"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Value": "0"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Names": [
+                                              "_",
+                                              "v"
+                                            ],
+                                            "Exprs": [
+                                              {
+                                                "Func": {
+                                                  "Value": "ipairs"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Value": "lst"
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            ],
+                                            "Stmts": [
+                                              {
+                                                "Lhs": [
+                                                  {
+                                                    "Value": "s"
+                                                  }
+                                                ],
+                                                "Rhs": [
+                                                  {
+                                                    "Operator": "+",
+                                                    "Lhs": {
+                                                      "Value": "s"
+                                                    },
+                                                    "Rhs": {
+                                                      "Value": "v"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Value": "s"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Func": {
+                                            "ParList": {
+                                              "HasVargs": false,
+                                              "Names": []
+                                            },
+                                            "Stmts": [
+                                              {
+                                                "Names": [
+                                                  "_res"
+                                                ],
+                                                "Exprs": [
+                                                  {
+                                                    "Fields": []
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "Names": [
+                                                  "_",
+                                                  "x"
+                                                ],
+                                                "Exprs": [
+                                                  {
+                                                    "Func": {
+                                                      "Value": "ipairs"
+                                                    },
+                                                    "Receiver": null,
+                                                    "Method": "",
+                                                    "Args": [
+                                                      {
+                                                        "Object": {
+                                                          "Value": "g"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "items"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "AdjustRet": false
+                                                  }
+                                                ],
+                                                "Stmts": [
+                                                  {
+                                                    "Expr": {
+                                                      "Func": {
+                                                        "Object": {
+                                                          "Value": "table"
+                                                        },
+                                                        "Key": {
+                                                          "Value": "insert"
+                                                        }
+                                                      },
+                                                      "Receiver": null,
+                                                      "Method": "",
+                                                      "Args": [
+                                                        {
+                                                          "Value": "_res"
+                                                        },
+                                                        {
+                                                          "Object": {
+                                                            "Value": "x"
+                                                          },
+                                                          "Key": {
+                                                            "Value": "val"
+                                                          }
+                                                        }
+                                                      ],
+                                                      "AdjustRet": false
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "Exprs": [
+                                                  {
+                                                    "Value": "_res"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [],
+                                          "AdjustRet": false
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "__tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Exprs": [
+                            {
+                              "Operator": "\u003c",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Rhs": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "__tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "grouped"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/group_items_iteration.lua.json
+++ b/tests/json-ast/x/lua/group_items_iteration.lua.json
@@ -1,0 +1,1461 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "data"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "tag"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "tag"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "tag"
+                    },
+                    "Value": {
+                      "Value": "b"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "val"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "groups"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "groups"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "orderKeys"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "d"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "data"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "key"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "d"
+                        },
+                        "Key": {
+                          "Value": "tag"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "ks"
+                    ],
+                    "Exprs": [
+                      {
+                        "Func": {
+                          "Value": "tostring"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "key"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ]
+                  },
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "g"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Lhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "key"
+                                },
+                                "Value": {
+                                  "Value": "key"
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "items"
+                                },
+                                "Value": {
+                                  "Fields": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Lhs": [
+                          {
+                            "Object": {
+                              "Value": "groups"
+                            },
+                            "Key": {
+                              "Value": "ks"
+                            }
+                          }
+                        ],
+                        "Rhs": [
+                          {
+                            "Value": "g"
+                          }
+                        ]
+                      },
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "orderKeys"
+                            },
+                            {
+                              "Value": "ks"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Object": {
+                            "Value": "g"
+                          },
+                          "Key": {
+                            "Value": "items"
+                          }
+                        },
+                        {
+                          "Value": "d"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "ks"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "orderKeys"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Names": [
+                      "g"
+                    ],
+                    "Exprs": [
+                      {
+                        "Object": {
+                          "Value": "groups"
+                        },
+                        "Key": {
+                          "Value": "ks"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "res"
+                        },
+                        {
+                          "Value": "g"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "tmp"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "g"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "groups"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Lhs": [
+            {
+              "Value": "total"
+            }
+          ],
+          "Rhs": [
+            {
+              "Value": "0"
+            }
+          ]
+        },
+        {
+          "Names": [
+            "_",
+            "x"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Object": {
+                    "Value": "g"
+                  },
+                  "Key": {
+                    "Value": "items"
+                  }
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Lhs": [
+                {
+                  "Value": "total"
+                }
+              ],
+              "Rhs": [
+                {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Value": "total"
+                  },
+                  "Rhs": {
+                    "Object": {
+                      "Value": "x"
+                    },
+                    "Key": {
+                      "Value": "val"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Lhs": [
+            {
+              "Value": "tmp"
+            }
+          ],
+          "Rhs": [
+            {
+              "Func": {
+                "ParList": {
+                  "HasVargs": false,
+                  "Names": [
+                    "lst",
+                    "item"
+                  ]
+                },
+                "Stmts": [
+                  {
+                    "Names": [
+                      "res"
+                    ],
+                    "Exprs": [
+                      {
+                        "Fields": [
+                          {
+                            "Key": null,
+                            "Value": {
+                              "Func": {
+                                "Object": {
+                                  "Value": "table"
+                                },
+                                "Key": {
+                                  "Value": "unpack"
+                                }
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "lst"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "res"
+                        },
+                        {
+                          "Value": "item"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  },
+                  {
+                    "Exprs": [
+                      {
+                        "Value": "res"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "tmp"
+                },
+                {
+                  "Fields": [
+                    {
+                      "Key": {
+                        "Value": "tag"
+                      },
+                      "Value": {
+                        "Object": {
+                          "Value": "g"
+                        },
+                        "Key": {
+                          "Value": "key"
+                        }
+                      }
+                    },
+                    {
+                      "Key": {
+                        "Value": "total"
+                      },
+                      "Value": {
+                        "Value": "total"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "AdjustRet": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "__tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "r"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "__tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "r"
+                                },
+                                "Key": {
+                                  "Value": "tag"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Value": "r"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "__tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Exprs": [
+                            {
+                              "Operator": "\u003c",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Rhs": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "__tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "_res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "result"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/if_else.lua.json
+++ b/tests/json-ast/x/lua/if_else.lua.json
@@ -1,0 +1,61 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "5"
+        }
+      ]
+    },
+    {
+      "Condition": {
+        "Operator": "\u003e",
+        "Lhs": {
+          "Value": "x"
+        },
+        "Rhs": {
+          "Value": "3"
+        }
+      },
+      "Then": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "big"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ],
+      "Else": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "small"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/if_then_else.lua.json
+++ b/tests/json-ast/x/lua/if_then_else.lua.json
@@ -1,0 +1,61 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "12"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "msg"
+        }
+      ],
+      "Rhs": [
+        {
+          "Operator": "or",
+          "Lhs": {
+            "Operator": "and",
+            "Lhs": {
+              "Operator": "\u003e",
+              "Lhs": {
+                "Value": "x"
+              },
+              "Rhs": {
+                "Value": "10"
+              }
+            },
+            "Rhs": {
+              "Value": "yes"
+            }
+          },
+          "Rhs": {
+            "Value": "no"
+          }
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "msg"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/if_then_else_nested.lua.json
+++ b/tests/json-ast/x/lua/if_then_else_nested.lua.json
@@ -1,0 +1,79 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "8"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "msg"
+        }
+      ],
+      "Rhs": [
+        {
+          "Operator": "or",
+          "Lhs": {
+            "Operator": "and",
+            "Lhs": {
+              "Operator": "\u003e",
+              "Lhs": {
+                "Value": "x"
+              },
+              "Rhs": {
+                "Value": "10"
+              }
+            },
+            "Rhs": {
+              "Value": "big"
+            }
+          },
+          "Rhs": {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "\u003e",
+                "Lhs": {
+                  "Value": "x"
+                },
+                "Rhs": {
+                  "Value": "5"
+                }
+              },
+              "Rhs": {
+                "Value": "medium"
+              }
+            },
+            "Rhs": {
+              "Value": "small"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "msg"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/in_operator.lua.json
+++ b/tests/json-ast/x/lua/in_operator.lua.json
@@ -1,0 +1,213 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "xs"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst",
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "_",
+                    "x"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Value": "x"
+                        },
+                        "Rhs": {
+                          "Value": "v"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {}
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {}
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "xs"
+              },
+              {
+                "Value": "2"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "lst",
+                      "v"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "_",
+                        "x"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "ipairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "lst"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Value": "x"
+                            },
+                            "Rhs": {
+                              "Value": "v"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {}
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {}
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "xs"
+                  },
+                  {
+                    "Value": "5"
+                  }
+                ],
+                "AdjustRet": true
+              },
+              "Rhs": {
+                "Value": "0"
+              }
+            },
+            "Rhs": {
+              "Value": "1"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/in_operator_extended.lua.json
+++ b/tests/json-ast/x/lua/in_operator_extended.lua.json
@@ -1,0 +1,442 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "xs"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "ys"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "x"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "xs"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Condition": {
+            "Operator": "==",
+            "Lhs": {
+              "Operator": "%",
+              "Lhs": {
+                "Value": "x"
+              },
+              "Rhs": {
+                "Value": "2"
+              }
+            },
+            "Rhs": {
+              "Value": "1"
+            }
+          },
+          "Then": [
+            {
+              "Expr": {
+                "Func": {
+                  "Object": {
+                    "Value": "table"
+                  },
+                  "Key": {
+                    "Value": "insert"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "ys"
+                  },
+                  {
+                    "Value": "x"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ],
+          "Else": null
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst",
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "_",
+                    "x"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Value": "x"
+                        },
+                        "Rhs": {
+                          "Value": "v"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {}
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {}
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "ys"
+              },
+              {
+                "Value": "1"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst",
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "_",
+                    "x"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Value": "x"
+                        },
+                        "Rhs": {
+                          "Value": "v"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {}
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {}
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "ys"
+              },
+              {
+                "Value": "2"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Object": {
+                "Value": "m"
+              },
+              "Key": {
+                "Value": "a"
+              }
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Object": {
+                "Value": "m"
+              },
+              "Key": {
+                "Value": "b"
+              }
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "s"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "hello"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "find"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s"
+                },
+                {
+                  "Value": "ell"
+                },
+                {
+                  "Value": "1"
+                },
+                {}
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "find"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s"
+                },
+                {
+                  "Value": "foo"
+                },
+                {
+                  "Value": "1"
+                },
+                {}
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/inner_join.lua.json
+++ b/tests/json-ast/x/lua/inner_join.lua.json
@@ -1,0 +1,460 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "250"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "125"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "102"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "300"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "103"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "4"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "80"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Object": {
+                    "Value": "o"
+                  },
+                  "Key": {
+                    "Value": "customerId"
+                  }
+                },
+                "Rhs": {
+                  "Object": {
+                    "Value": "c"
+                  },
+                  "Key": {
+                    "Value": "id"
+                  }
+                }
+              },
+              "Then": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "result"
+                      },
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "orderId"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "o"
+                              },
+                              "Key": {
+                                "Value": "id"
+                              }
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "customerName"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "c"
+                              },
+                              "Key": {
+                                "Value": "name"
+                              }
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "total"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "o"
+                              },
+                              "Key": {
+                                "Value": "total"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ],
+              "Else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Orders with customer info ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "entry"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "Order %s by %s - $ %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "orderId"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "customerName"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "total"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/join_multi.lua.json
+++ b/tests/json-ast/x/lua/join_multi.lua.json
@@ -1,0 +1,442 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "items"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "orderId"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "sku"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "orderId"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "sku"
+                    },
+                    "Value": {
+                      "Value": "b"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Names": [
+                "_",
+                "i"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "ipairs"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "items"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ],
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "o"
+                        },
+                        "Key": {
+                          "Value": "customerId"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "c"
+                        },
+                        "Key": {
+                          "Value": "id"
+                        }
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "o"
+                        },
+                        "Key": {
+                          "Value": "id"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "i"
+                        },
+                        "Key": {
+                          "Value": "orderId"
+                        }
+                      }
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Expr": {
+                        "Func": {
+                          "Object": {
+                            "Value": "table"
+                          },
+                          "Key": {
+                            "Value": "insert"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "result"
+                          },
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "name"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "c"
+                                  },
+                                  "Key": {
+                                    "Value": "name"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "sku"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "i"
+                                  },
+                                  "Key": {
+                                    "Value": "sku"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    }
+                  ],
+                  "Else": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Multi Join ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "r"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s bought item %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "r"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "r"
+                    },
+                    "Key": {
+                      "Value": "sku"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/json_builtin.lua.json
+++ b/tests/json-ast/x/lua/json_builtin.lua.json
@@ -1,0 +1,1080 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "is_array"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "t"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "i"
+                      ],
+                      "Exprs": [
+                        {
+                          "Value": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "k",
+                        "_"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "pairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "t"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Value": "k"
+                            },
+                            "Rhs": {
+                              "Value": "i"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {}
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Lhs": [
+                            {
+                              "Value": "i"
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Operator": "+",
+                              "Lhs": {
+                                "Value": "i"
+                              },
+                              "Rhs": {
+                                "Value": "1"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {}
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x",
+                      "ind"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Value": "ind"
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Operator": "or",
+                          "Lhs": {
+                            "Value": "ind"
+                          },
+                          "Rhs": {
+                            "Value": "0"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "pad"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Object": {
+                              "Value": "string"
+                            },
+                            "Key": {
+                              "Value": "rep"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "  "
+                            },
+                            {
+                              "Value": "ind"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ]
+                    },
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Func": {
+                              "Value": "is_array"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "x"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Func": {
+                                            "Value": "encode"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "val"
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "x"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Object": {
+                                              "Value": "string"
+                                            },
+                                            "Key": {
+                                              "Value": "rep"
+                                            }
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "  "
+                                            },
+                                            {
+                                              "Operator": "+",
+                                              "Lhs": {
+                                                "Value": "ind"
+                                              },
+                                              "Rhs": {
+                                                "Value": "1"
+                                              }
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Func": {
+                                              "Object": {
+                                                "Value": "string"
+                                              },
+                                              "Key": {
+                                                "Value": "format"
+                                              }
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Value": "%q"
+                                              },
+                                              {
+                                                "Value": "k"
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Value": ": "
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "encode"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Object": {
+                                                    "Value": "x"
+                                                  },
+                                                  "Key": {
+                                                    "Value": "k"
+                                                  }
+                                                },
+                                                {
+                                                  "Operator": "+",
+                                                  "Lhs": {
+                                                    "Value": "ind"
+                                                  },
+                                                  "Rhs": {
+                                                    "Value": "1"
+                                                  }
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ","
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "keys"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\n"
+                                      },
+                                      "Rhs": {
+                                        "Value": "pad"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "string"
+                                    },
+                                    "Key": {
+                                      "Value": "format"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "%q"
+                                    },
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "or",
+                                "Lhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "boolean"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Operator": "==",
+                                  "Lhs": {
+                                    "Func": {
+                                      "Value": "type"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "x"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  },
+                                  "Rhs": {
+                                    "Value": "number"
+                                  }
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Condition": {
+                                    "Operator": "==",
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {}
+                                  },
+                                  "Then": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": [
+                                    {
+                                      "Exprs": [
+                                        {
+                                          "Value": "null"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      },
+                      {
+                        "Value": "0"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "m"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/left_join.lua.json
+++ b/tests/json-ast/x/lua/left_join.lua.json
@@ -1,0 +1,370 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "250"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "80"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Object": {
+                    "Value": "o"
+                  },
+                  "Key": {
+                    "Value": "customerId"
+                  }
+                },
+                "Rhs": {
+                  "Object": {
+                    "Value": "c"
+                  },
+                  "Key": {
+                    "Value": "id"
+                  }
+                }
+              },
+              "Then": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "result"
+                      },
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "orderId"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "o"
+                              },
+                              "Key": {
+                                "Value": "id"
+                              }
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "customer"
+                            },
+                            "Value": {
+                              "Value": "c"
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "total"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "o"
+                              },
+                              "Key": {
+                                "Value": "total"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ],
+              "Else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Left Join ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "entry"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "Order %s customer %s total %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "orderId"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "customer"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "entry"
+                    },
+                    "Key": {
+                      "Value": "total"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/left_join_multi.lua.json
+++ b/tests/json-ast/x/lua/left_join_multi.lua.json
@@ -1,0 +1,435 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "items"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "orderId"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "sku"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Names": [
+                "_",
+                "i"
+              ],
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "ipairs"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "items"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ],
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "o"
+                        },
+                        "Key": {
+                          "Value": "customerId"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "c"
+                        },
+                        "Key": {
+                          "Value": "id"
+                        }
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "o"
+                        },
+                        "Key": {
+                          "Value": "id"
+                        }
+                      },
+                      "Rhs": {
+                        "Object": {
+                          "Value": "i"
+                        },
+                        "Key": {
+                          "Value": "orderId"
+                        }
+                      }
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Expr": {
+                        "Func": {
+                          "Object": {
+                            "Value": "table"
+                          },
+                          "Key": {
+                            "Value": "insert"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "result"
+                          },
+                          {
+                            "Fields": [
+                              {
+                                "Key": {
+                                  "Value": "orderId"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "o"
+                                  },
+                                  "Key": {
+                                    "Value": "id"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "name"
+                                },
+                                "Value": {
+                                  "Object": {
+                                    "Value": "c"
+                                  },
+                                  "Key": {
+                                    "Value": "name"
+                                  }
+                                }
+                              },
+                              {
+                                "Key": {
+                                  "Value": "item"
+                                },
+                                "Value": {
+                                  "Value": "i"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    }
+                  ],
+                  "Else": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Left Join Multi ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "r"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s %s %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "r"
+                    },
+                    "Key": {
+                      "Value": "orderId"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "r"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "r"
+                    },
+                    "Key": {
+                      "Value": "item"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/len_builtin.lua.json
+++ b/tests/json-ast/x/lua/len_builtin.lua.json
@@ -1,0 +1,215 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Func": {
+                          "Value": "type"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "v"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "table"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "~=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "v"
+                        },
+                        "Key": {
+                          "Value": "items"
+                        }
+                      },
+                      "Rhs": {}
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Expr": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "items"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": [
+                    {
+                      "Condition": {
+                        "Operator": "and",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Func": {
+                              "Value": "type"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "v"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Rhs": {
+                            "Value": "table"
+                          }
+                        },
+                        "Rhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "1"
+                            }
+                          },
+                          "Rhs": {}
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Names": [
+                            "c"
+                          ],
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "Names": [
+                            "_"
+                          ],
+                          "Exprs": [
+                            {
+                              "Func": {
+                                "Value": "pairs"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          ],
+                          "Stmts": [
+                            {
+                              "Lhs": [
+                                {
+                                  "Value": "c"
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Value": "c"
+                                  },
+                                  "Rhs": {
+                                    "Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "c"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Exprs": [
+                            {
+                              "Expr": {
+                                "Value": "v"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/len_map.lua.json
+++ b/tests/json-ast/x/lua/len_map.lua.json
@@ -1,0 +1,213 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Func": {
+                          "Value": "type"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "v"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "table"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "~=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "v"
+                        },
+                        "Key": {
+                          "Value": "items"
+                        }
+                      },
+                      "Rhs": {}
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Expr": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "items"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": [
+                    {
+                      "Condition": {
+                        "Operator": "and",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Func": {
+                              "Value": "type"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "v"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Rhs": {
+                            "Value": "table"
+                          }
+                        },
+                        "Rhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "1"
+                            }
+                          },
+                          "Rhs": {}
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Names": [
+                            "c"
+                          ],
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "Names": [
+                            "_"
+                          ],
+                          "Exprs": [
+                            {
+                              "Func": {
+                                "Value": "pairs"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          ],
+                          "Stmts": [
+                            {
+                              "Lhs": [
+                                {
+                                  "Value": "c"
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Value": "c"
+                                  },
+                                  "Rhs": {
+                                    "Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "c"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Exprs": [
+                            {
+                              "Expr": {
+                                "Value": "v"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/len_string.lua.json
+++ b/tests/json-ast/x/lua/len_string.lua.json
@@ -1,0 +1,196 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Func": {
+                          "Value": "type"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "v"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "table"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "~=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "v"
+                        },
+                        "Key": {
+                          "Value": "items"
+                        }
+                      },
+                      "Rhs": {}
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Expr": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "items"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": [
+                    {
+                      "Condition": {
+                        "Operator": "and",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Func": {
+                              "Value": "type"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "v"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Rhs": {
+                            "Value": "table"
+                          }
+                        },
+                        "Rhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "1"
+                            }
+                          },
+                          "Rhs": {}
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Names": [
+                            "c"
+                          ],
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "Names": [
+                            "_"
+                          ],
+                          "Exprs": [
+                            {
+                              "Func": {
+                                "Value": "pairs"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          ],
+                          "Stmts": [
+                            {
+                              "Lhs": [
+                                {
+                                  "Value": "c"
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Value": "c"
+                                  },
+                                  "Rhs": {
+                                    "Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "c"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Exprs": [
+                            {
+                              "Expr": {
+                                "Value": "v"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "mochi"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/let_and_print.lua.json
+++ b/tests/json-ast/x/lua/let_and_print.lua.json
@@ -1,0 +1,49 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "a"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "10"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "b"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "20"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "+",
+            "Lhs": {
+              "Value": "a"
+            },
+            "Rhs": {
+              "Value": "b"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/list_assign.lua.json
+++ b/tests/json-ast/x/lua/list_assign.lua.json
@@ -1,0 +1,78 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nums"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Object": {
+            "Value": "nums"
+          },
+          "Key": {
+            "Operator": "+",
+            "Lhs": {
+              "Value": "1"
+            },
+            "Rhs": {
+              "Value": "1"
+            }
+          }
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "3"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "nums"
+            },
+            "Key": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "1"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/list_index.lua.json
+++ b/tests/json-ast/x/lua/list_index.lua.json
@@ -1,0 +1,61 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "xs"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "10"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "20"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "30"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "xs"
+            },
+            "Key": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "1"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/list_nested_assign.lua.json
+++ b/tests/json-ast/x/lua/list_nested_assign.lua.json
@@ -1,0 +1,126 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "matrix"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "4"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Object": {
+            "Object": {
+              "Value": "matrix"
+            },
+            "Key": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "1"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          },
+          "Key": {
+            "Operator": "+",
+            "Lhs": {
+              "Value": "0"
+            },
+            "Rhs": {
+              "Value": "1"
+            }
+          }
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "5"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Object": {
+                "Value": "matrix"
+              },
+              "Key": {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "1"
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              }
+            },
+            "Key": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "0"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/list_set_ops.lua.json
+++ b/tests/json-ast/x/lua/list_set_ops.lua.json
@@ -1,0 +1,2834 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "a",
+                  "b"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "seen"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "res"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "a"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Expr": {
+                          "Object": {
+                            "Value": "seen"
+                          },
+                          "Key": {
+                            "Value": "v"
+                          }
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "seen"
+                              },
+                              "Key": {
+                                "Value": "v"
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {}
+                          ]
+                        },
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "res"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "res"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "b"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Expr": {
+                          "Object": {
+                            "Value": "seen"
+                          },
+                          "Key": {
+                            "Value": "v"
+                          }
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "seen"
+                              },
+                              "Key": {
+                                "Value": "v"
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {}
+                          ]
+                        },
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "res"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "res"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "res"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              },
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "a",
+                  "b"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "m"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "b"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Object": {
+                            "Value": "m"
+                          },
+                          "Key": {
+                            "Value": "v"
+                          }
+                        }
+                      ],
+                      "Rhs": [
+                        {}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "res"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "a"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Expr": {
+                          "Object": {
+                            "Value": "m"
+                          },
+                          "Key": {
+                            "Value": "v"
+                          }
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "res"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "res"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "res"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              },
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "a",
+                  "b"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "m"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "a"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Object": {
+                            "Value": "m"
+                          },
+                          "Key": {
+                            "Value": "v"
+                          }
+                        }
+                      ],
+                      "Rhs": [
+                        {}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "res"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "b"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Object": {
+                          "Value": "m"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "res"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "res"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "res"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              },
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "4"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Condition": {
+                    "Operator": "and",
+                    "Lhs": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Func": {
+                          "Value": "type"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "v"
+                          }
+                        ],
+                        "AdjustRet": false
+                      },
+                      "Rhs": {
+                        "Value": "table"
+                      }
+                    },
+                    "Rhs": {
+                      "Operator": "~=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "v"
+                        },
+                        "Key": {
+                          "Value": "items"
+                        }
+                      },
+                      "Rhs": {}
+                    }
+                  },
+                  "Then": [
+                    {
+                      "Exprs": [
+                        {
+                          "Expr": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "items"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "Else": [
+                    {
+                      "Condition": {
+                        "Operator": "and",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Func": {
+                              "Value": "type"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "v"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Rhs": {
+                            "Value": "table"
+                          }
+                        },
+                        "Rhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "1"
+                            }
+                          },
+                          "Rhs": {}
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Names": [
+                            "c"
+                          ],
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "Names": [
+                            "_"
+                          ],
+                          "Exprs": [
+                            {
+                              "Func": {
+                                "Value": "pairs"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          ],
+                          "Stmts": [
+                            {
+                              "Lhs": [
+                                {
+                                  "Value": "c"
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Value": "c"
+                                  },
+                                  "Rhs": {
+                                    "Value": "1"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "c"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Exprs": [
+                            {
+                              "Expr": {
+                                "Value": "v"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "a",
+                      "b"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "res"
+                      ],
+                      "Exprs": [
+                        {
+                          "Fields": [
+                            {
+                              "Key": null,
+                              "Value": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "unpack"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "a"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "_",
+                        "v"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "ipairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "b"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "res"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "res"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {
+                          "Value": "res"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Fields": [
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "1"
+                        }
+                      },
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "2"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Fields": [
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "2"
+                        }
+                      },
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "3"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/load_jsonl.lua.json
+++ b/tests/json-ast/x/lua/load_jsonl.lua.json
@@ -1,0 +1,311 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "30"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "email"
+                    },
+                    "Value": {
+                      "Value": "alice@example.com"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "15"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "email"
+                    },
+                    "Value": {
+                      "Value": "bob@example.com"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "20"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "email"
+                    },
+                    "Value": {
+                      "Value": "charlie@example.com"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "adults"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "people"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Condition": {
+                      "Operator": "\u003e=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "age"
+                        }
+                      },
+                      "Rhs": {
+                        "Value": "18"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "_res"
+                            },
+                            {
+                              "Fields": [
+                                {
+                                  "Key": {
+                                    "Value": "name"
+                                  },
+                                  "Value": {
+                                    "Object": {
+                                      "Value": "p"
+                                    },
+                                    "Key": {
+                                      "Value": "name"
+                                    }
+                                  }
+                                },
+                                {
+                                  "Key": {
+                                    "Value": "email"
+                                  },
+                                  "Value": {
+                                    "Object": {
+                                      "Value": "p"
+                                    },
+                                    "Key": {
+                                      "Value": "email"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "a"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "adults"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "a"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "a"
+                    },
+                    "Key": {
+                      "Value": "email"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/load_yaml.lua.json
+++ b/tests/json-ast/x/lua/load_yaml.lua.json
@@ -1,0 +1,311 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "30"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "email"
+                    },
+                    "Value": {
+                      "Value": "alice@example.com"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "15"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "email"
+                    },
+                    "Value": {
+                      "Value": "bob@example.com"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "20"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "email"
+                    },
+                    "Value": {
+                      "Value": "charlie@example.com"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "adults"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "people"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Condition": {
+                      "Operator": "\u003e=",
+                      "Lhs": {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "age"
+                        }
+                      },
+                      "Rhs": {
+                        "Value": "18"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "_res"
+                            },
+                            {
+                              "Fields": [
+                                {
+                                  "Key": {
+                                    "Value": "name"
+                                  },
+                                  "Value": {
+                                    "Object": {
+                                      "Value": "p"
+                                    },
+                                    "Key": {
+                                      "Value": "name"
+                                    }
+                                  }
+                                },
+                                {
+                                  "Key": {
+                                    "Value": "email"
+                                  },
+                                  "Value": {
+                                    "Object": {
+                                      "Value": "p"
+                                    },
+                                    "Key": {
+                                      "Value": "email"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "a"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "adults"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "%s %s"
+                  },
+                  {
+                    "Object": {
+                      "Value": "a"
+                    },
+                    "Key": {
+                      "Value": "name"
+                    }
+                  },
+                  {
+                    "Object": {
+                      "Value": "a"
+                    },
+                    "Key": {
+                      "Value": "email"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_assign.lua.json
+++ b/tests/json-ast/x/lua/map_assign.lua.json
@@ -1,0 +1,62 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "scores"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "alice"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Object": {
+            "Value": "scores"
+          },
+          "Key": {
+            "Value": "bob"
+          }
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "scores"
+            },
+            "Key": {
+              "Value": "bob"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_in_operator.lua.json
+++ b/tests/json-ast/x/lua/map_in_operator.lua.json
@@ -1,0 +1,81 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "1"
+              },
+              "Value": {
+                "Value": "a"
+              }
+            },
+            {
+              "Key": {
+                "Value": "2"
+              },
+              "Value": {
+                "Value": "b"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Object": {
+                "Value": "m"
+              },
+              "Key": {
+                "Value": "1"
+              }
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Object": {
+                "Value": "m"
+              },
+              "Key": {
+                "Value": "3"
+              }
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_index.lua.json
+++ b/tests/json-ast/x/lua/map_index.lua.json
@@ -1,0 +1,53 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "m"
+            },
+            "Key": {
+              "Value": "b"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_int_key.lua.json
+++ b/tests/json-ast/x/lua/map_int_key.lua.json
@@ -1,0 +1,53 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "1"
+              },
+              "Value": {
+                "Value": "a"
+              }
+            },
+            {
+              "Key": {
+                "Value": "2"
+              },
+              "Value": {
+                "Value": "b"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "m"
+            },
+            "Key": {
+              "Value": "1"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_literal_dynamic.lua.json
+++ b/tests/json-ast/x/lua/map_literal_dynamic.lua.json
@@ -1,0 +1,103 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "3"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "y"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "4"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "x"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "y"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "format"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "%s %s"
+              },
+              {
+                "Object": {
+                  "Value": "m"
+                },
+                "Key": {
+                  "Value": "a"
+                }
+              },
+              {
+                "Object": {
+                  "Value": "m"
+                },
+                "Key": {
+                  "Value": "b"
+                }
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_membership.lua.json
+++ b/tests/json-ast/x/lua/map_membership.lua.json
@@ -1,0 +1,81 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Object": {
+                "Value": "m"
+              },
+              "Key": {
+                "Value": "a"
+              }
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Object": {
+                "Value": "m"
+              },
+              "Key": {
+                "Value": "c"
+              }
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/map_nested_assign.lua.json
+++ b/tests/json-ast/x/lua/map_nested_assign.lua.json
@@ -1,0 +1,81 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "data"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "outer"
+              },
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "inner"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Object": {
+            "Object": {
+              "Value": "data"
+            },
+            "Key": {
+              "Value": "outer"
+            }
+          },
+          "Key": {
+            "Value": "inner"
+          }
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Object": {
+                "Value": "data"
+              },
+              "Key": {
+                "Value": "outer"
+              }
+            },
+            "Key": {
+              "Value": "inner"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/match_expr.lua.json
+++ b/tests/json-ast/x/lua/match_expr.lua.json
@@ -1,0 +1,139 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "label"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": [
+                "_m"
+              ]
+            },
+            "Stmts": [
+              {
+                "Condition": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "_m"
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                },
+                "Then": [
+                  {
+                    "Exprs": [
+                      {
+                        "Value": "one"
+                      }
+                    ]
+                  }
+                ],
+                "Else": [
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "_m"
+                      },
+                      "Rhs": {
+                        "Value": "2"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Exprs": [
+                          {
+                            "Value": "two"
+                          }
+                        ]
+                      }
+                    ],
+                    "Else": [
+                      {
+                        "Condition": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Value": "_m"
+                          },
+                          "Rhs": {
+                            "Value": "3"
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Exprs": [
+                              {
+                                "Value": "three"
+                              }
+                            ]
+                          }
+                        ],
+                        "Else": [
+                          {
+                            "Condition": {},
+                            "Then": [
+                              {
+                                "Exprs": [
+                                  {
+                                    "Value": "unknown"
+                                  }
+                                ]
+                              }
+                            ],
+                            "Else": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "x"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "label"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/match_full.lua.json
+++ b/tests/json-ast/x/lua/match_full.lua.json
@@ -1,0 +1,517 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "label"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": [
+                "_m"
+              ]
+            },
+            "Stmts": [
+              {
+                "Condition": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "_m"
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                },
+                "Then": [
+                  {
+                    "Exprs": [
+                      {
+                        "Value": "one"
+                      }
+                    ]
+                  }
+                ],
+                "Else": [
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "_m"
+                      },
+                      "Rhs": {
+                        "Value": "2"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Exprs": [
+                          {
+                            "Value": "two"
+                          }
+                        ]
+                      }
+                    ],
+                    "Else": [
+                      {
+                        "Condition": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Value": "_m"
+                          },
+                          "Rhs": {
+                            "Value": "3"
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Exprs": [
+                              {
+                                "Value": "three"
+                              }
+                            ]
+                          }
+                        ],
+                        "Else": [
+                          {
+                            "Condition": {},
+                            "Then": [
+                              {
+                                "Exprs": [
+                                  {
+                                    "Value": "unknown"
+                                  }
+                                ]
+                              }
+                            ],
+                            "Else": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "x"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "label"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "day"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "sun"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "mood"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": [
+                "_m"
+              ]
+            },
+            "Stmts": [
+              {
+                "Condition": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "_m"
+                  },
+                  "Rhs": {
+                    "Value": "mon"
+                  }
+                },
+                "Then": [
+                  {
+                    "Exprs": [
+                      {
+                        "Value": "tired"
+                      }
+                    ]
+                  }
+                ],
+                "Else": [
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "_m"
+                      },
+                      "Rhs": {
+                        "Value": "fri"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Exprs": [
+                          {
+                            "Value": "excited"
+                          }
+                        ]
+                      }
+                    ],
+                    "Else": [
+                      {
+                        "Condition": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Value": "_m"
+                          },
+                          "Rhs": {
+                            "Value": "sun"
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Exprs": [
+                              {
+                                "Value": "relaxed"
+                              }
+                            ]
+                          }
+                        ],
+                        "Else": [
+                          {
+                            "Condition": {},
+                            "Then": [
+                              {
+                                "Exprs": [
+                                  {
+                                    "Value": "normal"
+                                  }
+                                ]
+                              }
+                            ],
+                            "Else": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "day"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "mood"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "ok"
+        }
+      ],
+      "Rhs": [
+        {}
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "status"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": [
+                "_m"
+              ]
+            },
+            "Stmts": [
+              {
+                "Condition": {
+                  "Operator": "==",
+                  "Lhs": {
+                    "Value": "_m"
+                  },
+                  "Rhs": {}
+                },
+                "Then": [
+                  {
+                    "Exprs": [
+                      {
+                        "Value": "confirmed"
+                      }
+                    ]
+                  }
+                ],
+                "Else": [
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Value": "_m"
+                      },
+                      "Rhs": {}
+                    },
+                    "Then": [
+                      {
+                        "Exprs": [
+                          {
+                            "Value": "denied"
+                          }
+                        ]
+                      }
+                    ],
+                    "Else": null
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "ok"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "status"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Name": {
+        "Func": {
+          "Value": "classify"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "n"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "_m"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Value": "_m"
+                        },
+                        "Rhs": {
+                          "Value": "0"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "zero"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Value": "_m"
+                            },
+                            "Rhs": {
+                              "Value": "1"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Value": "one"
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {},
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Value": "many"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": null
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "n"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "classify"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "0"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "classify"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "5"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/math_ops.lua.json
+++ b/tests/json-ast/x/lua/math_ops.lua.json
@@ -1,0 +1,67 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "*",
+            "Lhs": {
+              "Value": "6"
+            },
+            "Rhs": {
+              "Value": "7"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "/",
+            "Lhs": {
+              "Value": "7"
+            },
+            "Rhs": {
+              "Value": "2"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "%",
+            "Lhs": {
+              "Value": "7"
+            },
+            "Rhs": {
+              "Value": "2"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/membership.lua.json
+++ b/tests/json-ast/x/lua/membership.lua.json
@@ -1,0 +1,201 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nums"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst",
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "_",
+                    "x"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Value": "x"
+                        },
+                        "Rhs": {
+                          "Value": "v"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {}
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {}
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "nums"
+              },
+              {
+                "Value": "2"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst",
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "_",
+                    "x"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Value": "x"
+                        },
+                        "Rhs": {
+                          "Value": "v"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {}
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {}
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "nums"
+              },
+              {
+                "Value": "4"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/min_max_builtin.lua.json
+++ b/tests/json-ast/x/lua/min_max_builtin.lua.json
@@ -1,0 +1,247 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nums"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "4"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "m"
+                  ],
+                  "Exprs": [
+                    {}
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "or",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Value": "m"
+                          },
+                          "Rhs": {}
+                        },
+                        "Rhs": {
+                          "Operator": "\u003c",
+                          "Lhs": {
+                            "Value": "v"
+                          },
+                          "Rhs": {
+                            "Value": "m"
+                          }
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Lhs": [
+                            {
+                              "Value": "m"
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "m"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "nums"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "m"
+                  ],
+                  "Exprs": [
+                    {}
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "or",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Value": "m"
+                          },
+                          "Rhs": {}
+                        },
+                        "Rhs": {
+                          "Operator": "\u003e",
+                          "Lhs": {
+                            "Value": "v"
+                          },
+                          "Rhs": {
+                            "Value": "m"
+                          }
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Lhs": [
+                            {
+                              "Value": "m"
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Value": "v"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": null
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "m"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "nums"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/nested_function.lua.json
+++ b/tests/json-ast/x/lua/nested_function.lua.json
@@ -1,0 +1,97 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "outer"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "x"
+          ]
+        },
+        "Stmts": [
+          {
+            "Name": {
+              "Func": {
+                "Value": "inner"
+              },
+              "Receiver": null,
+              "Method": ""
+            },
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "y"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Exprs": [
+                    {
+                      "Operator": "+",
+                      "Lhs": {
+                        "Value": "x"
+                      },
+                      "Rhs": {
+                        "Value": "y"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "Exprs": [
+              {
+                "Func": {
+                  "Value": "inner"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "5"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "outer"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/order_by_map.lua.json
+++ b/tests/json-ast/x/lua/order_by_map.lua.json
@@ -1,0 +1,1081 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "data"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "a"
+                    },
+                    "Value": {
+                      "Value": "0"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "b"
+                    },
+                    "Value": {
+                      "Value": "5"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "sorted"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "__tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "x"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "data"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "__tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Fields": [
+                                  {
+                                    "Key": {
+                                      "Value": "a"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Value": "x"
+                                      },
+                                      "Key": {
+                                        "Value": "a"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Key": {
+                                      "Value": "b"
+                                    },
+                                    "Value": {
+                                      "Object": {
+                                        "Value": "x"
+                                      },
+                                      "Key": {
+                                        "Value": "b"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Value": "x"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "__tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Object": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Key": {
+                                "Value": "a"
+                              }
+                            },
+                            "Rhs": {
+                              "Object": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Key": {
+                                "Value": "a"
+                              }
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Operator": "\u003c",
+                                  "Lhs": {
+                                    "Object": {
+                                      "Object": {
+                                        "Value": "a"
+                                      },
+                                      "Key": {
+                                        "Value": "k"
+                                      }
+                                    },
+                                    "Key": {
+                                      "Value": "a"
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Object": {
+                                      "Object": {
+                                        "Value": "b"
+                                      },
+                                      "Key": {
+                                        "Value": "k"
+                                      }
+                                    },
+                                    "Key": {
+                                      "Value": "a"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Condition": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Object": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Key": {
+                                "Value": "b"
+                              }
+                            },
+                            "Rhs": {
+                              "Object": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Key": {
+                                "Value": "b"
+                              }
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Operator": "\u003c",
+                                  "Lhs": {
+                                    "Object": {
+                                      "Object": {
+                                        "Value": "a"
+                                      },
+                                      "Key": {
+                                        "Value": "k"
+                                      }
+                                    },
+                                    "Key": {
+                                      "Value": "b"
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Object": {
+                                      "Object": {
+                                        "Value": "b"
+                                      },
+                                      "Key": {
+                                        "Value": "k"
+                                      }
+                                    },
+                                    "Key": {
+                                      "Value": "b"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Exprs": [
+                            {}
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "__tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "_res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "sorted"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/outer_join.lua.json
+++ b/tests/json-ast/x/lua/outer_join.lua.json
@@ -1,0 +1,602 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "4"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Diana"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "250"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "125"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "102"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "300"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "103"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "5"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "80"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Object": {
+                    "Value": "o"
+                  },
+                  "Key": {
+                    "Value": "customerId"
+                  }
+                },
+                "Rhs": {
+                  "Object": {
+                    "Value": "c"
+                  },
+                  "Key": {
+                    "Value": "id"
+                  }
+                }
+              },
+              "Then": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "result"
+                      },
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "order"
+                            },
+                            "Value": {
+                              "Value": "o"
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "customer"
+                            },
+                            "Value": {
+                              "Value": "c"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ],
+              "Else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Outer Join using syntax ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "row"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Condition": {
+            "Object": {
+              "Value": "row"
+            },
+            "Key": {
+              "Value": "order"
+            }
+          },
+          "Then": [
+            {
+              "Condition": {
+                "Object": {
+                  "Value": "row"
+                },
+                "Key": {
+                  "Value": "customer"
+                }
+              },
+              "Then": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Value": "print"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Func": {
+                          "Object": {
+                            "Value": "string"
+                          },
+                          "Key": {
+                            "Value": "format"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "Order %s by %s - $ %s"
+                          },
+                          {
+                            "Object": {
+                              "Object": {
+                                "Value": "row"
+                              },
+                              "Key": {
+                                "Value": "order"
+                              }
+                            },
+                            "Key": {
+                              "Value": "id"
+                            }
+                          },
+                          {
+                            "Object": {
+                              "Object": {
+                                "Value": "row"
+                              },
+                              "Key": {
+                                "Value": "customer"
+                              }
+                            },
+                            "Key": {
+                              "Value": "name"
+                            }
+                          },
+                          {
+                            "Object": {
+                              "Object": {
+                                "Value": "row"
+                              },
+                              "Key": {
+                                "Value": "order"
+                              }
+                            },
+                            "Key": {
+                              "Value": "total"
+                            }
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ],
+              "Else": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Value": "print"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Func": {
+                          "Object": {
+                            "Value": "string"
+                          },
+                          "Key": {
+                            "Value": "format"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "Order %s by Unknown - $ %s"
+                          },
+                          {
+                            "Object": {
+                              "Object": {
+                                "Value": "row"
+                              },
+                              "Key": {
+                                "Value": "order"
+                              }
+                            },
+                            "Key": {
+                              "Value": "id"
+                            }
+                          },
+                          {
+                            "Object": {
+                              "Object": {
+                                "Value": "row"
+                              },
+                              "Key": {
+                                "Value": "order"
+                              }
+                            },
+                            "Key": {
+                              "Value": "total"
+                            }
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ]
+            }
+          ],
+          "Else": [
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Object": {
+                        "Value": "string"
+                      },
+                      "Key": {
+                        "Value": "format"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "Customer %s has no orders"
+                      },
+                      {
+                        "Object": {
+                          "Object": {
+                            "Value": "row"
+                          },
+                          "Key": {
+                            "Value": "customer"
+                          }
+                        },
+                        "Key": {
+                          "Value": "name"
+                        }
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/pairs_loop.lua.json
+++ b/tests/json-ast/x/lua/pairs_loop.lua.json
@@ -1,0 +1,122 @@
+{
+  "stmts": [
+    {
+      "Names": [
+        "_",
+        "v"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Fields": [
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "10"
+                  }
+                },
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "20"
+                  }
+                }
+              ]
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "v"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "v"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "pairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "m"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "v"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/partial_application.lua.json
+++ b/tests/json-ast/x/lua/partial_application.lua.json
@@ -1,0 +1,101 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "add"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "a",
+            "b"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "a"
+                },
+                "Rhs": {
+                  "Value": "b"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "add5"
+        }
+      ],
+      "Rhs": [
+        {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "p0"
+            ]
+          },
+          "Stmts": [
+            {
+              "Exprs": [
+                {
+                  "Func": {
+                    "Value": "add"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "5"
+                    },
+                    {
+                      "Value": "p0"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "add5"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/print_hello.lua.json
+++ b/tests/json-ast/x/lua/print_hello.lua.json
@@ -1,0 +1,19 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "hello"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/pure_fold.lua.json
+++ b/tests/json-ast/x/lua/pure_fold.lua.json
@@ -1,0 +1,67 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "triple"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "x"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Operator": "*",
+                "Lhs": {
+                  "Value": "x"
+                },
+                "Rhs": {
+                  "Value": "3"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "triple"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "1"
+                },
+                "Rhs": {
+                  "Value": "2"
+                }
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/pure_global_fold.lua.json
+++ b/tests/json-ast/x/lua/pure_global_fold.lua.json
@@ -1,0 +1,73 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "k"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Name": {
+        "Func": {
+          "Value": "inc"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "x"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "x"
+                },
+                "Rhs": {
+                  "Value": "k"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "inc"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "3"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/python_auto.lua.json
+++ b/tests/json-ast/x/lua/python_auto.lua.json
@@ -1,0 +1,155 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "math"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "sqrt"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "sqrt"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "pow"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "pow"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "sin"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "sin"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "log"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "log"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "pi"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "pi"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "e"
+              },
+              "Value": {
+                "Func": {
+                  "Object": {
+                    "Value": "math"
+                  },
+                  "Key": {
+                    "Value": "exp"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "1"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "math"
+              },
+              "Key": {
+                "Value": "sqrt"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "16"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "math"
+            },
+            "Key": {
+              "Value": "pi"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/python_math.lua.json
+++ b/tests/json-ast/x/lua/python_math.lua.json
@@ -1,0 +1,474 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "math"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "sqrt"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "sqrt"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "pow"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "pow"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "sin"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "sin"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "log"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "log"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "pi"
+              },
+              "Value": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "pi"
+                }
+              }
+            },
+            {
+              "Key": {
+                "Value": "e"
+              },
+              "Value": {
+                "Func": {
+                  "Object": {
+                    "Value": "math"
+                  },
+                  "Key": {
+                    "Value": "exp"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "1"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "r"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "3"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "area"
+        }
+      ],
+      "Rhs": [
+        {
+          "Operator": "*",
+          "Lhs": {
+            "Object": {
+              "Value": "math"
+            },
+            "Key": {
+              "Value": "pi"
+            }
+          },
+          "Rhs": {
+            "Func": {
+              "Object": {
+                "Value": "math"
+              },
+              "Key": {
+                "Value": "pow"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "r"
+              },
+              {
+                "Value": "2"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "root"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "Object": {
+              "Value": "math"
+            },
+            "Key": {
+              "Value": "sqrt"
+            }
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "49"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "sin45"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "Object": {
+              "Value": "math"
+            },
+            "Key": {
+              "Value": "sin"
+            }
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Operator": "/",
+              "Lhs": {
+                "Object": {
+                  "Value": "math"
+                },
+                "Key": {
+                  "Value": "pi"
+                }
+              },
+              "Rhs": {
+                "Value": "4"
+              }
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "log_e"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "Object": {
+              "Value": "math"
+            },
+            "Key": {
+              "Value": "log"
+            }
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Object": {
+                "Value": "math"
+              },
+              "Key": {
+                "Value": "e"
+              }
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "gsub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "Circle area with r = %s =\u003e %s"
+                  },
+                  {
+                    "Value": "r"
+                  },
+                  {
+                    "Value": "area"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": "%s+$"
+              },
+              {
+                "Value": ""
+              }
+            ],
+            "AdjustRet": true
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "gsub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "Square root of 49: %s"
+                  },
+                  {
+                    "Value": "root"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": "%s+$"
+              },
+              {
+                "Value": ""
+              }
+            ],
+            "AdjustRet": true
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "gsub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "sin(π/4): %s"
+                  },
+                  {
+                    "Value": "sin45"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": "%s+$"
+              },
+              {
+                "Value": ""
+              }
+            ],
+            "AdjustRet": true
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "gsub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "Object": {
+                    "Value": "string"
+                  },
+                  "Key": {
+                    "Value": "format"
+                  }
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "log(e): %s"
+                  },
+                  {
+                    "Value": "log_e"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": "%s+$"
+              },
+              {
+                "Value": ""
+              }
+            ],
+            "AdjustRet": true
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/query_sum_select.lua.json
+++ b/tests/json-ast/x/lua/query_sum_select.lua.json
@@ -1,0 +1,225 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "nums"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Value": "3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "_tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "n"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "nums"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Condition": {
+                      "Operator": "\u003e",
+                      "Lhs": {
+                        "Value": "n"
+                      },
+                      "Rhs": {
+                        "Value": "1"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Expr": {
+                          "Func": {
+                            "Object": {
+                              "Value": "table"
+                            },
+                            "Key": {
+                              "Value": "insert"
+                            }
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "_tmp"
+                            },
+                            {
+                              "Value": "n"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      }
+                    ],
+                    "Else": null
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Func": {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "lst"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Names": [
+                            "s"
+                          ],
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        },
+                        {
+                          "Names": [
+                            "_",
+                            "v"
+                          ],
+                          "Exprs": [
+                            {
+                              "Func": {
+                                "Value": "ipairs"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "lst"
+                                }
+                              ],
+                              "AdjustRet": false
+                            }
+                          ],
+                          "Stmts": [
+                            {
+                              "Lhs": [
+                                {
+                                  "Value": "s"
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Value": "s"
+                                  },
+                                  "Rhs": {
+                                    "Value": "v"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "s"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "_tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "result"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/record_assign.lua.json
+++ b/tests/json-ast/x/lua/record_assign.lua.json
@@ -1,0 +1,806 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "inc"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "c"
+          ]
+        },
+        "Stmts": [
+          {
+            "Lhs": [
+              {
+                "Object": {
+                  "Value": "c"
+                },
+                "Key": {
+                  "Value": "n"
+                }
+              }
+            ],
+            "Rhs": [
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Object": {
+                    "Value": "c"
+                  },
+                  "Key": {
+                    "Value": "n"
+                  }
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "c"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "n"
+              },
+              "Value": {
+                "Value": "0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "inc"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "_t"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "_c"
+                  ],
+                  "Exprs": [
+                    {
+                      "Fields": []
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "k",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "pairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "_t"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Object": {
+                            "Value": "_c"
+                          },
+                          "Key": {
+                            "Value": "k"
+                          }
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Value": "v"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "_c"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "c"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "ParList": {
+            "HasVargs": false,
+            "Names": [
+              "v"
+            ]
+          },
+          "Stmts": [
+            {
+              "Names": [
+                "encode"
+              ],
+              "Exprs": [
+                {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "x"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Func": {
+                            "Value": "type"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "x"
+                            }
+                          ],
+                          "AdjustRet": false
+                        },
+                        "Rhs": {
+                          "Value": "table"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Condition": {
+                            "Operator": "\u003e",
+                            "Lhs": {
+                              "Expr": {
+                                "Value": "x"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "0"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "["
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "val"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Func": {
+                                        "Value": "encode"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "val"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "x"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Names": [
+                                "keys"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": []
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "insert"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "Value": "k"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Expr": {
+                                "Func": {
+                                  "Object": {
+                                    "Value": "table"
+                                  },
+                                  "Key": {
+                                    "Value": "sort"
+                                  }
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "keys"
+                                  },
+                                  {
+                                    "ParList": {
+                                      "HasVargs": false,
+                                      "Names": [
+                                        "a",
+                                        "b"
+                                      ]
+                                    },
+                                    "Stmts": [
+                                      {
+                                        "Exprs": [
+                                          {
+                                            "Operator": "\u003c",
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "a"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "b"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "AdjustRet": false
+                              }
+                            },
+                            {
+                              "Names": [
+                                "parts"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Fields": [
+                                    {
+                                      "Key": null,
+                                      "Value": {
+                                        "Value": "{"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "i",
+                                "k"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "ipairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "keys"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Func": {
+                                            "Value": "tostring"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "k"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        },
+                                        "Rhs": {
+                                          "Lhs": {
+                                            "Value": "': "
+                                          },
+                                          "Rhs": {
+                                            "Func": {
+                                              "Value": "encode"
+                                            },
+                                            "Receiver": null,
+                                            "Method": "",
+                                            "Args": [
+                                              {
+                                                "Object": {
+                                                  "Value": "x"
+                                                },
+                                                "Key": {
+                                                  "Value": "k"
+                                                }
+                                              }
+                                            ],
+                                            "AdjustRet": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Condition": {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "i"
+                                    },
+                                    "Rhs": {
+                                      "Expr": {
+                                        "Value": "keys"
+                                      }
+                                    }
+                                  },
+                                  "Then": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Value": ", "
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Else": null
+                                }
+                              ]
+                            },
+                            {
+                              "Lhs": [
+                                {
+                                  "Object": {
+                                    "Value": "parts"
+                                  },
+                                  "Key": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Expr": {
+                                        "Value": "parts"
+                                      }
+                                    },
+                                    "Rhs": {
+                                      "Value": "1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "Rhs": [
+                                {
+                                  "Value": "}"
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Object": {
+                                      "Value": "table"
+                                    },
+                                    "Key": {
+                                      "Value": "concat"
+                                    }
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "parts"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "string"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Lhs": {
+                                    "Value": "'"
+                                  },
+                                  "Rhs": {
+                                    "Lhs": {
+                                      "Value": "x"
+                                    },
+                                    "Rhs": {
+                                      "Value": "'"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "tostring"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Value": "encode"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "v"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "c"
+            },
+            "Key": {
+              "Value": "n"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/right_join.lua.json
+++ b/tests/json-ast/x/lua/right_join.lua.json
@@ -1,0 +1,496 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "customers"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "3"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "4"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Diana"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "orders"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "100"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "250"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "101"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "125"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "id"
+                    },
+                    "Value": {
+                      "Value": "102"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "customerId"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "total"
+                    },
+                    "Value": {
+                      "Value": "300"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": []
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "o"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "orders"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Names": [
+            "_",
+            "c"
+          ],
+          "Exprs": [
+            {
+              "Func": {
+                "Value": "ipairs"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "customers"
+                }
+              ],
+              "AdjustRet": false
+            }
+          ],
+          "Stmts": [
+            {
+              "Condition": {
+                "Operator": "==",
+                "Lhs": {
+                  "Object": {
+                    "Value": "o"
+                  },
+                  "Key": {
+                    "Value": "customerId"
+                  }
+                },
+                "Rhs": {
+                  "Object": {
+                    "Value": "c"
+                  },
+                  "Key": {
+                    "Value": "id"
+                  }
+                }
+              },
+              "Then": [
+                {
+                  "Expr": {
+                    "Func": {
+                      "Object": {
+                        "Value": "table"
+                      },
+                      "Key": {
+                        "Value": "insert"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "result"
+                      },
+                      {
+                        "Fields": [
+                          {
+                            "Key": {
+                              "Value": "customerName"
+                            },
+                            "Value": {
+                              "Object": {
+                                "Value": "c"
+                              },
+                              "Key": {
+                                "Value": "name"
+                              }
+                            }
+                          },
+                          {
+                            "Key": {
+                              "Value": "order"
+                            },
+                            "Value": {
+                              "Value": "o"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ],
+              "Else": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "--- Right Join using syntax ---"
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Names": [
+        "_",
+        "entry"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "result"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Condition": {
+            "Object": {
+              "Value": "entry"
+            },
+            "Key": {
+              "Value": "order"
+            }
+          },
+          "Then": [
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Object": {
+                        "Value": "string"
+                      },
+                      "Key": {
+                        "Value": "format"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "Customer %s has order %s - $ %s"
+                      },
+                      {
+                        "Object": {
+                          "Value": "entry"
+                        },
+                        "Key": {
+                          "Value": "customerName"
+                        }
+                      },
+                      {
+                        "Object": {
+                          "Object": {
+                            "Value": "entry"
+                          },
+                          "Key": {
+                            "Value": "order"
+                          }
+                        },
+                        "Key": {
+                          "Value": "id"
+                        }
+                      },
+                      {
+                        "Object": {
+                          "Object": {
+                            "Value": "entry"
+                          },
+                          "Key": {
+                            "Value": "order"
+                          }
+                        },
+                        "Key": {
+                          "Value": "total"
+                        }
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ],
+          "Else": [
+            {
+              "Expr": {
+                "Func": {
+                  "Value": "print"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Func": {
+                      "Object": {
+                        "Value": "string"
+                      },
+                      "Key": {
+                        "Value": "format"
+                      }
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "Customer %s has no orders"
+                      },
+                      {
+                        "Object": {
+                          "Value": "entry"
+                        },
+                        "Key": {
+                          "Value": "customerName"
+                        }
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "AdjustRet": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/save_jsonl_stdout.lua.json
+++ b/tests/json-ast/x/lua/save_jsonl_stdout.lua.json
@@ -1,0 +1,726 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "30"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "25"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Names": [
+        "_",
+        "_row"
+      ],
+      "Exprs": [
+        {
+          "Func": {
+            "Value": "ipairs"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Value": "people"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ],
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "encode"
+                  ],
+                  "Exprs": [
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "x"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "table"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "x"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Names": [
+                                    "parts"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": [
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "["
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "i",
+                                    "val"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "ipairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Func": {
+                                            "Value": "encode"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "val"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Condition": {
+                                        "Operator": "\u003c",
+                                        "Lhs": {
+                                          "Value": "i"
+                                        },
+                                        "Rhs": {
+                                          "Expr": {
+                                            "Value": "x"
+                                          }
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Value": ", "
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Value": "]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Object": {
+                                          "Value": "table"
+                                        },
+                                        "Key": {
+                                          "Value": "concat"
+                                        }
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "parts"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Names": [
+                                    "keys"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "k"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "pairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Expr": {
+                                        "Func": {
+                                          "Object": {
+                                            "Value": "table"
+                                          },
+                                          "Key": {
+                                            "Value": "insert"
+                                          }
+                                        },
+                                        "Receiver": null,
+                                        "Method": "",
+                                        "Args": [
+                                          {
+                                            "Value": "keys"
+                                          },
+                                          {
+                                            "Value": "k"
+                                          }
+                                        ],
+                                        "AdjustRet": false
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "sort"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": [
+                                            "a",
+                                            "b"
+                                          ]
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Operator": "\u003e",
+                                                "Lhs": {
+                                                  "Func": {
+                                                    "Value": "tostring"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "a"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                },
+                                                "Rhs": {
+                                                  "Func": {
+                                                    "Value": "tostring"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "b"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                },
+                                {
+                                  "Names": [
+                                    "parts"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": [
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "{"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "i",
+                                    "k"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "ipairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "keys"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Lhs": {
+                                            "Value": "\""
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "k"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Lhs": {
+                                                "Value": "\": "
+                                              },
+                                              "Rhs": {
+                                                "Func": {
+                                                  "Value": "encode"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "x"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "k"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Condition": {
+                                        "Operator": "\u003c",
+                                        "Lhs": {
+                                          "Value": "i"
+                                        },
+                                        "Rhs": {
+                                          "Expr": {
+                                            "Value": "keys"
+                                          }
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Value": ", "
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Value": "}"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Object": {
+                                          "Value": "table"
+                                        },
+                                        "Key": {
+                                          "Value": "concat"
+                                        }
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "parts"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Func": {
+                                    "Value": "type"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                },
+                                "Rhs": {
+                                  "Value": "string"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "\""
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Value": "x"
+                                        },
+                                        "Rhs": {
+                                          "Value": "\""
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Expr": {
+                    "Func": {
+                      "Value": "print"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Func": {
+                          "Value": "encode"
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "v"
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "_row"
+              }
+            ],
+            "AdjustRet": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/short_circuit.lua.json
+++ b/tests/json-ast/x/lua/short_circuit.lua.json
@@ -1,0 +1,132 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "boom"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "a",
+            "b"
+          ]
+        },
+        "Stmts": [
+          {
+            "Expr": {
+              "Func": {
+                "Value": "print"
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "boom"
+                }
+              ],
+              "AdjustRet": false
+            }
+          },
+          {
+            "Exprs": [
+              {}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "and",
+                "Lhs": {},
+                "Rhs": {
+                  "Func": {
+                    "Value": "boom"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "1"
+                    },
+                    {
+                      "Value": "2"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            },
+            "Rhs": {
+              "Value": "0"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "or",
+            "Lhs": {
+              "Operator": "and",
+              "Lhs": {
+                "Operator": "or",
+                "Lhs": {},
+                "Rhs": {
+                  "Func": {
+                    "Value": "boom"
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "1"
+                    },
+                    {
+                      "Value": "2"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            },
+            "Rhs": {
+              "Value": "0"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/slice.lua.json
+++ b/tests/json-ast/x/lua/slice.lua.json
@@ -1,0 +1,330 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "table"
+              },
+              "Key": {
+                "Value": "concat"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "lst",
+                      "s",
+                      "e"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "r"
+                      ],
+                      "Exprs": [
+                        {
+                          "Fields": []
+                        }
+                      ]
+                    },
+                    {
+                      "Name": "i",
+                      "Init": {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Value": "s"
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      },
+                      "Limit": {
+                        "Value": "e"
+                      },
+                      "Step": null,
+                      "Stmts": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "r"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "r"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Object": {
+                                "Value": "lst"
+                              },
+                              "Key": {
+                                "Value": "i"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {
+                          "Value": "r"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Fields": [
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "1"
+                        }
+                      },
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "2"
+                        }
+                      },
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "3"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Value": "1"
+                  },
+                  {
+                    "Value": "3"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": " "
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "table"
+              },
+              "Key": {
+                "Value": "concat"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "lst",
+                      "s",
+                      "e"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "r"
+                      ],
+                      "Exprs": [
+                        {
+                          "Fields": []
+                        }
+                      ]
+                    },
+                    {
+                      "Name": "i",
+                      "Init": {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Value": "s"
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      },
+                      "Limit": {
+                        "Value": "e"
+                      },
+                      "Step": null,
+                      "Stmts": [
+                        {
+                          "Lhs": [
+                            {
+                              "Object": {
+                                "Value": "r"
+                              },
+                              "Key": {
+                                "Operator": "+",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "r"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "1"
+                                }
+                              }
+                            }
+                          ],
+                          "Rhs": [
+                            {
+                              "Object": {
+                                "Value": "lst"
+                              },
+                              "Key": {
+                                "Value": "i"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {
+                          "Value": "r"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Fields": [
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "1"
+                        }
+                      },
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "2"
+                        }
+                      },
+                      {
+                        "Key": null,
+                        "Value": {
+                          "Value": "3"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Value": "0"
+                  },
+                  {
+                    "Value": "2"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": " "
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "sub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "hello"
+              },
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "1"
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              },
+              {
+                "Value": "4"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/sort_stable.lua.json
+++ b/tests/json-ast/x/lua/sort_stable.lua.json
@@ -1,0 +1,1033 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "items"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "n"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "v"
+                    },
+                    "Value": {
+                      "Value": "a"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "n"
+                    },
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "v"
+                    },
+                    "Value": {
+                      "Value": "b"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "n"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "v"
+                    },
+                    "Value": {
+                      "Value": "c"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "ParList": {
+              "HasVargs": false,
+              "Names": []
+            },
+            "Stmts": [
+              {
+                "Names": [
+                  "__tmp"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_res"
+                ],
+                "Exprs": [
+                  {
+                    "Fields": []
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_idx"
+                ],
+                "Exprs": [
+                  {
+                    "Value": "0"
+                  }
+                ]
+              },
+              {
+                "Names": [
+                  "_",
+                  "i"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "items"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Value": "_idx"
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Value": "_idx"
+                        },
+                        "Rhs": {
+                          "Value": "1"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Expr": {
+                      "Func": {
+                        "Object": {
+                          "Value": "table"
+                        },
+                        "Key": {
+                          "Value": "insert"
+                        }
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "__tmp"
+                        },
+                        {
+                          "Fields": [
+                            {
+                              "Key": {
+                                "Value": "i"
+                              },
+                              "Value": {
+                                "Value": "_idx"
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "k"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "i"
+                                },
+                                "Key": {
+                                  "Value": "n"
+                                }
+                              }
+                            },
+                            {
+                              "Key": {
+                                "Value": "v"
+                              },
+                              "Value": {
+                                "Object": {
+                                  "Value": "i"
+                                },
+                                "Key": {
+                                  "Value": "v"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  }
+                ]
+              },
+              {
+                "Expr": {
+                  "Func": {
+                    "Object": {
+                      "Value": "table"
+                    },
+                    "Key": {
+                      "Value": "sort"
+                    }
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "__tmp"
+                    },
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "a",
+                          "b"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Object": {
+                                "Value": "a"
+                              },
+                              "Key": {
+                                "Value": "k"
+                              }
+                            },
+                            "Rhs": {
+                              "Object": {
+                                "Value": "b"
+                              },
+                              "Key": {
+                                "Value": "k"
+                              }
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Operator": "\u003c",
+                                  "Lhs": {
+                                    "Object": {
+                                      "Value": "a"
+                                    },
+                                    "Key": {
+                                      "Value": "i"
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Object": {
+                                      "Value": "b"
+                                    },
+                                    "Key": {
+                                      "Value": "i"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        },
+                        {
+                          "Exprs": [
+                            {
+                              "Operator": "\u003c",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "a"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              },
+                              "Rhs": {
+                                "Object": {
+                                  "Value": "b"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              },
+              {
+                "Names": [
+                  "i",
+                  "p"
+                ],
+                "Exprs": [
+                  {
+                    "Func": {
+                      "Value": "ipairs"
+                    },
+                    "Receiver": null,
+                    "Method": "",
+                    "Args": [
+                      {
+                        "Value": "__tmp"
+                      }
+                    ],
+                    "AdjustRet": false
+                  }
+                ],
+                "Stmts": [
+                  {
+                    "Lhs": [
+                      {
+                        "Object": {
+                          "Value": "_res"
+                        },
+                        "Key": {
+                          "Value": "i"
+                        }
+                      }
+                    ],
+                    "Rhs": [
+                      {
+                        "Object": {
+                          "Value": "p"
+                        },
+                        "Key": {
+                          "Value": "v"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Exprs": [
+                  {
+                    "Value": "_res"
+                  }
+                ]
+              }
+            ]
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "v"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "encode"
+                  ],
+                  "Exprs": [
+                    {
+                      "ParList": {
+                        "HasVargs": false,
+                        "Names": [
+                          "x"
+                        ]
+                      },
+                      "Stmts": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "x"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "table"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Condition": {
+                                "Operator": "\u003e",
+                                "Lhs": {
+                                  "Expr": {
+                                    "Value": "x"
+                                  }
+                                },
+                                "Rhs": {
+                                  "Value": "0"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Names": [
+                                    "parts"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": [
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "["
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "i",
+                                    "val"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "ipairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Func": {
+                                            "Value": "encode"
+                                          },
+                                          "Receiver": null,
+                                          "Method": "",
+                                          "Args": [
+                                            {
+                                              "Value": "val"
+                                            }
+                                          ],
+                                          "AdjustRet": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Condition": {
+                                        "Operator": "\u003c",
+                                        "Lhs": {
+                                          "Value": "i"
+                                        },
+                                        "Rhs": {
+                                          "Expr": {
+                                            "Value": "x"
+                                          }
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Value": ", "
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Value": "]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Object": {
+                                          "Value": "table"
+                                        },
+                                        "Key": {
+                                          "Value": "concat"
+                                        }
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "parts"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Names": [
+                                    "keys"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "k"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "pairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Expr": {
+                                        "Func": {
+                                          "Object": {
+                                            "Value": "table"
+                                          },
+                                          "Key": {
+                                            "Value": "insert"
+                                          }
+                                        },
+                                        "Receiver": null,
+                                        "Method": "",
+                                        "Args": [
+                                          {
+                                            "Value": "keys"
+                                          },
+                                          {
+                                            "Value": "k"
+                                          }
+                                        ],
+                                        "AdjustRet": false
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Expr": {
+                                    "Func": {
+                                      "Object": {
+                                        "Value": "table"
+                                      },
+                                      "Key": {
+                                        "Value": "sort"
+                                      }
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "keys"
+                                      },
+                                      {
+                                        "ParList": {
+                                          "HasVargs": false,
+                                          "Names": [
+                                            "a",
+                                            "b"
+                                          ]
+                                        },
+                                        "Stmts": [
+                                          {
+                                            "Exprs": [
+                                              {
+                                                "Operator": "\u003e",
+                                                "Lhs": {
+                                                  "Func": {
+                                                    "Value": "tostring"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "a"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                },
+                                                "Rhs": {
+                                                  "Func": {
+                                                    "Value": "tostring"
+                                                  },
+                                                  "Receiver": null,
+                                                  "Method": "",
+                                                  "Args": [
+                                                    {
+                                                      "Value": "b"
+                                                    }
+                                                  ],
+                                                  "AdjustRet": false
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                },
+                                {
+                                  "Names": [
+                                    "parts"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Fields": [
+                                        {
+                                          "Key": null,
+                                          "Value": {
+                                            "Value": "{"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Names": [
+                                    "i",
+                                    "k"
+                                  ],
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "ipairs"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "keys"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ],
+                                  "Stmts": [
+                                    {
+                                      "Lhs": [
+                                        {
+                                          "Object": {
+                                            "Value": "parts"
+                                          },
+                                          "Key": {
+                                            "Operator": "+",
+                                            "Lhs": {
+                                              "Expr": {
+                                                "Value": "parts"
+                                              }
+                                            },
+                                            "Rhs": {
+                                              "Value": "1"
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "Rhs": [
+                                        {
+                                          "Lhs": {
+                                            "Value": "'"
+                                          },
+                                          "Rhs": {
+                                            "Lhs": {
+                                              "Func": {
+                                                "Value": "tostring"
+                                              },
+                                              "Receiver": null,
+                                              "Method": "",
+                                              "Args": [
+                                                {
+                                                  "Value": "k"
+                                                }
+                                              ],
+                                              "AdjustRet": false
+                                            },
+                                            "Rhs": {
+                                              "Lhs": {
+                                                "Value": "': "
+                                              },
+                                              "Rhs": {
+                                                "Func": {
+                                                  "Value": "encode"
+                                                },
+                                                "Receiver": null,
+                                                "Method": "",
+                                                "Args": [
+                                                  {
+                                                    "Object": {
+                                                      "Value": "x"
+                                                    },
+                                                    "Key": {
+                                                      "Value": "k"
+                                                    }
+                                                  }
+                                                ],
+                                                "AdjustRet": false
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Condition": {
+                                        "Operator": "\u003c",
+                                        "Lhs": {
+                                          "Value": "i"
+                                        },
+                                        "Rhs": {
+                                          "Expr": {
+                                            "Value": "keys"
+                                          }
+                                        }
+                                      },
+                                      "Then": [
+                                        {
+                                          "Lhs": [
+                                            {
+                                              "Object": {
+                                                "Value": "parts"
+                                              },
+                                              "Key": {
+                                                "Operator": "+",
+                                                "Lhs": {
+                                                  "Expr": {
+                                                    "Value": "parts"
+                                                  }
+                                                },
+                                                "Rhs": {
+                                                  "Value": "1"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "Rhs": [
+                                            {
+                                              "Value": ", "
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Else": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Object": {
+                                        "Value": "parts"
+                                      },
+                                      "Key": {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Expr": {
+                                            "Value": "parts"
+                                          }
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Value": "}"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Object": {
+                                          "Value": "table"
+                                        },
+                                        "Key": {
+                                          "Value": "concat"
+                                        }
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "parts"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Condition": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Func": {
+                                    "Value": "type"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "x"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                },
+                                "Rhs": {
+                                  "Value": "string"
+                                }
+                              },
+                              "Then": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Lhs": {
+                                        "Value": "'"
+                                      },
+                                      "Rhs": {
+                                        "Lhs": {
+                                          "Value": "x"
+                                        },
+                                        "Rhs": {
+                                          "Value": "'"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Else": [
+                                {
+                                  "Exprs": [
+                                    {
+                                      "Func": {
+                                        "Value": "tostring"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "x"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "encode"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "v"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "result"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/str_builtin.lua.json
+++ b/tests/json-ast/x/lua/str_builtin.lua.json
@@ -1,0 +1,29 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "tostring"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "123"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/string_compare.lua.json
+++ b/tests/json-ast/x/lua/string_compare.lua.json
@@ -1,0 +1,88 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "\u003c",
+            "Lhs": {
+              "Value": "a"
+            },
+            "Rhs": {
+              "Value": "b"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "\u003c=",
+            "Lhs": {
+              "Value": "a"
+            },
+            "Rhs": {
+              "Value": "a"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "\u003e",
+            "Lhs": {
+              "Value": "b"
+            },
+            "Rhs": {
+              "Value": "a"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "\u003e=",
+            "Lhs": {
+              "Value": "b"
+            },
+            "Rhs": {
+              "Value": "b"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/string_concat.lua.json
+++ b/tests/json-ast/x/lua/string_concat.lua.json
@@ -1,0 +1,24 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Lhs": {
+              "Value": "hello "
+            },
+            "Rhs": {
+              "Value": "world"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/string_contains.lua.json
+++ b/tests/json-ast/x/lua/string_contains.lua.json
@@ -1,0 +1,98 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "s"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "catch"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "find"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s"
+                },
+                {
+                  "Value": "cat"
+                },
+                {
+                  "Value": "1"
+                },
+                {}
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "find"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s"
+                },
+                {
+                  "Value": "dog"
+                },
+                {
+                  "Value": "1"
+                },
+                {}
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/string_in_operator.lua.json
+++ b/tests/json-ast/x/lua/string_in_operator.lua.json
@@ -1,0 +1,98 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "s"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "catch"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "find"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s"
+                },
+                {
+                  "Value": "cat"
+                },
+                {
+                  "Value": "1"
+                },
+                {}
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "~=",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "find"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s"
+                },
+                {
+                  "Value": "dog"
+                },
+                {
+                  "Value": "1"
+                },
+                {}
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {}
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/string_index.lua.json
+++ b/tests/json-ast/x/lua/string_index.lua.json
@@ -1,0 +1,64 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "s"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "mochi"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "sub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "s"
+              },
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "1"
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              },
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "1"
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/string_prefix_slice.lua.json
+++ b/tests/json-ast/x/lua/string_prefix_slice.lua.json
@@ -1,0 +1,490 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "prefix"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "fore"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "s1"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "forest"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "==",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "sub"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s1"
+                },
+                {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Value": "0"
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                },
+                {
+                  "Func": {
+                    "ParList": {
+                      "HasVargs": false,
+                      "Names": [
+                        "v"
+                      ]
+                    },
+                    "Stmts": [
+                      {
+                        "Condition": {
+                          "Operator": "and",
+                          "Lhs": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "table"
+                            }
+                          },
+                          "Rhs": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Object": {
+                                "Value": "v"
+                              },
+                              "Key": {
+                                "Value": "items"
+                              }
+                            },
+                            "Rhs": {}
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Exprs": [
+                              {
+                                "Expr": {
+                                  "Object": {
+                                    "Value": "v"
+                                  },
+                                  "Key": {
+                                    "Value": "items"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "Else": [
+                          {
+                            "Condition": {
+                              "Operator": "and",
+                              "Lhs": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Func": {
+                                    "Value": "type"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "v"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                },
+                                "Rhs": {
+                                  "Value": "table"
+                                }
+                              },
+                              "Rhs": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Object": {
+                                    "Value": "v"
+                                  },
+                                  "Key": {
+                                    "Value": "1"
+                                  }
+                                },
+                                "Rhs": {}
+                              }
+                            },
+                            "Then": [
+                              {
+                                "Names": [
+                                  "c"
+                                ],
+                                "Exprs": [
+                                  {
+                                    "Value": "0"
+                                  }
+                                ]
+                              },
+                              {
+                                "Names": [
+                                  "_"
+                                ],
+                                "Exprs": [
+                                  {
+                                    "Func": {
+                                      "Value": "pairs"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "v"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                ],
+                                "Stmts": [
+                                  {
+                                    "Lhs": [
+                                      {
+                                        "Value": "c"
+                                      }
+                                    ],
+                                    "Rhs": [
+                                      {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Value": "c"
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Exprs": [
+                                  {
+                                    "Value": "c"
+                                  }
+                                ]
+                              }
+                            ],
+                            "Else": [
+                              {
+                                "Exprs": [
+                                  {
+                                    "Expr": {
+                                      "Value": "v"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "prefix"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {
+              "Value": "prefix"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "s2"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "desert"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "==",
+            "Lhs": {
+              "Func": {
+                "Object": {
+                  "Value": "string"
+                },
+                "Key": {
+                  "Value": "sub"
+                }
+              },
+              "Receiver": null,
+              "Method": "",
+              "Args": [
+                {
+                  "Value": "s2"
+                },
+                {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Value": "0"
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                },
+                {
+                  "Func": {
+                    "ParList": {
+                      "HasVargs": false,
+                      "Names": [
+                        "v"
+                      ]
+                    },
+                    "Stmts": [
+                      {
+                        "Condition": {
+                          "Operator": "and",
+                          "Lhs": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Func": {
+                                "Value": "type"
+                              },
+                              "Receiver": null,
+                              "Method": "",
+                              "Args": [
+                                {
+                                  "Value": "v"
+                                }
+                              ],
+                              "AdjustRet": false
+                            },
+                            "Rhs": {
+                              "Value": "table"
+                            }
+                          },
+                          "Rhs": {
+                            "Operator": "~=",
+                            "Lhs": {
+                              "Object": {
+                                "Value": "v"
+                              },
+                              "Key": {
+                                "Value": "items"
+                              }
+                            },
+                            "Rhs": {}
+                          }
+                        },
+                        "Then": [
+                          {
+                            "Exprs": [
+                              {
+                                "Expr": {
+                                  "Object": {
+                                    "Value": "v"
+                                  },
+                                  "Key": {
+                                    "Value": "items"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "Else": [
+                          {
+                            "Condition": {
+                              "Operator": "and",
+                              "Lhs": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Func": {
+                                    "Value": "type"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "v"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                },
+                                "Rhs": {
+                                  "Value": "table"
+                                }
+                              },
+                              "Rhs": {
+                                "Operator": "==",
+                                "Lhs": {
+                                  "Object": {
+                                    "Value": "v"
+                                  },
+                                  "Key": {
+                                    "Value": "1"
+                                  }
+                                },
+                                "Rhs": {}
+                              }
+                            },
+                            "Then": [
+                              {
+                                "Names": [
+                                  "c"
+                                ],
+                                "Exprs": [
+                                  {
+                                    "Value": "0"
+                                  }
+                                ]
+                              },
+                              {
+                                "Names": [
+                                  "_"
+                                ],
+                                "Exprs": [
+                                  {
+                                    "Func": {
+                                      "Value": "pairs"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "v"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                ],
+                                "Stmts": [
+                                  {
+                                    "Lhs": [
+                                      {
+                                        "Value": "c"
+                                      }
+                                    ],
+                                    "Rhs": [
+                                      {
+                                        "Operator": "+",
+                                        "Lhs": {
+                                          "Value": "c"
+                                        },
+                                        "Rhs": {
+                                          "Value": "1"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Exprs": [
+                                  {
+                                    "Value": "c"
+                                  }
+                                ]
+                              }
+                            ],
+                            "Else": [
+                              {
+                                "Exprs": [
+                                  {
+                                    "Expr": {
+                                      "Value": "v"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "Receiver": null,
+                  "Method": "",
+                  "Args": [
+                    {
+                      "Value": "prefix"
+                    }
+                  ],
+                  "AdjustRet": false
+                }
+              ],
+              "AdjustRet": false
+            },
+            "Rhs": {
+              "Value": "prefix"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/substring_builtin.lua.json
+++ b/tests/json-ast/x/lua/substring_builtin.lua.json
@@ -1,0 +1,46 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "string"
+              },
+              "Key": {
+                "Value": "sub"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "mochi"
+              },
+              {
+                "Operator": "+",
+                "Lhs": {
+                  "Value": "1"
+                },
+                "Rhs": {
+                  "Value": "1"
+                }
+              },
+              {
+                "Value": "4"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/sum_builtin.lua.json
+++ b/tests/json-ast/x/lua/sum_builtin.lua.json
@@ -1,0 +1,113 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "ParList": {
+                "HasVargs": false,
+                "Names": [
+                  "lst"
+                ]
+              },
+              "Stmts": [
+                {
+                  "Names": [
+                    "s"
+                  ],
+                  "Exprs": [
+                    {
+                      "Value": "0"
+                    }
+                  ]
+                },
+                {
+                  "Names": [
+                    "_",
+                    "v"
+                  ],
+                  "Exprs": [
+                    {
+                      "Func": {
+                        "Value": "ipairs"
+                      },
+                      "Receiver": null,
+                      "Method": "",
+                      "Args": [
+                        {
+                          "Value": "lst"
+                        }
+                      ],
+                      "AdjustRet": false
+                    }
+                  ],
+                  "Stmts": [
+                    {
+                      "Lhs": [
+                        {
+                          "Value": "s"
+                        }
+                      ],
+                      "Rhs": [
+                        {
+                          "Operator": "+",
+                          "Lhs": {
+                            "Value": "s"
+                          },
+                          "Rhs": {
+                            "Value": "v"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Exprs": [
+                    {
+                      "Value": "s"
+                    }
+                  ]
+                }
+              ]
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Value": "3"
+                    }
+                  }
+                ]
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/tail_recursion.lua.json
+++ b/tests/json-ast/x/lua/tail_recursion.lua.json
@@ -1,0 +1,105 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "sum_rec"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "n",
+            "acc"
+          ]
+        },
+        "Stmts": [
+          {
+            "Condition": {
+              "Operator": "==",
+              "Lhs": {
+                "Value": "n"
+              },
+              "Rhs": {
+                "Value": "0"
+              }
+            },
+            "Then": [
+              {
+                "Exprs": [
+                  {
+                    "Value": "acc"
+                  }
+                ]
+              }
+            ],
+            "Else": null
+          },
+          {
+            "Exprs": [
+              {
+                "Func": {
+                  "Value": "sum_rec"
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Operator": "-",
+                    "Lhs": {
+                      "Value": "n"
+                    },
+                    "Rhs": {
+                      "Value": "1"
+                    }
+                  },
+                  {
+                    "Operator": "+",
+                    "Lhs": {
+                      "Value": "acc"
+                    },
+                    "Rhs": {
+                      "Value": "n"
+                    }
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "sum_rec"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "10"
+              },
+              {
+                "Value": "0"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/test_block.lua.json
+++ b/tests/json-ast/x/lua/test_block.lua.json
@@ -1,0 +1,19 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "ok"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/tree_sum.lua.json
+++ b/tests/json-ast/x/lua/tree_sum.lua.json
@@ -1,0 +1,307 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "sum_tree"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "t"
+          ]
+        },
+        "Stmts": [
+          {
+            "Exprs": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "_m"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "==",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "_m"
+                          },
+                          "Key": {
+                            "Value": "__name"
+                          }
+                        },
+                        "Rhs": {
+                          "Value": "Leaf"
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {
+                              "Value": "0"
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "==",
+                            "Lhs": {
+                              "Object": {
+                                "Value": "_m"
+                              },
+                              "Key": {
+                                "Value": "__name"
+                              }
+                            },
+                            "Rhs": {
+                              "Value": "Node"
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "left"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Object": {
+                                    "Value": "_m"
+                                  },
+                                  "Key": {
+                                    "Value": "left"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "value"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Object": {
+                                    "Value": "_m"
+                                  },
+                                  "Key": {
+                                    "Value": "value"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "right"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Object": {
+                                    "Value": "_m"
+                                  },
+                                  "Key": {
+                                    "Value": "right"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Operator": "+",
+                                  "Lhs": {
+                                    "Operator": "+",
+                                    "Lhs": {
+                                      "Func": {
+                                        "Value": "sum_tree"
+                                      },
+                                      "Receiver": null,
+                                      "Method": "",
+                                      "Args": [
+                                        {
+                                          "Value": "left"
+                                        }
+                                      ],
+                                      "AdjustRet": false
+                                    },
+                                    "Rhs": {
+                                      "Value": "value"
+                                    }
+                                  },
+                                  "Rhs": {
+                                    "Func": {
+                                      "Value": "sum_tree"
+                                    },
+                                    "Receiver": null,
+                                    "Method": "",
+                                    "Args": [
+                                      {
+                                        "Value": "right"
+                                      }
+                                    ],
+                                    "AdjustRet": false
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": null
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "t"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "t"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "__name"
+              },
+              "Value": {
+                "Value": "Node"
+              }
+            },
+            {
+              "Key": {
+                "Value": "left"
+              },
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "__name"
+                    },
+                    "Value": {
+                      "Value": "Leaf"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": {
+                "Value": "value"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "right"
+              },
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "__name"
+                    },
+                    "Value": {
+                      "Value": "Node"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "left"
+                    },
+                    "Value": {
+                      "Fields": [
+                        {
+                          "Key": {
+                            "Value": "__name"
+                          },
+                          "Value": {
+                            "Value": "Leaf"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "value"
+                    },
+                    "Value": {
+                      "Value": "2"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "right"
+                    },
+                    "Value": {
+                      "Fields": [
+                        {
+                          "Key": {
+                            "Value": "__name"
+                          },
+                          "Value": {
+                            "Value": "Leaf"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Value": "sum_tree"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "t"
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/two-sum.lua.json
+++ b/tests/json-ast/x/lua/two-sum.lua.json
@@ -1,0 +1,451 @@
+{
+  "stmts": [
+    {
+      "Name": {
+        "Func": {
+          "Value": "twoSum"
+        },
+        "Receiver": null,
+        "Method": ""
+      },
+      "Func": {
+        "ParList": {
+          "HasVargs": false,
+          "Names": [
+            "nums",
+            "target"
+          ]
+        },
+        "Stmts": [
+          {
+            "Lhs": [
+              {
+                "Value": "n"
+              }
+            ],
+            "Rhs": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "v"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Condition": {
+                        "Operator": "and",
+                        "Lhs": {
+                          "Operator": "==",
+                          "Lhs": {
+                            "Func": {
+                              "Value": "type"
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "v"
+                              }
+                            ],
+                            "AdjustRet": false
+                          },
+                          "Rhs": {
+                            "Value": "table"
+                          }
+                        },
+                        "Rhs": {
+                          "Operator": "~=",
+                          "Lhs": {
+                            "Object": {
+                              "Value": "v"
+                            },
+                            "Key": {
+                              "Value": "items"
+                            }
+                          },
+                          "Rhs": {}
+                        }
+                      },
+                      "Then": [
+                        {
+                          "Exprs": [
+                            {
+                              "Expr": {
+                                "Object": {
+                                  "Value": "v"
+                                },
+                                "Key": {
+                                  "Value": "items"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "Else": [
+                        {
+                          "Condition": {
+                            "Operator": "and",
+                            "Lhs": {
+                              "Operator": "==",
+                              "Lhs": {
+                                "Func": {
+                                  "Value": "type"
+                                },
+                                "Receiver": null,
+                                "Method": "",
+                                "Args": [
+                                  {
+                                    "Value": "v"
+                                  }
+                                ],
+                                "AdjustRet": false
+                              },
+                              "Rhs": {
+                                "Value": "table"
+                              }
+                            },
+                            "Rhs": {
+                              "Operator": "==",
+                              "Lhs": {
+                                "Object": {
+                                  "Value": "v"
+                                },
+                                "Key": {
+                                  "Value": "1"
+                                }
+                              },
+                              "Rhs": {}
+                            }
+                          },
+                          "Then": [
+                            {
+                              "Names": [
+                                "c"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Value": "0"
+                                }
+                              ]
+                            },
+                            {
+                              "Names": [
+                                "_"
+                              ],
+                              "Exprs": [
+                                {
+                                  "Func": {
+                                    "Value": "pairs"
+                                  },
+                                  "Receiver": null,
+                                  "Method": "",
+                                  "Args": [
+                                    {
+                                      "Value": "v"
+                                    }
+                                  ],
+                                  "AdjustRet": false
+                                }
+                              ],
+                              "Stmts": [
+                                {
+                                  "Lhs": [
+                                    {
+                                      "Value": "c"
+                                    }
+                                  ],
+                                  "Rhs": [
+                                    {
+                                      "Operator": "+",
+                                      "Lhs": {
+                                        "Value": "c"
+                                      },
+                                      "Rhs": {
+                                        "Value": "1"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Exprs": [
+                                {
+                                  "Value": "c"
+                                }
+                              ]
+                            }
+                          ],
+                          "Else": [
+                            {
+                              "Exprs": [
+                                {
+                                  "Expr": {
+                                    "Value": "v"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "nums"
+                  }
+                ],
+                "AdjustRet": false
+              }
+            ]
+          },
+          {
+            "Name": "i",
+            "Init": {
+              "Value": "0"
+            },
+            "Limit": {
+              "Operator": "-",
+              "Lhs": {
+                "Value": "n"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            },
+            "Step": null,
+            "Stmts": [
+              {
+                "Name": "j",
+                "Init": {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Value": "i"
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                },
+                "Limit": {
+                  "Operator": "-",
+                  "Lhs": {
+                    "Value": "n"
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                },
+                "Step": null,
+                "Stmts": [
+                  {
+                    "Condition": {
+                      "Operator": "==",
+                      "Lhs": {
+                        "Operator": "+",
+                        "Lhs": {
+                          "Object": {
+                            "Value": "nums"
+                          },
+                          "Key": {
+                            "Operator": "+",
+                            "Lhs": {
+                              "Value": "i"
+                            },
+                            "Rhs": {
+                              "Value": "1"
+                            }
+                          }
+                        },
+                        "Rhs": {
+                          "Object": {
+                            "Value": "nums"
+                          },
+                          "Key": {
+                            "Operator": "+",
+                            "Lhs": {
+                              "Value": "j"
+                            },
+                            "Rhs": {
+                              "Value": "1"
+                            }
+                          }
+                        }
+                      },
+                      "Rhs": {
+                        "Value": "target"
+                      }
+                    },
+                    "Then": [
+                      {
+                        "Exprs": [
+                          {
+                            "Fields": [
+                              {
+                                "Key": null,
+                                "Value": {
+                                  "Value": "i"
+                                }
+                              },
+                              {
+                                "Key": null,
+                                "Value": {
+                                  "Value": "j"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "Else": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Exprs": [
+              {
+                "Fields": [
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Operator": "-",
+                      "Lhs": {
+                        "Value": "0"
+                      },
+                      "Rhs": {
+                        "Value": "1"
+                      }
+                    }
+                  },
+                  {
+                    "Key": null,
+                    "Value": {
+                      "Operator": "-",
+                      "Lhs": {
+                        "Value": "0"
+                      },
+                      "Rhs": {
+                        "Value": "1"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "result"
+        }
+      ],
+      "Rhs": [
+        {
+          "Func": {
+            "Value": "twoSum"
+          },
+          "Receiver": null,
+          "Method": "",
+          "Args": [
+            {
+              "Fields": [
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "2"
+                  }
+                },
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "7"
+                  }
+                },
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "11"
+                  }
+                },
+                {
+                  "Key": null,
+                  "Value": {
+                    "Value": "15"
+                  }
+                }
+              ]
+            },
+            {
+              "Value": "9"
+            }
+          ],
+          "AdjustRet": false
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "result"
+            },
+            "Key": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "0"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Value": "result"
+            },
+            "Key": {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "1"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/typed_let.lua.json
+++ b/tests/json-ast/x/lua/typed_let.lua.json
@@ -1,0 +1,31 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "y"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "y"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/typed_var.lua.json
+++ b/tests/json-ast/x/lua/typed_var.lua.json
@@ -1,0 +1,31 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "x"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/unary_neg.lua.json
+++ b/tests/json-ast/x/lua/unary_neg.lua.json
@@ -1,0 +1,52 @@
+{
+  "stmts": [
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "-",
+            "Lhs": {
+              "Value": "0"
+            },
+            "Rhs": {
+              "Value": "3"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Operator": "+",
+            "Lhs": {
+              "Value": "5"
+            },
+            "Rhs": {
+              "Operator": "-",
+              "Lhs": {
+                "Value": "0"
+              },
+              "Rhs": {
+                "Value": "2"
+              }
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/update_stmt.lua.json
+++ b/tests/json-ast/x/lua/update_stmt.lua.json
@@ -1,0 +1,266 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "people"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Alice"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "17"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "status"
+                    },
+                    "Value": {
+                      "Value": "minor"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "25"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "status"
+                    },
+                    "Value": {
+                      "Value": "unknown"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Charlie"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "18"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "status"
+                    },
+                    "Value": {
+                      "Value": "unknown"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "Key": null,
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Diana"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "16"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "status"
+                    },
+                    "Value": {
+                      "Value": "minor"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "_i0",
+      "Init": {
+        "Value": "1"
+      },
+      "Limit": {
+        "Expr": {
+          "Value": "people"
+        }
+      },
+      "Step": null,
+      "Stmts": [
+        {
+          "Names": [
+            "item"
+          ],
+          "Exprs": [
+            {
+              "Object": {
+                "Value": "people"
+              },
+              "Key": {
+                "Value": "_i0"
+              }
+            }
+          ]
+        },
+        {
+          "Condition": {
+            "Operator": "\u003e=",
+            "Lhs": {
+              "Object": {
+                "Value": "item"
+              },
+              "Key": {
+                "Value": "age"
+              }
+            },
+            "Rhs": {
+              "Value": "18"
+            }
+          },
+          "Then": [
+            {
+              "Lhs": [
+                {
+                  "Object": {
+                    "Value": "item"
+                  },
+                  "Key": {
+                    "Value": "status"
+                  }
+                }
+              ],
+              "Rhs": [
+                {
+                  "Value": "adult"
+                }
+              ]
+            },
+            {
+              "Lhs": [
+                {
+                  "Object": {
+                    "Value": "item"
+                  },
+                  "Key": {
+                    "Value": "age"
+                  }
+                }
+              ],
+              "Rhs": [
+                {
+                  "Operator": "+",
+                  "Lhs": {
+                    "Object": {
+                      "Value": "item"
+                    },
+                    "Key": {
+                      "Value": "age"
+                    }
+                  },
+                  "Rhs": {
+                    "Value": "1"
+                  }
+                }
+              ]
+            }
+          ],
+          "Else": null
+        },
+        {
+          "Lhs": [
+            {
+              "Object": {
+                "Value": "people"
+              },
+              "Key": {
+                "Value": "_i0"
+              }
+            }
+          ],
+          "Rhs": [
+            {
+              "Value": "item"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "ok"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/user_type_literal.lua.json
+++ b/tests/json-ast/x/lua/user_type_literal.lua.json
@@ -1,0 +1,75 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "book"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "title"
+              },
+              "Value": {
+                "Value": "Go"
+              }
+            },
+            {
+              "Key": {
+                "Value": "author"
+              },
+              "Value": {
+                "Fields": [
+                  {
+                    "Key": {
+                      "Value": "name"
+                    },
+                    "Value": {
+                      "Value": "Bob"
+                    }
+                  },
+                  {
+                    "Key": {
+                      "Value": "age"
+                    },
+                    "Value": {
+                      "Value": "42"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Object": {
+              "Object": {
+                "Value": "book"
+              },
+              "Key": {
+                "Value": "author"
+              }
+            },
+            "Key": {
+              "Value": "name"
+            }
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/values_builtin.lua.json
+++ b/tests/json-ast/x/lua/values_builtin.lua.json
@@ -1,0 +1,258 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "m"
+        }
+      ],
+      "Rhs": [
+        {
+          "Fields": [
+            {
+              "Key": {
+                "Value": "a"
+              },
+              "Value": {
+                "Value": "1"
+              }
+            },
+            {
+              "Key": {
+                "Value": "b"
+              },
+              "Value": {
+                "Value": "2"
+              }
+            },
+            {
+              "Key": {
+                "Value": "c"
+              },
+              "Value": {
+                "Value": "3"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Func": {
+              "Object": {
+                "Value": "table"
+              },
+              "Key": {
+                "Value": "concat"
+              }
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Func": {
+                  "ParList": {
+                    "HasVargs": false,
+                    "Names": [
+                      "m"
+                    ]
+                  },
+                  "Stmts": [
+                    {
+                      "Names": [
+                        "keys"
+                      ],
+                      "Exprs": [
+                        {
+                          "Fields": []
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "k"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "pairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "m"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Expr": {
+                            "Func": {
+                              "Object": {
+                                "Value": "table"
+                              },
+                              "Key": {
+                                "Value": "insert"
+                              }
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "keys"
+                              },
+                              {
+                                "Value": "k"
+                              }
+                            ],
+                            "AdjustRet": false
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Expr": {
+                        "Func": {
+                          "Object": {
+                            "Value": "table"
+                          },
+                          "Key": {
+                            "Value": "sort"
+                          }
+                        },
+                        "Receiver": null,
+                        "Method": "",
+                        "Args": [
+                          {
+                            "Value": "keys"
+                          },
+                          {
+                            "ParList": {
+                              "HasVargs": false,
+                              "Names": [
+                                "a",
+                                "b"
+                              ]
+                            },
+                            "Stmts": [
+                              {
+                                "Exprs": [
+                                  {
+                                    "Operator": "\u003c",
+                                    "Lhs": {
+                                      "Value": "a"
+                                    },
+                                    "Rhs": {
+                                      "Value": "b"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        "AdjustRet": false
+                      }
+                    },
+                    {
+                      "Names": [
+                        "res"
+                      ],
+                      "Exprs": [
+                        {
+                          "Fields": []
+                        }
+                      ]
+                    },
+                    {
+                      "Names": [
+                        "_",
+                        "k"
+                      ],
+                      "Exprs": [
+                        {
+                          "Func": {
+                            "Value": "ipairs"
+                          },
+                          "Receiver": null,
+                          "Method": "",
+                          "Args": [
+                            {
+                              "Value": "keys"
+                            }
+                          ],
+                          "AdjustRet": false
+                        }
+                      ],
+                      "Stmts": [
+                        {
+                          "Expr": {
+                            "Func": {
+                              "Object": {
+                                "Value": "table"
+                              },
+                              "Key": {
+                                "Value": "insert"
+                              }
+                            },
+                            "Receiver": null,
+                            "Method": "",
+                            "Args": [
+                              {
+                                "Value": "res"
+                              },
+                              {
+                                "Object": {
+                                  "Value": "m"
+                                },
+                                "Key": {
+                                  "Value": "k"
+                                }
+                              }
+                            ],
+                            "AdjustRet": false
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Exprs": [
+                        {
+                          "Value": "res"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "Receiver": null,
+                "Method": "",
+                "Args": [
+                  {
+                    "Value": "m"
+                  }
+                ],
+                "AdjustRet": false
+              },
+              {
+                "Value": " "
+              }
+            ],
+            "AdjustRet": false
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/var_assignment.lua.json
+++ b/tests/json-ast/x/lua/var_assignment.lua.json
@@ -1,0 +1,43 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Lhs": [
+        {
+          "Value": "x"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Expr": {
+        "Func": {
+          "Value": "print"
+        },
+        "Receiver": null,
+        "Method": "",
+        "Args": [
+          {
+            "Value": "x"
+          }
+        ],
+        "AdjustRet": false
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/lua/while_loop.lua.json
+++ b/tests/json-ast/x/lua/while_loop.lua.json
@@ -1,0 +1,62 @@
+{
+  "stmts": [
+    {
+      "Lhs": [
+        {
+          "Value": "i"
+        }
+      ],
+      "Rhs": [
+        {
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Condition": {
+        "Operator": "\u003c",
+        "Lhs": {
+          "Value": "i"
+        },
+        "Rhs": {
+          "Value": "3"
+        }
+      },
+      "Stmts": [
+        {
+          "Expr": {
+            "Func": {
+              "Value": "print"
+            },
+            "Receiver": null,
+            "Method": "",
+            "Args": [
+              {
+                "Value": "i"
+              }
+            ],
+            "AdjustRet": false
+          }
+        },
+        {
+          "Lhs": [
+            {
+              "Value": "i"
+            }
+          ],
+          "Rhs": [
+            {
+              "Operator": "+",
+              "Lhs": {
+                "Value": "i"
+              },
+              "Rhs": {
+                "Value": "1"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tools/json-ast/x/lua/inspect.go
+++ b/tools/json-ast/x/lua/inspect.go
@@ -1,0 +1,117 @@
+package lua
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	luaast "github.com/yuin/gopher-lua/ast"
+	luaparse "github.com/yuin/gopher-lua/parse"
+)
+
+// Program represents a parsed Lua source file.
+type Program struct {
+	Stmts []luaast.Stmt `json:"stmts"`
+}
+
+// Inspect parses the given Lua source code and returns its AST.
+func Inspect(src string) (*Program, error) {
+	pre := preprocessLuaSource(src)
+	chunk, err := luaparse.Parse(bytes.NewReader([]byte(pre)), "src.lua")
+	if err != nil {
+		return nil, fmt.Errorf("%s", formatLuaParseError(err, src))
+	}
+	return &Program{Stmts: chunk}, nil
+}
+
+func preprocessLuaSource(src string) string {
+	var out strings.Builder
+	inStr := false
+	strDelim := byte(0)
+	inComment := false
+	for i := 0; i < len(src); i++ {
+		ch := src[i]
+		if inComment {
+			out.WriteByte(ch)
+			if ch == '\n' {
+				inComment = false
+			}
+			continue
+		}
+		if inStr {
+			out.WriteByte(ch)
+			if ch == strDelim && (i == 0 || src[i-1] != '\\') {
+				inStr = false
+			}
+			continue
+		}
+		if ch == '-' && i+1 < len(src) && src[i+1] == '-' {
+			out.WriteByte(ch)
+			inComment = true
+			continue
+		}
+		if ch == '\'' || ch == '"' {
+			inStr = true
+			strDelim = ch
+			out.WriteByte(ch)
+			continue
+		}
+		if ch == '/' && i+1 < len(src) && src[i+1] == '/' {
+			out.WriteByte('/')
+			out.WriteByte(' ')
+			i++
+			continue
+		}
+		out.WriteByte(ch)
+	}
+	res := out.String()
+	lines := strings.Split(res, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "goto __continue") || strings.HasPrefix(trimmed, "::__continue") {
+			lines[i] = "--" + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatLuaParseError(err error, src string) string {
+	msg := err.Error()
+	line := 0
+	col := 0
+	if idx := strings.Index(msg, "line:"); idx >= 0 {
+		i := idx + len("line:")
+		for i < len(msg) && msg[i] >= '0' && msg[i] <= '9' {
+			line = line*10 + int(msg[i]-'0')
+			i++
+		}
+		if strings.HasPrefix(msg[i:], "(column:") {
+			i += len("(column:")
+			for i < len(msg) && msg[i] >= '0' && msg[i] <= '9' {
+				col = col*10 + int(msg[i]-'0')
+				i++
+			}
+		}
+	}
+	lines := strings.Split(src, "\n")
+	if line <= 0 || line-1 >= len(lines) {
+		return msg
+	}
+	start := line - 2
+	if start < 0 {
+		start = 0
+	}
+	end := line
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("line %d: %s\n", line, msg))
+	for i := start; i <= end; i++ {
+		b.WriteString(fmt.Sprintf("%4d| %s\n", i+1, lines[i]))
+		if i == line-1 && col > 0 {
+			b.WriteString("     " + strings.Repeat(" ", col-1) + "^\n")
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/tools/json-ast/x/lua/inspect_test.go
+++ b/tools/json-ast/x/lua/inspect_test.go
@@ -1,0 +1,81 @@
+//go:build slow
+
+package lua_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	lua "mochi/tools/json-ast/x/lua"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func TestInspect_Golden(t *testing.T) {
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "lua")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "lua")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.lua"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".lua")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := lua.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".lua.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add new `lua` package for JSON AST inspection
- implement Lua AST inspection using gopher-lua parser
- generate golden JSON files for Lua sources

## Testing
- `go test -tags slow ./tools/json-ast/x/lua -run TestInspect_Golden`


------
https://chatgpt.com/codex/tasks/task_e_6889160f88948320a54f453bd23538a6