### PR TITLE
Add Swift AST inspector

### DIFF
--- a/tests/json-ast/x/swift/append_builtin.swift.json
+++ b/tests/json-ast/x/swift/append_builtin.swift.json
@@ -1,0 +1,51 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 103
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 103
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "a"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 105,
+          "end": 185
+        }
+      },
+      "range": {
+        "start": 105,
+        "end": 185
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/avg_builtin.swift.json
+++ b/tests/json-ast/x/swift/avg_builtin.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 151
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 151
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/basic_compare.swift.json
+++ b/tests/json-ast/x/swift/basic_compare.swift.json
@@ -1,0 +1,97 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 86
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 86
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "a"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 88,
+          "end": 102
+        }
+      },
+      "range": {
+        "start": 88,
+        "end": 102
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "b"
+        }
+      },
+      "range": {
+        "start": 92,
+        "end": 92
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 104,
+          "end": 111
+        }
+      },
+      "range": {
+        "start": 104,
+        "end": 111
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 113,
+          "end": 137
+        }
+      },
+      "range": {
+        "start": 113,
+        "end": 137
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 139,
+          "end": 162
+        }
+      },
+      "range": {
+        "start": 139,
+        "end": 162
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/bench_block.swift.json
+++ b/tests/json-ast/x/swift/bench_block.swift.json
@@ -1,0 +1,102 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 105
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 105
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "_nowSeed"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 107,
+          "end": 124
+        }
+      },
+      "range": {
+        "start": 107,
+        "end": 124
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "_nowSeeded"
+        }
+      },
+      "range": {
+        "start": 111,
+        "end": 111
+      },
+      "interface_type": "$sSbD",
+      "access": "internal"
+    },
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "_now"
+        }
+      },
+      "params": {
+        "params": null
+      },
+      "body": {
+        "range": {
+          "start": 149,
+          "end": 511
+        }
+      },
+      "range": {
+        "start": 130,
+        "end": 511
+      },
+      "result": "$sSiD",
+      "interface_type": "$sSiycD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 513,
+          "end": 888
+        }
+      },
+      "range": {
+        "start": 513,
+        "end": 888
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/binary_precedence.swift.json
+++ b/tests/json-ast/x/swift/binary_precedence.swift.json
@@ -1,0 +1,56 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 78
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 80,
+          "end": 87
+        }
+      },
+      "range": {
+        "start": 80,
+        "end": 87
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 89,
+          "end": 96
+        }
+      },
+      "range": {
+        "start": 89,
+        "end": 96
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 98,
+          "end": 105
+        }
+      },
+      "range": {
+        "start": 98,
+        "end": 105
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/bool_chain.swift.json
+++ b/tests/json-ast/x/swift/bool_chain.swift.json
@@ -1,0 +1,67 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "boom"
+        }
+      },
+      "params": {
+        "params": null
+      },
+      "body": {
+        "range": {
+          "start": 91,
+          "end": 127
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 127
+      },
+      "result": "$sSbD",
+      "interface_type": "$sSbycD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 129,
+          "end": 211
+        }
+      },
+      "range": {
+        "start": 129,
+        "end": 211
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 213,
+          "end": 294
+        }
+      },
+      "range": {
+        "start": 213,
+        "end": 294
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 296,
+          "end": 401
+        }
+      },
+      "range": {
+        "start": 296,
+        "end": 401
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/break_continue.swift.json
+++ b/tests/json-ast/x/swift/break_continue.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 111
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 111
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "numbers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 113,
+          "end": 254
+        }
+      },
+      "range": {
+        "start": 113,
+        "end": 254
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/cast_string_to_int.swift.json
+++ b/tests/json-ast/x/swift/cast_string_to_int.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 81
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 81
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/cast_struct.swift.json
+++ b/tests/json-ast/x/swift/cast_struct.swift.json
@@ -1,0 +1,114 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "struct_decl",
+      "name": {
+        "base_name": {
+          "name": "Todo"
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 126
+      },
+      "interface_type": "$s4main4TodoVmD",
+      "access": "internal",
+      "members": [
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 108,
+            "end": 119
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "title"
+            }
+          },
+          "range": {
+            "start": 112,
+            "end": 112
+          },
+          "interface_type": "$sSSD",
+          "access": "internal"
+        },
+        {
+          "_kind": "constructor_decl",
+          "name": {
+            "base_name": {
+              "name": ""
+            }
+          },
+          "params": {
+            "params": [
+              {
+                "name": {
+                  "base_name": {
+                    "name": "title"
+                  }
+                },
+                "interface_type": "$sSSD"
+              }
+            ]
+          },
+          "range": {
+            "start": 97,
+            "end": 97
+          },
+          "interface_type": "$sy4main4TodoVSS_tcACmcD",
+          "access": "internal"
+        }
+      ]
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 128,
+          "end": 155
+        }
+      },
+      "range": {
+        "start": 128,
+        "end": 155
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "todo"
+        }
+      },
+      "range": {
+        "start": 132,
+        "end": 132
+      },
+      "interface_type": "$s4main4TodoVD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 157,
+          "end": 173
+        }
+      },
+      "range": {
+        "start": 157,
+        "end": 173
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/count_builtin.swift.json
+++ b/tests/json-ast/x/swift/count_builtin.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 106
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 106
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/cross_join.swift.json
+++ b/tests/json-ast/x/swift/cross_join.swift.json
@@ -1,0 +1,111 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 170
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 170
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "customers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 172,
+          "end": 316
+        }
+      },
+      "range": {
+        "start": 172,
+        "end": 316
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "orders"
+        }
+      },
+      "range": {
+        "start": 176,
+        "end": 176
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 318,
+          "end": 602
+        }
+      },
+      "range": {
+        "start": 318,
+        "end": 602
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "result"
+        }
+      },
+      "range": {
+        "start": 322,
+        "end": 322
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 604,
+          "end": 656
+        }
+      },
+      "range": {
+        "start": 604,
+        "end": 656
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 658,
+          "end": 844
+        }
+      },
+      "range": {
+        "start": 658,
+        "end": 844
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/cross_join_filter.swift.json
+++ b/tests/json-ast/x/swift/cross_join_filter.swift.json
@@ -1,0 +1,111 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 90
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 90
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "nums"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 92,
+          "end": 115
+        }
+      },
+      "range": {
+        "start": 92,
+        "end": 115
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "letters"
+        }
+      },
+      "range": {
+        "start": 96,
+        "end": 96
+      },
+      "interface_type": "$sSSXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 117,
+          "end": 338
+        }
+      },
+      "range": {
+        "start": 117,
+        "end": 338
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "pairs"
+        }
+      },
+      "range": {
+        "start": 121,
+        "end": 121
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 340,
+          "end": 366
+        }
+      },
+      "range": {
+        "start": 340,
+        "end": 366
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 368,
+          "end": 413
+        }
+      },
+      "range": {
+        "start": 368,
+        "end": 413
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/cross_join_triple.swift.json
+++ b/tests/json-ast/x/swift/cross_join_triple.swift.json
@@ -1,0 +1,138 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 87
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 87
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "nums"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 89,
+          "end": 112
+        }
+      },
+      "range": {
+        "start": 89,
+        "end": 112
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "letters"
+        }
+      },
+      "range": {
+        "start": 93,
+        "end": 93
+      },
+      "interface_type": "$sSSXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 114,
+          "end": 138
+        }
+      },
+      "range": {
+        "start": 114,
+        "end": 138
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "bools"
+        }
+      },
+      "range": {
+        "start": 118,
+        "end": 118
+      },
+      "interface_type": "$sSbXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 140,
+          "end": 368
+        }
+      },
+      "range": {
+        "start": 140,
+        "end": 368
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "combos"
+        }
+      },
+      "range": {
+        "start": 144,
+        "end": 144
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 370,
+          "end": 411
+        }
+      },
+      "range": {
+        "start": 370,
+        "end": 411
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 413,
+          "end": 468
+        }
+      },
+      "range": {
+        "start": 413,
+        "end": 468
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/dataset_sort_take_limit.swift.json
+++ b/tests/json-ast/x/swift/dataset_sort_take_limit.swift.json
@@ -1,0 +1,91 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 352
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 352
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "products"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 354,
+          "end": 719
+        }
+      },
+      "range": {
+        "start": 354,
+        "end": 719
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "expensive"
+        }
+      },
+      "range": {
+        "start": 358,
+        "end": 358
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 721,
+          "end": 776
+        }
+      },
+      "range": {
+        "start": 721,
+        "end": 776
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 778,
+          "end": 894
+        }
+      },
+      "range": {
+        "start": 778,
+        "end": 894
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/for_list_collection.swift.json
+++ b/tests/json-ast/x/swift/for_list_collection.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 105
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 105
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/for_loop.swift.json
+++ b/tests/json-ast/x/swift/for_loop.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 101
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 101
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/for_map_collection.swift.json
+++ b/tests/json-ast/x/swift/for_map_collection.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 94
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 94
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSSiXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 96,
+          "end": 136
+        }
+      },
+      "range": {
+        "start": 96,
+        "end": 136
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/fun_call.swift.json
+++ b/tests/json-ast/x/swift/fun_call.swift.json
@@ -1,0 +1,58 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "add"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "a"
+              }
+            },
+            "interface_type": "$sSiD"
+          },
+          {
+            "name": {
+              "base_name": {
+                "name": "b"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 107,
+          "end": 128
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 128
+      },
+      "result": "$sSiD",
+      "interface_type": "$syS2i_SitcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 130,
+          "end": 155
+        }
+      },
+      "range": {
+        "start": 130,
+        "end": 155
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/fun_expr_in_let.swift.json
+++ b/tests/json-ast/x/swift/fun_expr_in_let.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 113
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 113
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "square"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$syS2icD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 115,
+          "end": 140
+        }
+      },
+      "range": {
+        "start": 115,
+        "end": 140
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/fun_three_args.swift.json
+++ b/tests/json-ast/x/swift/fun_three_args.swift.json
@@ -1,0 +1,66 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "sum3"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "a"
+              }
+            },
+            "interface_type": "$sSiD"
+          },
+          {
+            "name": {
+              "base_name": {
+                "name": "b"
+              }
+            },
+            "interface_type": "$sSiD"
+          },
+          {
+            "name": {
+              "base_name": {
+                "name": "c"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 118,
+          "end": 145
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 145
+      },
+      "result": "$sSiD",
+      "interface_type": "$syS2i_S2itcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 147,
+          "end": 176
+        }
+      },
+      "range": {
+        "start": 147,
+        "end": 176
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/go_auto.swift.json
+++ b/tests/json-ast/x/swift/go_auto.swift.json
@@ -1,0 +1,172 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "struct_decl",
+      "name": {
+        "base_name": {
+          "name": "testpkg"
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 223
+      },
+      "interface_type": "$s4main7testpkgVmD",
+      "access": "internal",
+      "members": [
+        {
+          "_kind": "func_decl",
+          "name": {
+            "base_name": {
+              "name": "Add"
+            }
+          },
+          "params": {
+            "params": [
+              {
+                "name": {
+                  "base_name": {
+                    "name": "a"
+                  }
+                },
+                "interface_type": "$sSiD"
+              },
+              {
+                "name": {
+                  "base_name": {
+                    "name": "b"
+                  }
+                },
+                "interface_type": "$sSiD"
+              }
+            ]
+          },
+          "body": {
+            "range": {
+              "start": 154,
+              "end": 169
+            }
+          },
+          "range": {
+            "start": 111,
+            "end": 169
+          },
+          "result": "$sSiD",
+          "interface_type": "$syS2i_Sitc4main7testpkgVmcD",
+          "access": "internal"
+        },
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 175,
+            "end": 191
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "Pi"
+            }
+          },
+          "range": {
+            "start": 186,
+            "end": 186
+          },
+          "interface_type": "$sSdD",
+          "access": "internal"
+        },
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 200,
+            "end": 220
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "Answer"
+            }
+          },
+          "range": {
+            "start": 211,
+            "end": 211
+          },
+          "interface_type": "$sSiD",
+          "access": "internal"
+        },
+        {
+          "_kind": "constructor_decl",
+          "name": {
+            "base_name": {
+              "name": ""
+            }
+          },
+          "params": {
+            "params": null
+          },
+          "body": {
+            "range": {
+              "start": 97,
+              "end": 97
+            }
+          },
+          "range": {
+            "start": 97,
+            "end": 97
+          },
+          "interface_type": "$sy4main7testpkgVycACmcD",
+          "access": "internal"
+        }
+      ]
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 225,
+          "end": 248
+        }
+      },
+      "range": {
+        "start": 225,
+        "end": 248
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 250,
+          "end": 266
+        }
+      },
+      "range": {
+        "start": 250,
+        "end": 266
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 268,
+          "end": 288
+        }
+      },
+      "range": {
+        "start": 268,
+        "end": 288
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/group_by_join.swift.json
+++ b/tests/json-ast/x/swift/group_by_join.swift.json
@@ -1,0 +1,111 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 140
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 140
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "customers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 142,
+          "end": 244
+        }
+      },
+      "range": {
+        "start": 142,
+        "end": 244
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "orders"
+        }
+      },
+      "range": {
+        "start": 146,
+        "end": 146
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 246,
+          "end": 1056
+        }
+      },
+      "range": {
+        "start": 246,
+        "end": 1056
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "stats"
+        }
+      },
+      "range": {
+        "start": 250,
+        "end": 250
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 1058,
+          "end": 1093
+        }
+      },
+      "range": {
+        "start": 1058,
+        "end": 1093
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 1095,
+          "end": 1158
+        }
+      },
+      "range": {
+        "start": 1095,
+        "end": 1158
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/group_by_multi_sort.swift.json
+++ b/tests/json-ast/x/swift/group_by_multi_sort.swift.json
@@ -1,0 +1,78 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 233
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 233
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "items"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sypXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 235,
+          "end": 1638
+        }
+      },
+      "range": {
+        "start": 235,
+        "end": 1638
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "grouped"
+        }
+      },
+      "range": {
+        "start": 239,
+        "end": 239
+      },
+      "interface_type": "$sypXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 1640,
+          "end": 1740
+        }
+      },
+      "range": {
+        "start": 1640,
+        "end": 1740
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/if_else.swift.json
+++ b/tests/json-ast/x/swift/if_else.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 149
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 149
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/if_then_else.swift.json
+++ b/tests/json-ast/x/swift/if_then_else.swift.json
@@ -1,0 +1,71 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 82,
+          "end": 139
+        }
+      },
+      "range": {
+        "start": 82,
+        "end": 139
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "msg"
+        }
+      },
+      "range": {
+        "start": 86,
+        "end": 86
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 141,
+          "end": 163
+        }
+      },
+      "range": {
+        "start": 141,
+        "end": 163
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/if_then_else_nested.swift.json
+++ b/tests/json-ast/x/swift/if_then_else_nested.swift.json
@@ -1,0 +1,71 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 174
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 174
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "msg"
+        }
+      },
+      "range": {
+        "start": 85,
+        "end": 85
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 176,
+          "end": 198
+        }
+      },
+      "range": {
+        "start": 176,
+        "end": 198
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/in_operator.swift.json
+++ b/tests/json-ast/x/swift/in_operator.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 88
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 88
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "xs"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 112
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 112
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 114,
+          "end": 150
+        }
+      },
+      "range": {
+        "start": 114,
+        "end": 150
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/in_operator_extended.swift.json
+++ b/tests/json-ast/x/swift/in_operator_extended.swift.json
@@ -1,0 +1,190 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 88
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 88
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "xs"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 227
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 227
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "ys"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 229,
+          "end": 251
+        }
+      },
+      "range": {
+        "start": 229,
+        "end": 251
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 253,
+          "end": 275
+        }
+      },
+      "range": {
+        "start": 253,
+        "end": 275
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 277,
+          "end": 292
+        }
+      },
+      "range": {
+        "start": 277,
+        "end": 292
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 281,
+        "end": 281
+      },
+      "interface_type": "$sSSSiXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 294,
+          "end": 315
+        }
+      },
+      "range": {
+        "start": 294,
+        "end": 315
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 317,
+          "end": 338
+        }
+      },
+      "range": {
+        "start": 317,
+        "end": 338
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 340,
+          "end": 348
+        }
+      },
+      "range": {
+        "start": 340,
+        "end": 348
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "s"
+        }
+      },
+      "range": {
+        "start": 344,
+        "end": 344
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 356,
+          "end": 394
+        }
+      },
+      "range": {
+        "start": 356,
+        "end": 394
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 396,
+          "end": 434
+        }
+      },
+      "range": {
+        "start": 396,
+        "end": 434
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/inner_join.swift.json
+++ b/tests/json-ast/x/swift/inner_join.swift.json
@@ -1,0 +1,111 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 170
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 170
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "customers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 172,
+          "end": 359
+        }
+      },
+      "range": {
+        "start": 172,
+        "end": 359
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "orders"
+        }
+      },
+      "range": {
+        "start": 176,
+        "end": 176
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 361,
+          "end": 665
+        }
+      },
+      "range": {
+        "start": 361,
+        "end": 665
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "result"
+        }
+      },
+      "range": {
+        "start": 365,
+        "end": 365
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 667,
+          "end": 708
+        }
+      },
+      "range": {
+        "start": 667,
+        "end": 708
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 710,
+          "end": 824
+        }
+      },
+      "range": {
+        "start": 710,
+        "end": 824
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/join_multi.swift.json
+++ b/tests/json-ast/x/swift/join_multi.swift.json
@@ -1,0 +1,138 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 140
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 140
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "customers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 142,
+          "end": 214
+        }
+      },
+      "range": {
+        "start": 142,
+        "end": 214
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "orders"
+        }
+      },
+      "range": {
+        "start": 146,
+        "end": 146
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 216,
+          "end": 287
+        }
+      },
+      "range": {
+        "start": 216,
+        "end": 287
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "items"
+        }
+      },
+      "range": {
+        "start": 220,
+        "end": 220
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 289,
+          "end": 678
+        }
+      },
+      "range": {
+        "start": 289,
+        "end": 678
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "result"
+        }
+      },
+      "range": {
+        "start": 293,
+        "end": 293
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 680,
+          "end": 706
+        }
+      },
+      "range": {
+        "start": 680,
+        "end": 706
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 708,
+          "end": 774
+        }
+      },
+      "range": {
+        "start": 708,
+        "end": 774
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/left_join.swift.json
+++ b/tests/json-ast/x/swift/left_join.swift.json
@@ -1,0 +1,111 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 140
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 140
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "customers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 142,
+          "end": 241
+        }
+      },
+      "range": {
+        "start": 142,
+        "end": 241
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "orders"
+        }
+      },
+      "range": {
+        "start": 146,
+        "end": 146
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 243,
+          "end": 735
+        }
+      },
+      "range": {
+        "start": 243,
+        "end": 735
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "result"
+        }
+      },
+      "range": {
+        "start": 247,
+        "end": 247
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 737,
+          "end": 762
+        }
+      },
+      "range": {
+        "start": 737,
+        "end": 762
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 764,
+          "end": 882
+        }
+      },
+      "range": {
+        "start": 764,
+        "end": 882
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/left_join_multi.swift.json
+++ b/tests/json-ast/x/swift/left_join_multi.swift.json
@@ -1,0 +1,138 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 140
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 140
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "customers"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 142,
+          "end": 214
+        }
+      },
+      "range": {
+        "start": 142,
+        "end": 214
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "orders"
+        }
+      },
+      "range": {
+        "start": 146,
+        "end": 146
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 216,
+          "end": 257
+        }
+      },
+      "range": {
+        "start": 216,
+        "end": 257
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "items"
+        }
+      },
+      "range": {
+        "start": 220,
+        "end": 220
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 259,
+          "end": 672
+        }
+      },
+      "range": {
+        "start": 259,
+        "end": 672
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "result"
+        }
+      },
+      "range": {
+        "start": 263,
+        "end": 263
+      },
+      "interface_type": "$sSSypXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 674,
+          "end": 705
+        }
+      },
+      "range": {
+        "start": 674,
+        "end": 705
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 707,
+          "end": 774
+        }
+      },
+      "range": {
+        "start": 707,
+        "end": 774
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/len_builtin.swift.json
+++ b/tests/json-ast/x/swift/len_builtin.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 78
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/len_map.swift.json
+++ b/tests/json-ast/x/swift/len_map.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 78
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/len_string.swift.json
+++ b/tests/json-ast/x/swift/len_string.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 78
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/let_and_print.swift.json
+++ b/tests/json-ast/x/swift/let_and_print.swift.json
@@ -1,0 +1,71 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "a"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 82,
+          "end": 90
+        }
+      },
+      "range": {
+        "start": 82,
+        "end": 90
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "b"
+        }
+      },
+      "range": {
+        "start": 86,
+        "end": 86
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 93,
+          "end": 126
+        }
+      },
+      "range": {
+        "start": 93,
+        "end": 126
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/list_assign.swift.json
+++ b/tests/json-ast/x/swift/list_assign.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 87
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 87
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "nums"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 89,
+          "end": 99
+        }
+      },
+      "range": {
+        "start": 89,
+        "end": 99
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 101,
+          "end": 124
+        }
+      },
+      "range": {
+        "start": 101,
+        "end": 124
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/list_index.swift.json
+++ b/tests/json-ast/x/swift/list_index.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 91
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 91
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "xs"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 93,
+          "end": 114
+        }
+      },
+      "range": {
+        "start": 93,
+        "end": 114
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/list_nested_assign.swift.json
+++ b/tests/json-ast/x/swift/list_nested_assign.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 99
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 99
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "matrix"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 101,
+          "end": 116
+        }
+      },
+      "range": {
+        "start": 101,
+        "end": 116
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 118,
+          "end": 146
+        }
+      },
+      "range": {
+        "start": 118,
+        "end": 146
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/map_assign.swift.json
+++ b/tests/json-ast/x/swift/map_assign.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 95
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 95
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "scores"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSSiXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 97,
+          "end": 113
+        }
+      },
+      "range": {
+        "start": 97,
+        "end": 113
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 115,
+          "end": 145
+        }
+      },
+      "range": {
+        "start": 115,
+        "end": 145
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/map_in_operator.swift.json
+++ b/tests/json-ast/x/swift/map_in_operator.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 94
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 94
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiSSXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 96,
+          "end": 115
+        }
+      },
+      "range": {
+        "start": 96,
+        "end": 115
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 117,
+          "end": 136
+        }
+      },
+      "range": {
+        "start": 117,
+        "end": 136
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/map_index.swift.json
+++ b/tests/json-ast/x/swift/map_index.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 94
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 94
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSSiXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 96,
+          "end": 119
+        }
+      },
+      "range": {
+        "start": 96,
+        "end": 119
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/map_int_key.swift.json
+++ b/tests/json-ast/x/swift/map_int_key.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 94
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 94
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiSSXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 96,
+          "end": 120
+        }
+      },
+      "range": {
+        "start": 96,
+        "end": 120
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/map_literal_dynamic.swift.json
+++ b/tests/json-ast/x/swift/map_literal_dynamic.swift.json
@@ -1,0 +1,98 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 89
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 89
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "y"
+        }
+      },
+      "range": {
+        "start": 85,
+        "end": 85
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 91,
+          "end": 134
+        }
+      },
+      "range": {
+        "start": 91,
+        "end": 134
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 95,
+        "end": 95
+      },
+      "interface_type": "$sSSSiXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 136,
+          "end": 178
+        }
+      },
+      "range": {
+        "start": 136,
+        "end": 178
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/map_membership.swift.json
+++ b/tests/json-ast/x/swift/map_membership.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 94
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 94
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "m"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSSiXSDD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 96,
+          "end": 117
+        }
+      },
+      "range": {
+        "start": 96,
+        "end": 117
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 119,
+          "end": 140
+        }
+      },
+      "range": {
+        "start": 119,
+        "end": 140
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/match_expr.swift.json
+++ b/tests/json-ast/x/swift/match_expr.swift.json
@@ -1,0 +1,71 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 209
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 209
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "label"
+        }
+      },
+      "range": {
+        "start": 85,
+        "end": 85
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 211,
+          "end": 235
+        }
+      },
+      "range": {
+        "start": 211,
+        "end": 235
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/match_full.swift.json
+++ b/tests/json-ast/x/swift/match_full.swift.json
@@ -1,0 +1,264 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 209
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 209
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "label"
+        }
+      },
+      "range": {
+        "start": 85,
+        "end": 85
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 211,
+          "end": 235
+        }
+      },
+      "range": {
+        "start": 211,
+        "end": 235
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 237,
+          "end": 247
+        }
+      },
+      "range": {
+        "start": 237,
+        "end": 247
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "day"
+        }
+      },
+      "range": {
+        "start": 241,
+        "end": 241
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 253,
+          "end": 414
+        }
+      },
+      "range": {
+        "start": 253,
+        "end": 414
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "mood"
+        }
+      },
+      "range": {
+        "start": 257,
+        "end": 257
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 416,
+          "end": 439
+        }
+      },
+      "range": {
+        "start": 416,
+        "end": 439
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 441,
+          "end": 450
+        }
+      },
+      "range": {
+        "start": 441,
+        "end": 450
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "ok"
+        }
+      },
+      "range": {
+        "start": 445,
+        "end": 445
+      },
+      "interface_type": "$sSbD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 455,
+          "end": 565
+        }
+      },
+      "range": {
+        "start": 455,
+        "end": 565
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "status"
+        }
+      },
+      "range": {
+        "start": 459,
+        "end": 459
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 567,
+          "end": 592
+        }
+      },
+      "range": {
+        "start": 567,
+        "end": 592
+      }
+    },
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "classify"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "n"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 628,
+          "end": 704
+        }
+      },
+      "range": {
+        "start": 594,
+        "end": 704
+      },
+      "result": "$sSSD",
+      "interface_type": "$sySSSicD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 706,
+          "end": 736
+        }
+      },
+      "range": {
+        "start": 706,
+        "end": 736
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 738,
+          "end": 768
+        }
+      },
+      "range": {
+        "start": 738,
+        "end": 768
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/math_ops.swift.json
+++ b/tests/json-ast/x/swift/math_ops.swift.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 88
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 88
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 97
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 97
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/membership.swift.json
+++ b/tests/json-ast/x/swift/membership.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 90
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 90
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "nums"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 92,
+          "end": 116
+        }
+      },
+      "range": {
+        "start": 92,
+        "end": 116
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 118,
+          "end": 142
+        }
+      },
+      "range": {
+        "start": 118,
+        "end": 142
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/min_max_builtin.swift.json
+++ b/tests/json-ast/x/swift/min_max_builtin.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 90
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 90
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "nums"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 92,
+          "end": 121
+        }
+      },
+      "range": {
+        "start": 92,
+        "end": 121
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 123,
+          "end": 152
+        }
+      },
+      "range": {
+        "start": 123,
+        "end": 152
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/nested_function.swift.json
+++ b/tests/json-ast/x/swift/nested_function.swift.json
@@ -1,0 +1,50 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "outer"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "x"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 99,
+          "end": 184
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 184
+      },
+      "result": "$sSiD",
+      "interface_type": "$syS2icD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 186,
+          "end": 210
+        }
+      },
+      "range": {
+        "start": 186,
+        "end": 210
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/order_by_map.swift.json
+++ b/tests/json-ast/x/swift/order_by_map.swift.json
@@ -1,0 +1,78 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 154
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 154
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "data"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 156,
+          "end": 501
+        }
+      },
+      "range": {
+        "start": 156,
+        "end": 501
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "sorted"
+        }
+      },
+      "range": {
+        "start": 160,
+        "end": 160
+      },
+      "interface_type": "$sSSSiXSDXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 503,
+          "end": 535
+        }
+      },
+      "range": {
+        "start": 503,
+        "end": 535
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/print_hello.swift.json
+++ b/tests/json-ast/x/swift/print_hello.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 84
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 84
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/pure_fold.swift.json
+++ b/tests/json-ast/x/swift/pure_fold.swift.json
@@ -1,0 +1,50 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "triple"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "x"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 100,
+          "end": 121
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 121
+      },
+      "result": "$sSiD",
+      "interface_type": "$syS2icD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 123,
+          "end": 154
+        }
+      },
+      "range": {
+        "start": 123,
+        "end": 154
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/pure_global_fold.swift.json
+++ b/tests/json-ast/x/swift/pure_global_fold.swift.json
@@ -1,0 +1,77 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "k"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "inc"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "x"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 107,
+          "end": 138
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 138
+      },
+      "result": "$sSiD",
+      "interface_type": "$syS2icD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 140,
+          "end": 162
+        }
+      },
+      "range": {
+        "start": 140,
+        "end": 162
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/record_assign.swift.json
+++ b/tests/json-ast/x/swift/record_assign.swift.json
@@ -1,0 +1,160 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "struct_decl",
+      "name": {
+        "base_name": {
+          "name": "Counter"
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 122
+      },
+      "interface_type": "$s4main7CounterVmD",
+      "access": "internal",
+      "members": [
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 111,
+            "end": 118
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "n"
+            }
+          },
+          "range": {
+            "start": 115,
+            "end": 115
+          },
+          "interface_type": "$sSiD",
+          "access": "internal"
+        },
+        {
+          "_kind": "constructor_decl",
+          "name": {
+            "base_name": {
+              "name": ""
+            }
+          },
+          "params": {
+            "params": [
+              {
+                "name": {
+                  "base_name": {
+                    "name": "n"
+                  }
+                },
+                "interface_type": "$sSiD"
+              }
+            ]
+          },
+          "range": {
+            "start": 97,
+            "end": 97
+          },
+          "interface_type": "$sy4main7CounterVSi_tcACmcD",
+          "access": "internal"
+        }
+      ]
+    },
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "inc"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "c"
+              }
+            },
+            "interface_type": "$s4main7CounterVD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 147,
+          "end": 183
+        }
+      },
+      "range": {
+        "start": 124,
+        "end": 183
+      },
+      "result": "$sytD",
+      "interface_type": "$syy4main7CounterVcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 185,
+          "end": 205
+        }
+      },
+      "range": {
+        "start": 185,
+        "end": 205
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "c"
+        }
+      },
+      "range": {
+        "start": 189,
+        "end": 189
+      },
+      "interface_type": "$s4main7CounterVD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 207,
+          "end": 212
+        }
+      },
+      "range": {
+        "start": 207,
+        "end": 212
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 214,
+          "end": 223
+        }
+      },
+      "range": {
+        "start": 214,
+        "end": 223
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/save_jsonl_stdout.swift.json
+++ b/tests/json-ast/x/swift/save_jsonl_stdout.swift.json
@@ -1,0 +1,84 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "toJsonObj"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "v"
+              }
+            },
+            "interface_type": "$sypD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 122,
+          "end": 354
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 354
+      },
+      "result": "$sypD",
+      "interface_type": "$syypypcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 356,
+          "end": 438
+        }
+      },
+      "range": {
+        "start": 356,
+        "end": 438
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "people"
+        }
+      },
+      "range": {
+        "start": 360,
+        "end": 360
+      },
+      "interface_type": "$sypXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 440,
+          "end": 642
+        }
+      },
+      "range": {
+        "start": 440,
+        "end": 642
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/short_circuit.swift.json
+++ b/tests/json-ast/x/swift/short_circuit.swift.json
@@ -1,0 +1,71 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "boom"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "a"
+              }
+            },
+            "interface_type": "$sSiD"
+          },
+          {
+            "name": {
+              "base_name": {
+                "name": "b"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 109,
+          "end": 145
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 145
+      },
+      "result": "$sSbD",
+      "interface_type": "$sySbSi_SitcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 147,
+          "end": 195
+        }
+      },
+      "range": {
+        "start": 147,
+        "end": 195
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 197,
+          "end": 244
+        }
+      },
+      "range": {
+        "start": 197,
+        "end": 244
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/str_builtin.swift.json
+++ b/tests/json-ast/x/swift/str_builtin.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 101
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 101
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/string_compare.swift.json
+++ b/tests/json-ast/x/swift/string_compare.swift.json
@@ -1,0 +1,56 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 78
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 80,
+          "end": 87
+        }
+      },
+      "range": {
+        "start": 80,
+        "end": 87
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 89,
+          "end": 96
+        }
+      },
+      "range": {
+        "start": 89,
+        "end": 96
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 98,
+          "end": 105
+        }
+      },
+      "range": {
+        "start": 98,
+        "end": 105
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/string_concat.swift.json
+++ b/tests/json-ast/x/swift/string_concat.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 90
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 90
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/string_contains.swift.json
+++ b/tests/json-ast/x/swift/string_contains.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "s"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 87,
+          "end": 112
+        }
+      },
+      "range": {
+        "start": 87,
+        "end": 112
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 114,
+          "end": 139
+        }
+      },
+      "range": {
+        "start": 114,
+        "end": 139
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/string_in_operator.swift.json
+++ b/tests/json-ast/x/swift/string_in_operator.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "s"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 87,
+          "end": 125
+        }
+      },
+      "range": {
+        "start": 87,
+        "end": 125
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 127,
+          "end": 165
+        }
+      },
+      "range": {
+        "start": 127,
+        "end": 165
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/string_index.swift.json
+++ b/tests/json-ast/x/swift/string_index.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "s"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 87,
+          "end": 125
+        }
+      },
+      "range": {
+        "start": 87,
+        "end": 125
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/string_prefix_slice.swift.json
+++ b/tests/json-ast/x/swift/string_prefix_slice.swift.json
@@ -1,0 +1,111 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 84
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 84
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "prefix"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 91,
+          "end": 100
+        }
+      },
+      "range": {
+        "start": 91,
+        "end": 100
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "s1"
+        }
+      },
+      "range": {
+        "start": 95,
+        "end": 95
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 109,
+          "end": 225
+        }
+      },
+      "range": {
+        "start": 109,
+        "end": 225
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 227,
+          "end": 236
+        }
+      },
+      "range": {
+        "start": 227,
+        "end": 236
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "s2"
+        }
+      },
+      "range": {
+        "start": 231,
+        "end": 231
+      },
+      "interface_type": "$sSSD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 245,
+          "end": 361
+        }
+      },
+      "range": {
+        "start": 245,
+        "end": 361
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/substring_builtin.swift.json
+++ b/tests/json-ast/x/swift/substring_builtin.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 119
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 119
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/sum_builtin.swift.json
+++ b/tests/json-ast/x/swift/sum_builtin.swift.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 110
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 110
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/tail_recursion.swift.json
+++ b/tests/json-ast/x/swift/tail_recursion.swift.json
@@ -1,0 +1,58 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "sum_rec"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "n"
+              }
+            },
+            "interface_type": "$sSiD"
+          },
+          {
+            "name": {
+              "base_name": {
+                "name": "acc"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 113,
+          "end": 217
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 217
+      },
+      "result": "$sSiD",
+      "interface_type": "$syS2i_SitcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 219,
+          "end": 249
+        }
+      },
+      "range": {
+        "start": 219,
+        "end": 249
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/test_block.swift.json
+++ b/tests/json-ast/x/swift/test_block.swift.json
@@ -1,0 +1,64 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 90,
+          "end": 104
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 104
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 94,
+        "end": 94
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 106,
+          "end": 131
+        }
+      },
+      "range": {
+        "start": 106,
+        "end": 131
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 133,
+          "end": 143
+        }
+      },
+      "range": {
+        "start": 133,
+        "end": 143
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/two-sum.swift.json
+++ b/tests/json-ast/x/swift/two-sum.swift.json
@@ -1,0 +1,98 @@
+{
+  "items": [
+    {
+      "_kind": "func_decl",
+      "name": {
+        "base_name": {
+          "name": "twoSum"
+        }
+      },
+      "params": {
+        "params": [
+          {
+            "name": {
+              "base_name": {
+                "name": "nums"
+              }
+            },
+            "interface_type": "$sSiXSaD"
+          },
+          {
+            "name": {
+              "base_name": {
+                "name": "target"
+              }
+            },
+            "interface_type": "$sSiD"
+          }
+        ]
+      },
+      "body": {
+        "range": {
+          "start": 122,
+          "end": 342
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 342
+      },
+      "result": "$sSiXSaD",
+      "interface_type": "$sySiXSaSiXSa_SitcD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 344,
+          "end": 381
+        }
+      },
+      "range": {
+        "start": 344,
+        "end": 381
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "result"
+        }
+      },
+      "range": {
+        "start": 348,
+        "end": 348
+      },
+      "interface_type": "$sSiXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 383,
+          "end": 408
+        }
+      },
+      "range": {
+        "start": 383,
+        "end": 408
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 410,
+          "end": 435
+        }
+      },
+      "range": {
+        "start": 410,
+        "end": 435
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/typed_let.swift.json
+++ b/tests/json-ast/x/swift/typed_let.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "y"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 98
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 98
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/typed_var.swift.json
+++ b/tests/json-ast/x/swift/typed_var.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 98
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 98
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/unary_neg.swift.json
+++ b/tests/json-ast/x/swift/unary_neg.swift.json
@@ -1,0 +1,30 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 88
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 88
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/update_stmt.swift.json
+++ b/tests/json-ast/x/swift/update_stmt.swift.json
@@ -1,0 +1,198 @@
+{
+  "items": [
+    {
+      "_kind": "import_decl",
+      "range": {
+        "start": 71,
+        "end": 78
+      }
+    },
+    {
+      "_kind": "struct_decl",
+      "name": {
+        "base_name": {
+          "name": "Person"
+        }
+      },
+      "range": {
+        "start": 90,
+        "end": 167
+      },
+      "interface_type": "$s4main6PersonVmD",
+      "access": "internal",
+      "members": [
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 110,
+            "end": 120
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "name"
+            }
+          },
+          "range": {
+            "start": 114,
+            "end": 114
+          },
+          "interface_type": "$sSSD",
+          "access": "internal"
+        },
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 131,
+            "end": 140
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "age"
+            }
+          },
+          "range": {
+            "start": 135,
+            "end": 135
+          },
+          "interface_type": "$sSiD",
+          "access": "internal"
+        },
+        {
+          "_kind": "pattern_binding_decl",
+          "range": {
+            "start": 148,
+            "end": 160
+          }
+        },
+        {
+          "_kind": "var_decl",
+          "name": {
+            "base_name": {
+              "name": "status"
+            }
+          },
+          "range": {
+            "start": 152,
+            "end": 152
+          },
+          "interface_type": "$sSSD",
+          "access": "internal"
+        },
+        {
+          "_kind": "constructor_decl",
+          "name": {
+            "base_name": {
+              "name": ""
+            }
+          },
+          "params": {
+            "params": [
+              {
+                "name": {
+                  "base_name": {
+                    "name": "name"
+                  }
+                },
+                "interface_type": "$sSSD"
+              },
+              {
+                "name": {
+                  "base_name": {
+                    "name": "age"
+                  }
+                },
+                "interface_type": "$sSiD"
+              },
+              {
+                "name": {
+                  "base_name": {
+                    "name": "status"
+                  }
+                },
+                "interface_type": "$sSSD"
+              }
+            ]
+          },
+          "range": {
+            "start": 97,
+            "end": 97
+          },
+          "interface_type": "$sy4main6PersonVSS_SiSStcACmcD",
+          "access": "internal"
+        }
+      ]
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 169,
+          "end": 396
+        }
+      },
+      "range": {
+        "start": 169,
+        "end": 396
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "people"
+        }
+      },
+      "range": {
+        "start": 173,
+        "end": 173
+      },
+      "interface_type": "$s4main6PersonVXSaD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 398,
+          "end": 655
+        }
+      },
+      "range": {
+        "start": 398,
+        "end": 655
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 657,
+          "end": 943
+        }
+      },
+      "range": {
+        "start": 657,
+        "end": 943
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 945,
+          "end": 955
+        }
+      },
+      "range": {
+        "start": 945,
+        "end": 955
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/var_assignment.swift.json
+++ b/tests/json-ast/x/swift/var_assignment.swift.json
@@ -1,0 +1,57 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "x"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 85
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 85
+      }
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 87,
+          "end": 104
+        }
+      },
+      "range": {
+        "start": 87,
+        "end": 104
+      }
+    }
+  ]
+}

--- a/tests/json-ast/x/swift/while_loop.swift.json
+++ b/tests/json-ast/x/swift/while_loop.swift.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 71,
+          "end": 79
+        }
+      },
+      "range": {
+        "start": 71,
+        "end": 79
+      }
+    },
+    {
+      "_kind": "var_decl",
+      "name": {
+        "base_name": {
+          "name": "i"
+        }
+      },
+      "range": {
+        "start": 75,
+        "end": 75
+      },
+      "interface_type": "$sSiD",
+      "access": "internal"
+    },
+    {
+      "_kind": "top_level_code_decl",
+      "body": {
+        "range": {
+          "start": 81,
+          "end": 156
+        }
+      },
+      "range": {
+        "start": 81,
+        "end": 156
+      }
+    }
+  ]
+}

--- a/tools/json-ast/x/swift/inspect.go
+++ b/tools/json-ast/x/swift/inspect.go
@@ -1,0 +1,133 @@
+package swift
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Program represents a parsed Swift source file as produced by
+// `swiftc -dump-ast -dump-ast-format json`.
+type Program struct {
+	Items []item `json:"items"`
+}
+
+type item struct {
+	Kind          string      `json:"_kind"`
+	Name          *declName   `json:"name,omitempty"`
+	Params        *paramList  `json:"params,omitempty"`
+	Body          *body       `json:"body,omitempty"`
+	Range         offsetRange `json:"range"`
+	Result        string      `json:"result,omitempty"`
+	InterfaceType string      `json:"interface_type,omitempty"`
+	ThrownType    string      `json:"thrown_type,omitempty"`
+	Access        string      `json:"access,omitempty"`
+	Members       []item      `json:"members,omitempty"`
+	Elements      []item      `json:"elements,omitempty"`
+}
+
+type declName struct {
+	BaseName baseName `json:"base_name"`
+}
+
+type baseName struct {
+	Name string `json:"name"`
+}
+
+type paramList struct {
+	Params []param `json:"params"`
+}
+
+type param struct {
+	Name          declName `json:"name"`
+	InterfaceType string   `json:"interface_type,omitempty"`
+}
+
+type body struct {
+	Range offsetRange `json:"range"`
+}
+
+type offsetRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+// Inspect parses Swift source code using the Swift compiler and
+// returns its AST as a Program.
+func Inspect(src string) (*Program, error) {
+	tmp, err := os.CreateTemp("", "swift-src-*.swift")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(src); err != nil {
+		tmp.Close()
+		return nil, err
+	}
+	tmp.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "swiftc", "-dump-ast", "-dump-ast-format", "json", tmp.Name())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("swiftc: %v: %s", err, out.String())
+	}
+	data := filterOutput(out.Bytes())
+	var prog Program
+	if err := json.Unmarshal(data, &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
+}
+
+func filterOutput(data []byte) []byte {
+	var filtered [][]byte
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		trim := bytes.TrimSpace(line)
+		if len(trim) == 0 {
+			continue
+		}
+		if trim[0] >= '0' && trim[0] <= '9' && bytes.Contains(trim, []byte("|")) {
+			continue
+		}
+		if bytes.HasPrefix(trim, []byte("tests/")) && bytes.Contains(trim, []byte("warning")) {
+			continue
+		}
+		filtered = append(filtered, trim)
+	}
+	data = bytes.Join(filtered, []byte("\n"))
+	start := bytes.Index(data, []byte("{\"_kind\""))
+	if start >= 0 {
+		data = data[start:]
+		depth := 0
+		inStr := false
+		for i, b := range data {
+			switch b {
+			case '"':
+				if i == 0 || data[i-1] != '\\' {
+					inStr = !inStr
+				}
+			case '{':
+				if !inStr {
+					depth++
+				}
+			case '}':
+				if !inStr {
+					depth--
+					if depth == 0 {
+						data = data[:i+1]
+						break
+					}
+				}
+			}
+		}
+	}
+	return data
+}

--- a/tools/json-ast/x/swift/inspect_test.go
+++ b/tools/json-ast/x/swift/inspect_test.go
@@ -1,0 +1,104 @@
+//go:build slow
+
+package swift_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	swift "mochi/tools/json-ast/x/swift"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureSwift(t *testing.T) string {
+	if env := os.Getenv("SWIFT"); env != "" {
+		if p, err := exec.LookPath(env); err == nil {
+			return p
+		}
+	}
+	if p, err := exec.LookPath("swiftc"); err == nil {
+		return p
+	}
+	if p, err := exec.LookPath("swift"); err == nil {
+		return p
+	}
+	t.Skip("swift not found")
+	return ""
+}
+
+func TestInspect_Golden(t *testing.T) {
+	_ = ensureSwift(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "swift")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "swift")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.swift"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".swift")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(srcDir, name+".error")); err == nil {
+				t.Logf("skip %s due to compile error", name)
+				return
+			}
+			prog, err := swift.Inspect(string(data))
+			if err != nil {
+				t.Logf("skip %s: %v", name, err)
+				return
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".swift.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add tools to inspect Swift AST using `swiftc`
- generate Swift AST JSON files for transpiler tests

## Testing
- `go test -tags=slow ./tools/json-ast/x/swift -run TestInspect -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6889168481d88320ace141e9f8ff3ab2