### PR TITLE
Add embedded Racket parser for JSON AST

### DIFF
--- a/tools/json-ast/x/rkt/inspect.go
+++ b/tools/json-ast/x/rkt/inspect.go
@@ -3,20 +3,69 @@
 package rkt
 
 import (
-	rktparse "mochi/tools/a2mochi/x/rkt"
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 )
+
+//go:embed parse.rkt
+var racketParser string
+
+// Form represents a top-level form parsed from Racket source.
+type Form struct {
+	Datum any `json:"datum"`
+	Line  int `json:"line"`
+	Col   int `json:"col"`
+}
 
 // Program represents a parsed Racket source file.
 type Program struct {
-	Forms []rktparse.Form `json:"forms"`
+	Forms []Form `json:"forms"`
 }
 
 // Inspect parses the provided Racket source code and returns a Program
 // describing its structure using the official Racket parser.
 func Inspect(src string) (*Program, error) {
-	prog, err := rktparse.Parse(src)
+	prog, err := parse(src)
 	if err != nil {
 		return nil, err
 	}
-	return &Program{Forms: prog.Forms}, nil
+	return prog, nil
+}
+
+func parse(src string) (*Program, error) {
+	if _, err := exec.LookPath("racket"); err != nil {
+		return nil, fmt.Errorf("racket not installed")
+	}
+	script, err := os.CreateTemp("", "parse-*.rkt")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(script.Name())
+	if _, err := script.WriteString(racketParser); err != nil {
+		script.Close()
+		return nil, err
+	}
+	script.Close()
+	cmd := exec.Command("racket", script.Name())
+	cmd.Stdin = strings.NewReader(src)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if errBuf.Len() > 0 {
+			return nil, fmt.Errorf("racket: %s", errBuf.String())
+		}
+		return nil, err
+	}
+	var forms []Form
+	if err := json.Unmarshal(out.Bytes(), &forms); err != nil {
+		return nil, err
+	}
+	return &Program{Forms: forms}, nil
 }

--- a/tools/json-ast/x/rkt/parse.rkt
+++ b/tools/json-ast/x/rkt/parse.rkt
@@ -1,0 +1,32 @@
+#lang racket
+(require json)
+
+(define src-lines (string-split (port->string (current-input-port)) "\n"))
+(define (drop-header ls)
+  (cond
+    [(null? ls) '()]
+    [(regexp-match? #"^#lang" (car ls)) (cdr ls)]
+    [else (drop-header (cdr ls))]))
+(define body (string-join (drop-header src-lines) "\n"))
+(define in (open-input-string body))
+(define (datum->json d)
+  (cond [(symbol? d) (hash 'sym (symbol->string d))]
+        [(keyword? d) (hash 'sym (keyword->string d))]
+        [(pair? d) (map datum->json d)]
+        [(vector? d) (map datum->json (vector->list d))]
+        [(hash? d) (for/hash ([(k v) (in-hash d)])
+                           (values (datum->json k) (datum->json v)))]
+        [else d]))
+
+(define forms '())
+(parameterize ([read-accept-reader #t])
+  (let loop ()
+    (define stx (with-handlers ([exn:fail:read? (lambda (e) eof)])
+                  (read-syntax 'source in)))
+    (unless (eof-object? stx)
+      (set! forms (append forms
+                          (list (hash 'datum (datum->json (syntax->datum stx))
+                                      'line (or (syntax-line stx) 0)
+                                      'col (or (syntax-column stx) 0)))))
+      (loop))))
+(write-json forms)


### PR DESCRIPTION
## Summary
- replace use of a2mochi Racket parser in `tools/json-ast/x/rkt` with
  an embedded parser script
- add Racket parser script to the json-ast tools

## Testing
- `go test -run TestInspect_Golden -tags slow ./tools/json-ast/x/rkt -count=1 -v` *(fails: racket not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889191175f48320bb25da9777896017