### PR TITLE
Add typed Clojure AST inspector

### DIFF
--- a/tests/json-ast/x/clj/cross_join.clj.json
+++ b/tests/json-ast/x/clj/cross_join.clj.json
@@ -1,144 +1,447 @@
 {
   "forms": [
-    [
-      "ns",
-      "main"
-    ],
-    [
-      "require",
-      [
-        "quote",
-        "clojure.set"
-      ]
-    ],
-    [
-      "defrecord",
-      "Orders",
-      [
-        "id",
-        "customerId",
-        "total"
-      ]
-    ],
-    [
-      "defrecord",
-      "Customers",
-      [
-        "id",
-        "name"
-      ]
-    ],
-    [
-      "def",
-      "customers",
-      [
+    {
+      "list": [
         {
-          "id": 1,
-          "name": "Alice"
+          "sym": "ns"
         },
         {
-          "id": 2,
-          "name": "Bob"
-        },
-        {
-          "id": 3,
-          "name": "Charlie"
+          "sym": "main"
         }
       ]
-    ],
-    [
-      "def",
-      "orders",
-      [
+    },
+    {
+      "list": [
         {
-          "customerId": 1,
-          "id": 100,
-          "total": 250
+          "sym": "require"
         },
         {
-          "customerId": 2,
-          "id": 101,
-          "total": 125
-        },
-        {
-          "customerId": 1,
-          "id": 102,
-          "total": 300
-        }
-      ]
-    ],
-    [
-      "def",
-      "result",
-      [
-        "for",
-        [
-          "o",
-          "orders",
-          "c",
-          "customers"
-        ],
-        {
-          "orderCustomerId": [
-            "customerId",
-            "o"
-          ],
-          "orderId": [
-            "id",
-            "o"
-          ],
-          "orderTotal": [
-            "total",
-            "o"
-          ],
-          "pairedCustomerName": [
-            "name",
-            "c"
+          "list": [
+            {
+              "sym": "quote"
+            },
+            {
+              "sym": "clojure.set"
+            }
           ]
         }
       ]
-    ],
-    [
-      "defn",
-      "-main",
-      [],
-      [
-        "println",
-        "--- Cross Join: All order-customer pairs ---"
-      ],
-      [
-        "doseq",
-        [
-          "entry",
-          "result"
-        ],
-        [
-          "println",
-          "Order",
-          [
-            "orderId",
-            "entry"
-          ],
-          "(customerId:",
-          [
-            "orderCustomerId",
-            "entry"
-          ],
-          ", total: $",
-          [
-            "orderTotal",
-            "entry"
-          ],
-          ") paired with",
-          [
-            "pairedCustomerName",
-            "entry"
+    },
+    {
+      "list": [
+        {
+          "sym": "defrecord"
+        },
+        {
+          "sym": "Orders"
+        },
+        {
+          "vector": [
+            {
+              "sym": "id"
+            },
+            {
+              "sym": "customerId"
+            },
+            {
+              "sym": "total"
+            }
           ]
-        ]
+        }
       ]
-    ],
-    [
-      "-main"
-    ]
+    },
+    {
+      "list": [
+        {
+          "sym": "defrecord"
+        },
+        {
+          "sym": "Customers"
+        },
+        {
+          "vector": [
+            {
+              "sym": "id"
+            },
+            {
+              "sym": "name"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "customers"
+        },
+        {
+          "vector": [
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":id"
+                  },
+                  "val": {
+                    "num": 1
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":name"
+                  },
+                  "val": {
+                    "str": "Alice"
+                  }
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":id"
+                  },
+                  "val": {
+                    "num": 2
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":name"
+                  },
+                  "val": {
+                    "str": "Bob"
+                  }
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":id"
+                  },
+                  "val": {
+                    "num": 3
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":name"
+                  },
+                  "val": {
+                    "str": "Charlie"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "orders"
+        },
+        {
+          "vector": [
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":id"
+                  },
+                  "val": {
+                    "num": 100
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":customerId"
+                  },
+                  "val": {
+                    "num": 1
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":total"
+                  },
+                  "val": {
+                    "num": 250
+                  }
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":id"
+                  },
+                  "val": {
+                    "num": 101
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":customerId"
+                  },
+                  "val": {
+                    "num": 2
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":total"
+                  },
+                  "val": {
+                    "num": 125
+                  }
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":id"
+                  },
+                  "val": {
+                    "num": 102
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":customerId"
+                  },
+                  "val": {
+                    "num": 1
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":total"
+                  },
+                  "val": {
+                    "num": 300
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "result"
+        },
+        {
+          "list": [
+            {
+              "sym": "for"
+            },
+            {
+              "vector": [
+                {
+                  "sym": "o"
+                },
+                {
+                  "sym": "orders"
+                },
+                {
+                  "sym": "c"
+                },
+                {
+                  "sym": "customers"
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":orderId"
+                  },
+                  "val": {
+                    "list": [
+                      {
+                        "kw": ":id"
+                      },
+                      {
+                        "sym": "o"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":orderCustomerId"
+                  },
+                  "val": {
+                    "list": [
+                      {
+                        "kw": ":customerId"
+                      },
+                      {
+                        "sym": "o"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":pairedCustomerName"
+                  },
+                  "val": {
+                    "list": [
+                      {
+                        "kw": ":name"
+                      },
+                      {
+                        "sym": "c"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":orderTotal"
+                  },
+                  "val": {
+                    "list": [
+                      {
+                        "kw": ":total"
+                      },
+                      {
+                        "sym": "o"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "defn"
+        },
+        {
+          "sym": "-main"
+        },
+        {},
+        {
+          "list": [
+            {
+              "sym": "println"
+            },
+            {
+              "str": "--- Cross Join: All order-customer pairs ---"
+            }
+          ]
+        },
+        {
+          "list": [
+            {
+              "sym": "doseq"
+            },
+            {
+              "vector": [
+                {
+                  "sym": "entry"
+                },
+                {
+                  "sym": "result"
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "sym": "println"
+                },
+                {
+                  "str": "Order"
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":orderId"
+                    },
+                    {
+                      "sym": "entry"
+                    }
+                  ]
+                },
+                {
+                  "str": "(customerId:"
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":orderCustomerId"
+                    },
+                    {
+                      "sym": "entry"
+                    }
+                  ]
+                },
+                {
+                  "str": ", total: $"
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":orderTotal"
+                    },
+                    {
+                      "sym": "entry"
+                    }
+                  ]
+                },
+                {
+                  "str": ") paired with"
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":pairedCustomerName"
+                    },
+                    {
+                      "sym": "entry"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "-main"
+        }
+      ]
+    }
   ]
 }

--- a/tests/json-ast/x/clj/cross_join_filter.clj.json
+++ b/tests/json-ast/x/clj/cross_join_filter.clj.json
@@ -1,89 +1,225 @@
 {
   "forms": [
-    [
-      "ns",
-      "main"
-    ],
-    [
-      "require",
-      [
-        "quote",
-        "clojure.set"
-      ]
-    ],
-    [
-      "def",
-      "nums",
-      [
-        1,
-        2,
-        3
-      ]
-    ],
-    [
-      "def",
-      "letters",
-      [
-        "A",
-        "B"
-      ]
-    ],
-    [
-      "def",
-      "pairs",
-      [
-        "for",
-        [
-          "n",
-          "nums",
-          "l",
-          "letters",
-          "when",
-          [
-            "=",
-            [
-              "mod",
-              "n",
-              2
-            ],
-            0
-          ]
-        ],
+    {
+      "list": [
         {
-          "l": "l",
-          "n": "n"
+          "sym": "ns"
+        },
+        {
+          "sym": "main"
         }
       ]
-    ],
-    [
-      "defn",
-      "-main",
-      [],
-      [
-        "println",
-        "--- Even pairs ---"
-      ],
-      [
-        "doseq",
-        [
-          "p",
-          "pairs"
-        ],
-        [
-          "println",
-          [
-            "n",
-            "p"
-          ],
-          [
-            "l",
-            "p"
+    },
+    {
+      "list": [
+        {
+          "sym": "require"
+        },
+        {
+          "list": [
+            {
+              "sym": "quote"
+            },
+            {
+              "sym": "clojure.set"
+            }
           ]
-        ]
+        }
       ]
-    ],
-    [
-      "-main"
-    ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "nums"
+        },
+        {
+          "vector": [
+            {
+              "num": 1
+            },
+            {
+              "num": 2
+            },
+            {
+              "num": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "letters"
+        },
+        {
+          "vector": [
+            {
+              "str": "A"
+            },
+            {
+              "str": "B"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "pairs"
+        },
+        {
+          "list": [
+            {
+              "sym": "for"
+            },
+            {
+              "vector": [
+                {
+                  "sym": "n"
+                },
+                {
+                  "sym": "nums"
+                },
+                {
+                  "sym": "l"
+                },
+                {
+                  "sym": "letters"
+                },
+                {
+                  "kw": ":when"
+                },
+                {
+                  "list": [
+                    {
+                      "sym": "="
+                    },
+                    {
+                      "list": [
+                        {
+                          "sym": "mod"
+                        },
+                        {
+                          "sym": "n"
+                        },
+                        {
+                          "num": 2
+                        }
+                      ]
+                    },
+                    {
+                      "num": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":n"
+                  },
+                  "val": {
+                    "sym": "n"
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":l"
+                  },
+                  "val": {
+                    "sym": "l"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "defn"
+        },
+        {
+          "sym": "-main"
+        },
+        {},
+        {
+          "list": [
+            {
+              "sym": "println"
+            },
+            {
+              "str": "--- Even pairs ---"
+            }
+          ]
+        },
+        {
+          "list": [
+            {
+              "sym": "doseq"
+            },
+            {
+              "vector": [
+                {
+                  "sym": "p"
+                },
+                {
+                  "sym": "pairs"
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "sym": "println"
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":n"
+                    },
+                    {
+                      "sym": "p"
+                    }
+                  ]
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":l"
+                    },
+                    {
+                      "sym": "p"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "-main"
+        }
+      ]
+    }
   ]
 }

--- a/tests/json-ast/x/clj/cross_join_triple.clj.json
+++ b/tests/json-ast/x/clj/cross_join_triple.clj.json
@@ -1,93 +1,240 @@
 {
   "forms": [
-    [
-      "ns",
-      "main"
-    ],
-    [
-      "require",
-      [
-        "quote",
-        "clojure.set"
-      ]
-    ],
-    [
-      "def",
-      "nums",
-      [
-        1,
-        2
-      ]
-    ],
-    [
-      "def",
-      "letters",
-      [
-        "A",
-        "B"
-      ]
-    ],
-    [
-      "def",
-      "bools",
-      [
-        true,
-        false
-      ]
-    ],
-    [
-      "def",
-      "combos",
-      [
-        "for",
-        [
-          "n",
-          "nums",
-          "l",
-          "letters",
-          "b",
-          "bools"
-        ],
+    {
+      "list": [
         {
-          "b": "b",
-          "l": "l",
-          "n": "n"
+          "sym": "ns"
+        },
+        {
+          "sym": "main"
         }
       ]
-    ],
-    [
-      "defn",
-      "-main",
-      [],
-      [
-        "println",
-        "--- Cross Join of three lists ---"
-      ],
-      [
-        "doseq",
-        [
-          "c",
-          "combos"
-        ],
-        [
-          "println",
-          [
-            "n",
-            "c"
-          ],
-          [
-            "l",
-            "c"
-          ],
-          [
-            "b",
-            "c"
+    },
+    {
+      "list": [
+        {
+          "sym": "require"
+        },
+        {
+          "list": [
+            {
+              "sym": "quote"
+            },
+            {
+              "sym": "clojure.set"
+            }
           ]
-        ]
+        }
       ]
-    ],
-    [
-      "-main"
-    ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "nums"
+        },
+        {
+          "vector": [
+            {
+              "num": 1
+            },
+            {
+              "num": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "letters"
+        },
+        {
+          "vector": [
+            {
+              "str": "A"
+            },
+            {
+              "str": "B"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "bools"
+        },
+        {
+          "vector": [
+            {
+              "bool": true
+            },
+            {
+              "bool": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "def"
+        },
+        {
+          "sym": "combos"
+        },
+        {
+          "list": [
+            {
+              "sym": "for"
+            },
+            {
+              "vector": [
+                {
+                  "sym": "n"
+                },
+                {
+                  "sym": "nums"
+                },
+                {
+                  "sym": "l"
+                },
+                {
+                  "sym": "letters"
+                },
+                {
+                  "sym": "b"
+                },
+                {
+                  "sym": "bools"
+                }
+              ]
+            },
+            {
+              "map": [
+                {
+                  "key": {
+                    "kw": ":n"
+                  },
+                  "val": {
+                    "sym": "n"
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":l"
+                  },
+                  "val": {
+                    "sym": "l"
+                  }
+                },
+                {
+                  "key": {
+                    "kw": ":b"
+                  },
+                  "val": {
+                    "sym": "b"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "defn"
+        },
+        {
+          "sym": "-main"
+        },
+        {},
+        {
+          "list": [
+            {
+              "sym": "println"
+            },
+            {
+              "str": "--- Cross Join of three lists ---"
+            }
+          ]
+        },
+        {
+          "list": [
+            {
+              "sym": "doseq"
+            },
+            {
+              "vector": [
+                {
+                  "sym": "c"
+                },
+                {
+                  "sym": "combos"
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "sym": "println"
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":n"
+                    },
+                    {
+                      "sym": "c"
+                    }
+                  ]
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":l"
+                    },
+                    {
+                      "sym": "c"
+                    }
+                  ]
+                },
+                {
+                  "list": [
+                    {
+                      "kw": ":b"
+                    },
+                    {
+                      "sym": "c"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "sym": "-main"
+        }
+      ]
+    }
   ]
 }

--- a/tools/json-ast/x/clj/inspect_test.go
+++ b/tools/json-ast/x/clj/inspect_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -37,8 +36,8 @@ func repoRoot(t *testing.T) string {
 }
 
 func ensureBabashka(t *testing.T) {
-	if _, err := exec.LookPath("bb"); err != nil {
-		t.Skip("bb not installed")
+	if err := clj.EnsureBabashka(); err != nil {
+		t.Skipf("bb not installed: %v", err)
 	}
 }
 

--- a/tools/json-ast/x/clj/tools.go
+++ b/tools/json-ast/x/clj/tools.go
@@ -1,0 +1,61 @@
+package clj
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsureBabashka verifies that the babashka command is available. It attempts a
+// best-effort installation using common package managers when missing.
+func EnsureBabashka() error {
+	if _, err := exec.LookPath(babashkaCmd); err == nil {
+		return nil
+	}
+	fmt.Println("🔧 Installing Babashka...")
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "babashka")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+		if _, err := exec.LookPath("apk"); err == nil {
+			cmd := exec.Command("apk", "add", "--no-cache", "babashka")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "babashka")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "babashka")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "babashka")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath(babashkaCmd); err == nil {
+		return nil
+	}
+	return fmt.Errorf("babashka not installed")
+}


### PR DESCRIPTION
## Summary
- generate a typed representation of Clojure forms instead of using `any`
- update Babashka script to emit structured JSON
- refresh cross_join golden files

## Testing
- `go vet ./...`
- `go test ./tools/json-ast/x/clj -run TestInspect_Golden/cross_join -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_6889869455d08320ab05796ddae25e11