### PR TITLE
Add nested Haskell AST output

### DIFF
--- a/tests/json-ast/x/haskell/cross_join.hs.json
+++ b/tests/json-ast/x/haskell/cross_join.hs.json
@@ -1,0 +1,4461 @@
+{
+  "ast": {
+    "children": [
+      {
+        "node": "()"
+      },
+      {
+        "node": "Nothing"
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "node": "()"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      "DuplicateRecordFields"
+                    ],
+                    "node": "Ident"
+                  },
+                  {
+                    "node": "[]"
+                  }
+                ],
+                "node": "(:)"
+              }
+            ],
+            "node": "LanguagePragma"
+          },
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "node": "()"
+                  },
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          "OverloadedRecordDot"
+                        ],
+                        "node": "Ident"
+                      },
+                      {
+                        "node": "[]"
+                      }
+                    ],
+                    "node": "(:)"
+                  }
+                ],
+                "node": "LanguagePragma"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              "NoFieldSelectors"
+                            ],
+                            "node": "Ident"
+                          },
+                          {
+                            "node": "[]"
+                          }
+                        ],
+                        "node": "(:)"
+                      }
+                    ],
+                    "node": "LanguagePragma"
+                  },
+                  {
+                    "node": "[]"
+                  }
+                ],
+                "node": "(:)"
+              }
+            ],
+            "node": "(:)"
+          }
+        ],
+        "node": "(:)"
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "node": "()"
+              },
+              {
+                "children": [
+                  {
+                    "node": "()"
+                  },
+                  "Prelude"
+                ],
+                "node": "ModuleName"
+              },
+              false,
+              false,
+              false,
+              {
+                "node": "Nothing"
+              },
+              {
+                "node": "Nothing"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      true,
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  "customerId"
+                                ],
+                                "node": "Ident"
+                              }
+                            ],
+                            "node": "IVar"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      "id"
+                                    ],
+                                    "node": "Ident"
+                                  }
+                                ],
+                                "node": "IVar"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          "name"
+                                        ],
+                                        "node": "Ident"
+                                      }
+                                    ],
+                                    "node": "IVar"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              "orderCustomerId"
+                                            ],
+                                            "node": "Ident"
+                                          }
+                                        ],
+                                        "node": "IVar"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "orderId"
+                                                ],
+                                                "node": "Ident"
+                                              }
+                                            ],
+                                            "node": "IVar"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "orderTotal"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "IVar"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "pairedCustomerName"
+                                                        ],
+                                                        "node": "Ident"
+                                                      }
+                                                    ],
+                                                    "node": "IVar"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "total"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "IVar"
+                                                      },
+                                                      {
+                                                        "node": "[]"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      }
+                                    ],
+                                    "node": "(:)"
+                                  }
+                                ],
+                                "node": "(:)"
+                              }
+                            ],
+                            "node": "(:)"
+                          }
+                        ],
+                        "node": "(:)"
+                      }
+                    ],
+                    "node": "ImportSpecList"
+                  }
+                ],
+                "node": "Just"
+              }
+            ],
+            "node": "ImportDecl"
+          },
+          {
+            "node": "[]"
+          }
+        ],
+        "node": "(:)"
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "node": "()"
+              },
+              {
+                "children": [
+                  {
+                    "node": "()"
+                  }
+                ],
+                "node": "DataType"
+              },
+              {
+                "node": "Nothing"
+              },
+              {
+                "children": [
+                  {
+                    "node": "()"
+                  },
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      "GenType1"
+                    ],
+                    "node": "Ident"
+                  }
+                ],
+                "node": "DHead"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      {
+                        "node": "Nothing"
+                      },
+                      {
+                        "node": "Nothing"
+                      },
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              "GenType1"
+                            ],
+                            "node": "Ident"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          "id"
+                                        ],
+                                        "node": "Ident"
+                                      },
+                                      {
+                                        "node": "[]"
+                                      }
+                                    ],
+                                    "node": "(:)"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              "Int"
+                                            ],
+                                            "node": "Ident"
+                                          }
+                                        ],
+                                        "node": "UnQual"
+                                      }
+                                    ],
+                                    "node": "TyCon"
+                                  }
+                                ],
+                                "node": "FieldDecl"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              "name"
+                                            ],
+                                            "node": "Ident"
+                                          },
+                                          {
+                                            "node": "[]"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "String"
+                                                ],
+                                                "node": "Ident"
+                                              }
+                                            ],
+                                            "node": "UnQual"
+                                          }
+                                        ],
+                                        "node": "TyCon"
+                                      }
+                                    ],
+                                    "node": "FieldDecl"
+                                  },
+                                  {
+                                    "node": "[]"
+                                  }
+                                ],
+                                "node": "(:)"
+                              }
+                            ],
+                            "node": "(:)"
+                          }
+                        ],
+                        "node": "RecDecl"
+                      }
+                    ],
+                    "node": "QualConDecl"
+                  },
+                  {
+                    "node": "[]"
+                  }
+                ],
+                "node": "(:)"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      {
+                        "node": "Nothing"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "node": "Nothing"
+                                  },
+                                  {
+                                    "node": "Nothing"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              "Show"
+                                            ],
+                                            "node": "Ident"
+                                          }
+                                        ],
+                                        "node": "UnQual"
+                                      }
+                                    ],
+                                    "node": "IHCon"
+                                  }
+                                ],
+                                "node": "IRule"
+                              }
+                            ],
+                            "node": "IParen"
+                          },
+                          {
+                            "node": "[]"
+                          }
+                        ],
+                        "node": "(:)"
+                      }
+                    ],
+                    "node": "Deriving"
+                  },
+                  {
+                    "node": "[]"
+                  }
+                ],
+                "node": "(:)"
+              }
+            ],
+            "node": "DataDecl"
+          },
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "node": "()"
+                  },
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      }
+                    ],
+                    "node": "DataType"
+                  },
+                  {
+                    "node": "Nothing"
+                  },
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          "GenType2"
+                        ],
+                        "node": "Ident"
+                      }
+                    ],
+                    "node": "DHead"
+                  },
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          {
+                            "node": "Nothing"
+                          },
+                          {
+                            "node": "Nothing"
+                          },
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  "GenType2"
+                                ],
+                                "node": "Ident"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              "id"
+                                            ],
+                                            "node": "Ident"
+                                          },
+                                          {
+                                            "node": "[]"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "Int"
+                                                ],
+                                                "node": "Ident"
+                                              }
+                                            ],
+                                            "node": "UnQual"
+                                          }
+                                        ],
+                                        "node": "TyCon"
+                                      }
+                                    ],
+                                    "node": "FieldDecl"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "customerId"
+                                                ],
+                                                "node": "Ident"
+                                              },
+                                              {
+                                                "node": "[]"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "Int"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              }
+                                            ],
+                                            "node": "TyCon"
+                                          }
+                                        ],
+                                        "node": "FieldDecl"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "total"
+                                                    ],
+                                                    "node": "Ident"
+                                                  },
+                                                  {
+                                                    "node": "[]"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "Int"
+                                                        ],
+                                                        "node": "Ident"
+                                                      }
+                                                    ],
+                                                    "node": "UnQual"
+                                                  }
+                                                ],
+                                                "node": "TyCon"
+                                              }
+                                            ],
+                                            "node": "FieldDecl"
+                                          },
+                                          {
+                                            "node": "[]"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      }
+                                    ],
+                                    "node": "(:)"
+                                  }
+                                ],
+                                "node": "(:)"
+                              }
+                            ],
+                            "node": "RecDecl"
+                          }
+                        ],
+                        "node": "QualConDecl"
+                      },
+                      {
+                        "node": "[]"
+                      }
+                    ],
+                    "node": "(:)"
+                  },
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          {
+                            "node": "Nothing"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "node": "Nothing"
+                                      },
+                                      {
+                                        "node": "Nothing"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "Show"
+                                                ],
+                                                "node": "Ident"
+                                              }
+                                            ],
+                                            "node": "UnQual"
+                                          }
+                                        ],
+                                        "node": "IHCon"
+                                      }
+                                    ],
+                                    "node": "IRule"
+                                  }
+                                ],
+                                "node": "IParen"
+                              },
+                              {
+                                "node": "[]"
+                              }
+                            ],
+                            "node": "(:)"
+                          }
+                        ],
+                        "node": "Deriving"
+                      },
+                      {
+                        "node": "[]"
+                      }
+                    ],
+                    "node": "(:)"
+                  }
+                ],
+                "node": "DataDecl"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "node": "()"
+                      },
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          }
+                        ],
+                        "node": "DataType"
+                      },
+                      {
+                        "node": "Nothing"
+                      },
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              "GenType3"
+                            ],
+                            "node": "Ident"
+                          }
+                        ],
+                        "node": "DHead"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "node": "Nothing"
+                              },
+                              {
+                                "node": "Nothing"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      "GenType3"
+                                    ],
+                                    "node": "Ident"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "orderId"
+                                                ],
+                                                "node": "Ident"
+                                              },
+                                              {
+                                                "node": "[]"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "Int"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              }
+                                            ],
+                                            "node": "TyCon"
+                                          }
+                                        ],
+                                        "node": "FieldDecl"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "orderCustomerId"
+                                                    ],
+                                                    "node": "Ident"
+                                                  },
+                                                  {
+                                                    "node": "[]"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "Int"
+                                                        ],
+                                                        "node": "Ident"
+                                                      }
+                                                    ],
+                                                    "node": "UnQual"
+                                                  }
+                                                ],
+                                                "node": "TyCon"
+                                              }
+                                            ],
+                                            "node": "FieldDecl"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "pairedCustomerName"
+                                                        ],
+                                                        "node": "Ident"
+                                                      },
+                                                      {
+                                                        "node": "[]"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "String"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "UnQual"
+                                                      }
+                                                    ],
+                                                    "node": "TyCon"
+                                                  }
+                                                ],
+                                                "node": "FieldDecl"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "orderTotal"
+                                                            ],
+                                                            "node": "Ident"
+                                                          },
+                                                          {
+                                                            "node": "[]"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "Int"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          }
+                                                        ],
+                                                        "node": "TyCon"
+                                                      }
+                                                    ],
+                                                    "node": "FieldDecl"
+                                                  },
+                                                  {
+                                                    "node": "[]"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      }
+                                    ],
+                                    "node": "(:)"
+                                  }
+                                ],
+                                "node": "RecDecl"
+                              }
+                            ],
+                            "node": "QualConDecl"
+                          },
+                          {
+                            "node": "[]"
+                          }
+                        ],
+                        "node": "(:)"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "node": "Nothing"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "node": "Nothing"
+                                          },
+                                          {
+                                            "node": "Nothing"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "Show"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              }
+                                            ],
+                                            "node": "IHCon"
+                                          }
+                                        ],
+                                        "node": "IRule"
+                                      }
+                                    ],
+                                    "node": "IParen"
+                                  },
+                                  {
+                                    "node": "[]"
+                                  }
+                                ],
+                                "node": "(:)"
+                              }
+                            ],
+                            "node": "Deriving"
+                          },
+                          {
+                            "node": "[]"
+                          }
+                        ],
+                        "node": "(:)"
+                      }
+                    ],
+                    "node": "DataDecl"
+                  },
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "node": "()"
+                          },
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  "customers"
+                                ],
+                                "node": "Ident"
+                              }
+                            ],
+                            "node": "PVar"
+                          },
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "GenType1"
+                                                ],
+                                                "node": "Ident"
+                                              }
+                                            ],
+                                            "node": "UnQual"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "id"
+                                                        ],
+                                                        "node": "Ident"
+                                                      }
+                                                    ],
+                                                    "node": "UnQual"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          1,
+                                                          "1"
+                                                        ],
+                                                        "node": "Int"
+                                                      }
+                                                    ],
+                                                    "node": "Lit"
+                                                  }
+                                                ],
+                                                "node": "FieldUpdate"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "name"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "UnQual"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "Alice",
+                                                              "Alice"
+                                                            ],
+                                                            "node": "String"
+                                                          }
+                                                        ],
+                                                        "node": "Lit"
+                                                      }
+                                                    ],
+                                                    "node": "FieldUpdate"
+                                                  },
+                                                  {
+                                                    "node": "[]"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          }
+                                        ],
+                                        "node": "RecConstr"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "GenType1"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "id"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "UnQual"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              2,
+                                                              "2"
+                                                            ],
+                                                            "node": "Int"
+                                                          }
+                                                        ],
+                                                        "node": "Lit"
+                                                      }
+                                                    ],
+                                                    "node": "FieldUpdate"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "name"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "Bob",
+                                                                  "Bob"
+                                                                ],
+                                                                "node": "String"
+                                                              }
+                                                            ],
+                                                            "node": "Lit"
+                                                          }
+                                                        ],
+                                                        "node": "FieldUpdate"
+                                                      },
+                                                      {
+                                                        "node": "[]"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "RecConstr"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "GenType1"
+                                                        ],
+                                                        "node": "Ident"
+                                                      }
+                                                    ],
+                                                    "node": "UnQual"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "id"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  3,
+                                                                  "3"
+                                                                ],
+                                                                "node": "Int"
+                                                              }
+                                                            ],
+                                                            "node": "Lit"
+                                                          }
+                                                        ],
+                                                        "node": "FieldUpdate"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "name"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "Charlie",
+                                                                      "Charlie"
+                                                                    ],
+                                                                    "node": "String"
+                                                                  }
+                                                                ],
+                                                                "node": "Lit"
+                                                              }
+                                                            ],
+                                                            "node": "FieldUpdate"
+                                                          },
+                                                          {
+                                                            "node": "[]"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "RecConstr"
+                                              },
+                                              {
+                                                "node": "[]"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      }
+                                    ],
+                                    "node": "(:)"
+                                  }
+                                ],
+                                "node": "List"
+                              }
+                            ],
+                            "node": "UnGuardedRhs"
+                          },
+                          {
+                            "node": "Nothing"
+                          }
+                        ],
+                        "node": "PatBind"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "node": "()"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      "orders"
+                                    ],
+                                    "node": "Ident"
+                                  }
+                                ],
+                                "node": "PVar"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "GenType2"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "id"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "UnQual"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              100,
+                                                              "100"
+                                                            ],
+                                                            "node": "Int"
+                                                          }
+                                                        ],
+                                                        "node": "Lit"
+                                                      }
+                                                    ],
+                                                    "node": "FieldUpdate"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "customerId"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  1,
+                                                                  "1"
+                                                                ],
+                                                                "node": "Int"
+                                                              }
+                                                            ],
+                                                            "node": "Lit"
+                                                          }
+                                                        ],
+                                                        "node": "FieldUpdate"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "total"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      250,
+                                                                      "250"
+                                                                    ],
+                                                                    "node": "Int"
+                                                                  }
+                                                                ],
+                                                                "node": "Lit"
+                                                              }
+                                                            ],
+                                                            "node": "FieldUpdate"
+                                                          },
+                                                          {
+                                                            "node": "[]"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "RecConstr"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          "GenType2"
+                                                        ],
+                                                        "node": "Ident"
+                                                      }
+                                                    ],
+                                                    "node": "UnQual"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "id"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  101,
+                                                                  "101"
+                                                                ],
+                                                                "node": "Int"
+                                                              }
+                                                            ],
+                                                            "node": "Lit"
+                                                          }
+                                                        ],
+                                                        "node": "FieldUpdate"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "customerId"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      2,
+                                                                      "2"
+                                                                    ],
+                                                                    "node": "Int"
+                                                                  }
+                                                                ],
+                                                                "node": "Lit"
+                                                              }
+                                                            ],
+                                                            "node": "FieldUpdate"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "total"
+                                                                        ],
+                                                                        "node": "Ident"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          125,
+                                                                          "125"
+                                                                        ],
+                                                                        "node": "Int"
+                                                                      }
+                                                                    ],
+                                                                    "node": "Lit"
+                                                                  }
+                                                                ],
+                                                                "node": "FieldUpdate"
+                                                              },
+                                                              {
+                                                                "node": "[]"
+                                                              }
+                                                            ],
+                                                            "node": "(:)"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "RecConstr"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "GenType2"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "UnQual"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "id"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      102,
+                                                                      "102"
+                                                                    ],
+                                                                    "node": "Int"
+                                                                  }
+                                                                ],
+                                                                "node": "Lit"
+                                                              }
+                                                            ],
+                                                            "node": "FieldUpdate"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "customerId"
+                                                                        ],
+                                                                        "node": "Ident"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          1,
+                                                                          "1"
+                                                                        ],
+                                                                        "node": "Int"
+                                                                      }
+                                                                    ],
+                                                                    "node": "Lit"
+                                                                  }
+                                                                ],
+                                                                "node": "FieldUpdate"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              "total"
+                                                                            ],
+                                                                            "node": "Ident"
+                                                                          }
+                                                                        ],
+                                                                        "node": "UnQual"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              300,
+                                                                              "300"
+                                                                            ],
+                                                                            "node": "Int"
+                                                                          }
+                                                                        ],
+                                                                        "node": "Lit"
+                                                                      }
+                                                                    ],
+                                                                    "node": "FieldUpdate"
+                                                                  },
+                                                                  {
+                                                                    "node": "[]"
+                                                                  }
+                                                                ],
+                                                                "node": "(:)"
+                                                              }
+                                                            ],
+                                                            "node": "(:)"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      }
+                                                    ],
+                                                    "node": "RecConstr"
+                                                  },
+                                                  {
+                                                    "node": "[]"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      }
+                                    ],
+                                    "node": "List"
+                                  }
+                                ],
+                                "node": "UnGuardedRhs"
+                              },
+                              {
+                                "node": "Nothing"
+                              }
+                            ],
+                            "node": "PatBind"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "node": "()"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          "result"
+                                        ],
+                                        "node": "Ident"
+                                      }
+                                    ],
+                                    "node": "PVar"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "GenType3"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "orderId"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "UnQual"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "o"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              }
+                                                            ],
+                                                            "node": "Var"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "."
+                                                                    ],
+                                                                    "node": "Symbol"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              }
+                                                            ],
+                                                            "node": "QVarOp"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "id"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              }
+                                                            ],
+                                                            "node": "Var"
+                                                          }
+                                                        ],
+                                                        "node": "InfixApp"
+                                                      }
+                                                    ],
+                                                    "node": "FieldUpdate"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "orderCustomerId"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "o"
+                                                                        ],
+                                                                        "node": "Ident"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  }
+                                                                ],
+                                                                "node": "Var"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "."
+                                                                        ],
+                                                                        "node": "Symbol"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  }
+                                                                ],
+                                                                "node": "QVarOp"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "customerId"
+                                                                        ],
+                                                                        "node": "Ident"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  }
+                                                                ],
+                                                                "node": "Var"
+                                                              }
+                                                            ],
+                                                            "node": "InfixApp"
+                                                          }
+                                                        ],
+                                                        "node": "FieldUpdate"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "pairedCustomerName"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              "c"
+                                                                            ],
+                                                                            "node": "Ident"
+                                                                          }
+                                                                        ],
+                                                                        "node": "UnQual"
+                                                                      }
+                                                                    ],
+                                                                    "node": "Var"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              "."
+                                                                            ],
+                                                                            "node": "Symbol"
+                                                                          }
+                                                                        ],
+                                                                        "node": "UnQual"
+                                                                      }
+                                                                    ],
+                                                                    "node": "QVarOp"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              "name"
+                                                                            ],
+                                                                            "node": "Ident"
+                                                                          }
+                                                                        ],
+                                                                        "node": "UnQual"
+                                                                      }
+                                                                    ],
+                                                                    "node": "Var"
+                                                                  }
+                                                                ],
+                                                                "node": "InfixApp"
+                                                              }
+                                                            ],
+                                                            "node": "FieldUpdate"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "orderTotal"
+                                                                        ],
+                                                                        "node": "Ident"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              {
+                                                                                "children": [
+                                                                                  {
+                                                                                    "node": "()"
+                                                                                  },
+                                                                                  "o"
+                                                                                ],
+                                                                                "node": "Ident"
+                                                                              }
+                                                                            ],
+                                                                            "node": "UnQual"
+                                                                          }
+                                                                        ],
+                                                                        "node": "Var"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              {
+                                                                                "children": [
+                                                                                  {
+                                                                                    "node": "()"
+                                                                                  },
+                                                                                  "."
+                                                                                ],
+                                                                                "node": "Symbol"
+                                                                              }
+                                                                            ],
+                                                                            "node": "UnQual"
+                                                                          }
+                                                                        ],
+                                                                        "node": "QVarOp"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              {
+                                                                                "children": [
+                                                                                  {
+                                                                                    "node": "()"
+                                                                                  },
+                                                                                  "total"
+                                                                                ],
+                                                                                "node": "Ident"
+                                                                              }
+                                                                            ],
+                                                                            "node": "UnQual"
+                                                                          }
+                                                                        ],
+                                                                        "node": "Var"
+                                                                      }
+                                                                    ],
+                                                                    "node": "InfixApp"
+                                                                  }
+                                                                ],
+                                                                "node": "FieldUpdate"
+                                                              },
+                                                              {
+                                                                "node": "[]"
+                                                              }
+                                                            ],
+                                                            "node": "(:)"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "RecConstr"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              "o"
+                                                            ],
+                                                            "node": "Ident"
+                                                          }
+                                                        ],
+                                                        "node": "PVar"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "orders"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "UnQual"
+                                                          }
+                                                        ],
+                                                        "node": "Var"
+                                                      }
+                                                    ],
+                                                    "node": "Generator"
+                                                  }
+                                                ],
+                                                "node": "QualStmt"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  "c"
+                                                                ],
+                                                                "node": "Ident"
+                                                              }
+                                                            ],
+                                                            "node": "PVar"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "customers"
+                                                                    ],
+                                                                    "node": "Ident"
+                                                                  }
+                                                                ],
+                                                                "node": "UnQual"
+                                                              }
+                                                            ],
+                                                            "node": "Var"
+                                                          }
+                                                        ],
+                                                        "node": "Generator"
+                                                      }
+                                                    ],
+                                                    "node": "QualStmt"
+                                                  },
+                                                  {
+                                                    "node": "[]"
+                                                  }
+                                                ],
+                                                "node": "(:)"
+                                              }
+                                            ],
+                                            "node": "(:)"
+                                          }
+                                        ],
+                                        "node": "ListComp"
+                                      }
+                                    ],
+                                    "node": "UnGuardedRhs"
+                                  },
+                                  {
+                                    "node": "Nothing"
+                                  }
+                                ],
+                                "node": "PatBind"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "node": "()"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              "main"
+                                            ],
+                                            "node": "Ident"
+                                          },
+                                          {
+                                            "node": "[]"
+                                          }
+                                        ],
+                                        "node": "(:)"
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      },
+                                                      "IO"
+                                                    ],
+                                                    "node": "Ident"
+                                                  }
+                                                ],
+                                                "node": "UnQual"
+                                              }
+                                            ],
+                                            "node": "TyCon"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "node": "()"
+                                                      }
+                                                    ],
+                                                    "node": "UnitCon"
+                                                  }
+                                                ],
+                                                "node": "Special"
+                                              }
+                                            ],
+                                            "node": "TyCon"
+                                          }
+                                        ],
+                                        "node": "TyApp"
+                                      }
+                                    ],
+                                    "node": "TypeSig"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "children": [
+                                          {
+                                            "node": "()"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  "main"
+                                                ],
+                                                "node": "Ident"
+                                              }
+                                            ],
+                                            "node": "PVar"
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "node": "()"
+                                              },
+                                              {
+                                                "children": [
+                                                  {
+                                                    "node": "()"
+                                                  },
+                                                  {
+                                                    "children": [
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "node": "()"
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          "putStrLn"
+                                                                        ],
+                                                                        "node": "Ident"
+                                                                      }
+                                                                    ],
+                                                                    "node": "UnQual"
+                                                                  }
+                                                                ],
+                                                                "node": "Var"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      "--- Cross Join: All order-customer pairs ---",
+                                                                      "--- Cross Join: All order-customer pairs ---"
+                                                                    ],
+                                                                    "node": "String"
+                                                                  }
+                                                                ],
+                                                                "node": "Lit"
+                                                              }
+                                                            ],
+                                                            "node": "App"
+                                                          }
+                                                        ],
+                                                        "node": "Qualifier"
+                                                      },
+                                                      {
+                                                        "children": [
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "node": "()"
+                                                              },
+                                                              {
+                                                                "children": [
+                                                                  {
+                                                                    "node": "()"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              {
+                                                                                "children": [
+                                                                                  {
+                                                                                    "node": "()"
+                                                                                  },
+                                                                                  "mapM_"
+                                                                                ],
+                                                                                "node": "Ident"
+                                                                              }
+                                                                            ],
+                                                                            "node": "UnQual"
+                                                                          }
+                                                                        ],
+                                                                        "node": "Var"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              {
+                                                                                "children": [
+                                                                                  {
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "node": "()"
+                                                                                      },
+                                                                                      {
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "node": "()"
+                                                                                          },
+                                                                                          "entry"
+                                                                                        ],
+                                                                                        "node": "Ident"
+                                                                                      }
+                                                                                    ],
+                                                                                    "node": "PVar"
+                                                                                  },
+                                                                                  {
+                                                                                    "node": "[]"
+                                                                                  }
+                                                                                ],
+                                                                                "node": "(:)"
+                                                                              },
+                                                                              {
+                                                                                "children": [
+                                                                                  {
+                                                                                    "node": "()"
+                                                                                  },
+                                                                                  {
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "node": "()"
+                                                                                          },
+                                                                                          {
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "node": "()"
+                                                                                              },
+                                                                                              {
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "node": "()"
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "node": "()"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "node": "()"
+                                                                                                          },
+                                                                                                          "putStrLn"
+                                                                                                        ],
+                                                                                                        "node": "Ident"
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "node": "UnQual"
+                                                                                                  }
+                                                                                                ],
+                                                                                                "node": "Var"
+                                                                                              },
+                                                                                              {
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "node": "()"
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "node": "()"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "node": "()"
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "node": "()"
+                                                                                                              },
+                                                                                                              "Order",
+                                                                                                              "Order"
+                                                                                                            ],
+                                                                                                            "node": "String"
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "node": "Lit"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "node": "()"
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "node": "()"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "node": "()"
+                                                                                                                  },
+                                                                                                                  "++"
+                                                                                                                ],
+                                                                                                                "node": "Symbol"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "node": "UnQual"
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "node": "QVarOp"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "node": "()"
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "node": "()"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "node": "()"
+                                                                                                                  },
+                                                                                                                  " ",
+                                                                                                                  " "
+                                                                                                                ],
+                                                                                                                "node": "String"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "node": "Lit"
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "node": "()"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "node": "()"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      "++"
+                                                                                                                    ],
+                                                                                                                    "node": "Symbol"
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                "node": "UnQual"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "node": "QVarOp"
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "node": "()"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "node": "()"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  "show"
+                                                                                                                                ],
+                                                                                                                                "node": "Ident"
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "node": "UnQual"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "Var"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  "entry"
+                                                                                                                                ],
+                                                                                                                                "node": "Ident"
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "node": "UnQual"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "Var"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "App"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              "."
+                                                                                                                            ],
+                                                                                                                            "node": "Symbol"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "UnQual"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "QVarOp"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              "orderId"
+                                                                                                                            ],
+                                                                                                                            "node": "Ident"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "UnQual"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "Var"
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                "node": "InfixApp"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "node": "()"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          "++"
+                                                                                                                        ],
+                                                                                                                        "node": "Symbol"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "UnQual"
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                "node": "QVarOp"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "node": "()"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          " ",
+                                                                                                                          " "
+                                                                                                                        ],
+                                                                                                                        "node": "String"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "Lit"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              "++"
+                                                                                                                            ],
+                                                                                                                            "node": "Symbol"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "UnQual"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "QVarOp"
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "node": "()"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              "(customerId:",
+                                                                                                                              "(customerId:"
+                                                                                                                            ],
+                                                                                                                            "node": "String"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "Lit"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  "++"
+                                                                                                                                ],
+                                                                                                                                "node": "Symbol"
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "node": "UnQual"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "QVarOp"
+                                                                                                                      },
+                                                                                                                      {
+                                                                                                                        "children": [
+                                                                                                                          {
+                                                                                                                            "node": "()"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  " ",
+                                                                                                                                  " "
+                                                                                                                                ],
+                                                                                                                                "node": "String"
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "node": "Lit"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      "++"
+                                                                                                                                    ],
+                                                                                                                                    "node": "Symbol"
+                                                                                                                                  }
+                                                                                                                                ],
+                                                                                                                                "node": "UnQual"
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "node": "QVarOp"
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "children": [
+                                                                                                                              {
+                                                                                                                                "node": "()"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  "show"
+                                                                                                                                                ],
+                                                                                                                                                "node": "Ident"
+                                                                                                                                              }
+                                                                                                                                            ],
+                                                                                                                                            "node": "UnQual"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "Var"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  "entry"
+                                                                                                                                                ],
+                                                                                                                                                "node": "Ident"
+                                                                                                                                              }
+                                                                                                                                            ],
+                                                                                                                                            "node": "UnQual"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "Var"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "App"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              "."
+                                                                                                                                            ],
+                                                                                                                                            "node": "Symbol"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "UnQual"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "QVarOp"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              "orderCustomerId"
+                                                                                                                                            ],
+                                                                                                                                            "node": "Ident"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "UnQual"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "Var"
+                                                                                                                                  }
+                                                                                                                                ],
+                                                                                                                                "node": "InfixApp"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          "++"
+                                                                                                                                        ],
+                                                                                                                                        "node": "Symbol"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "UnQual"
+                                                                                                                                  }
+                                                                                                                                ],
+                                                                                                                                "node": "QVarOp"
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                "children": [
+                                                                                                                                  {
+                                                                                                                                    "node": "()"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          " ",
+                                                                                                                                          " "
+                                                                                                                                        ],
+                                                                                                                                        "node": "String"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "Lit"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              "++"
+                                                                                                                                            ],
+                                                                                                                                            "node": "Symbol"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "UnQual"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "QVarOp"
+                                                                                                                                  },
+                                                                                                                                  {
+                                                                                                                                    "children": [
+                                                                                                                                      {
+                                                                                                                                        "node": "()"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              ", total: $",
+                                                                                                                                              ", total: $"
+                                                                                                                                            ],
+                                                                                                                                            "node": "String"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "Lit"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  "++"
+                                                                                                                                                ],
+                                                                                                                                                "node": "Symbol"
+                                                                                                                                              }
+                                                                                                                                            ],
+                                                                                                                                            "node": "UnQual"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "QVarOp"
+                                                                                                                                      },
+                                                                                                                                      {
+                                                                                                                                        "children": [
+                                                                                                                                          {
+                                                                                                                                            "node": "()"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  " ",
+                                                                                                                                                  " "
+                                                                                                                                                ],
+                                                                                                                                                "node": "String"
+                                                                                                                                              }
+                                                                                                                                            ],
+                                                                                                                                            "node": "Lit"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      "++"
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "Symbol"
+                                                                                                                                                  }
+                                                                                                                                                ],
+                                                                                                                                                "node": "UnQual"
+                                                                                                                                              }
+                                                                                                                                            ],
+                                                                                                                                            "node": "QVarOp"
+                                                                                                                                          },
+                                                                                                                                          {
+                                                                                                                                            "children": [
+                                                                                                                                              {
+                                                                                                                                                "node": "()"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  "show"
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "Ident"
+                                                                                                                                                              }
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "UnQual"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "Var"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  "entry"
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "Ident"
+                                                                                                                                                              }
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "UnQual"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "Var"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "App"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              "."
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "Symbol"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "UnQual"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "QVarOp"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              "orderTotal"
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "Ident"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "UnQual"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "Var"
+                                                                                                                                                  }
+                                                                                                                                                ],
+                                                                                                                                                "node": "InfixApp"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          "++"
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "Symbol"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "UnQual"
+                                                                                                                                                  }
+                                                                                                                                                ],
+                                                                                                                                                "node": "QVarOp"
+                                                                                                                                              },
+                                                                                                                                              {
+                                                                                                                                                "children": [
+                                                                                                                                                  {
+                                                                                                                                                    "node": "()"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          " ",
+                                                                                                                                                          " "
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "String"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "Lit"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              "++"
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "Symbol"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "UnQual"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "QVarOp"
+                                                                                                                                                  },
+                                                                                                                                                  {
+                                                                                                                                                    "children": [
+                                                                                                                                                      {
+                                                                                                                                                        "node": "()"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              ") paired with",
+                                                                                                                                                              ") paired with"
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "String"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "Lit"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  "++"
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "Symbol"
+                                                                                                                                                              }
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "UnQual"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "QVarOp"
+                                                                                                                                                      },
+                                                                                                                                                      {
+                                                                                                                                                        "children": [
+                                                                                                                                                          {
+                                                                                                                                                            "node": "()"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  " ",
+                                                                                                                                                                  " "
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "String"
+                                                                                                                                                              }
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "Lit"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  {
+                                                                                                                                                                    "children": [
+                                                                                                                                                                      {
+                                                                                                                                                                        "node": "()"
+                                                                                                                                                                      },
+                                                                                                                                                                      "++"
+                                                                                                                                                                    ],
+                                                                                                                                                                    "node": "Symbol"
+                                                                                                                                                                  }
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "UnQual"
+                                                                                                                                                              }
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "QVarOp"
+                                                                                                                                                          },
+                                                                                                                                                          {
+                                                                                                                                                            "children": [
+                                                                                                                                                              {
+                                                                                                                                                                "node": "()"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  {
+                                                                                                                                                                    "children": [
+                                                                                                                                                                      {
+                                                                                                                                                                        "node": "()"
+                                                                                                                                                                      },
+                                                                                                                                                                      {
+                                                                                                                                                                        "children": [
+                                                                                                                                                                          {
+                                                                                                                                                                            "node": "()"
+                                                                                                                                                                          },
+                                                                                                                                                                          "entry"
+                                                                                                                                                                        ],
+                                                                                                                                                                        "node": "Ident"
+                                                                                                                                                                      }
+                                                                                                                                                                    ],
+                                                                                                                                                                    "node": "UnQual"
+                                                                                                                                                                  }
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "Var"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  {
+                                                                                                                                                                    "children": [
+                                                                                                                                                                      {
+                                                                                                                                                                        "node": "()"
+                                                                                                                                                                      },
+                                                                                                                                                                      {
+                                                                                                                                                                        "children": [
+                                                                                                                                                                          {
+                                                                                                                                                                            "node": "()"
+                                                                                                                                                                          },
+                                                                                                                                                                          "."
+                                                                                                                                                                        ],
+                                                                                                                                                                        "node": "Symbol"
+                                                                                                                                                                      }
+                                                                                                                                                                    ],
+                                                                                                                                                                    "node": "UnQual"
+                                                                                                                                                                  }
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "QVarOp"
+                                                                                                                                                              },
+                                                                                                                                                              {
+                                                                                                                                                                "children": [
+                                                                                                                                                                  {
+                                                                                                                                                                    "node": "()"
+                                                                                                                                                                  },
+                                                                                                                                                                  {
+                                                                                                                                                                    "children": [
+                                                                                                                                                                      {
+                                                                                                                                                                        "node": "()"
+                                                                                                                                                                      },
+                                                                                                                                                                      {
+                                                                                                                                                                        "children": [
+                                                                                                                                                                          {
+                                                                                                                                                                            "node": "()"
+                                                                                                                                                                          },
+                                                                                                                                                                          "pairedCustomerName"
+                                                                                                                                                                        ],
+                                                                                                                                                                        "node": "Ident"
+                                                                                                                                                                      }
+                                                                                                                                                                    ],
+                                                                                                                                                                    "node": "UnQual"
+                                                                                                                                                                  }
+                                                                                                                                                                ],
+                                                                                                                                                                "node": "Var"
+                                                                                                                                                              }
+                                                                                                                                                            ],
+                                                                                                                                                            "node": "InfixApp"
+                                                                                                                                                          }
+                                                                                                                                                        ],
+                                                                                                                                                        "node": "InfixApp"
+                                                                                                                                                      }
+                                                                                                                                                    ],
+                                                                                                                                                    "node": "InfixApp"
+                                                                                                                                                  }
+                                                                                                                                                ],
+                                                                                                                                                "node": "InfixApp"
+                                                                                                                                              }
+                                                                                                                                            ],
+                                                                                                                                            "node": "InfixApp"
+                                                                                                                                          }
+                                                                                                                                        ],
+                                                                                                                                        "node": "InfixApp"
+                                                                                                                                      }
+                                                                                                                                    ],
+                                                                                                                                    "node": "InfixApp"
+                                                                                                                                  }
+                                                                                                                                ],
+                                                                                                                                "node": "InfixApp"
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "node": "InfixApp"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "node": "InfixApp"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "node": "InfixApp"
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                "node": "InfixApp"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "node": "InfixApp"
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "node": "InfixApp"
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "node": "InfixApp"
+                                                                                                  }
+                                                                                                ],
+                                                                                                "node": "Paren"
+                                                                                              }
+                                                                                            ],
+                                                                                            "node": "App"
+                                                                                          }
+                                                                                        ],
+                                                                                        "node": "Qualifier"
+                                                                                      },
+                                                                                      {
+                                                                                        "node": "[]"
+                                                                                      }
+                                                                                    ],
+                                                                                    "node": "(:)"
+                                                                                  }
+                                                                                ],
+                                                                                "node": "Do"
+                                                                              }
+                                                                            ],
+                                                                            "node": "Lambda"
+                                                                          }
+                                                                        ],
+                                                                        "node": "Paren"
+                                                                      }
+                                                                    ],
+                                                                    "node": "App"
+                                                                  },
+                                                                  {
+                                                                    "children": [
+                                                                      {
+                                                                        "node": "()"
+                                                                      },
+                                                                      {
+                                                                        "children": [
+                                                                          {
+                                                                            "node": "()"
+                                                                          },
+                                                                          {
+                                                                            "children": [
+                                                                              {
+                                                                                "node": "()"
+                                                                              },
+                                                                              "result"
+                                                                            ],
+                                                                            "node": "Ident"
+                                                                          }
+                                                                        ],
+                                                                        "node": "UnQual"
+                                                                      }
+                                                                    ],
+                                                                    "node": "Var"
+                                                                  }
+                                                                ],
+                                                                "node": "App"
+                                                              }
+                                                            ],
+                                                            "node": "Qualifier"
+                                                          },
+                                                          {
+                                                            "node": "[]"
+                                                          }
+                                                        ],
+                                                        "node": "(:)"
+                                                      }
+                                                    ],
+                                                    "node": "(:)"
+                                                  }
+                                                ],
+                                                "node": "Do"
+                                              }
+                                            ],
+                                            "node": "UnGuardedRhs"
+                                          },
+                                          {
+                                            "node": "Nothing"
+                                          }
+                                        ],
+                                        "node": "PatBind"
+                                      },
+                                      {
+                                        "node": "[]"
+                                      }
+                                    ],
+                                    "node": "(:)"
+                                  }
+                                ],
+                                "node": "(:)"
+                              }
+                            ],
+                            "node": "(:)"
+                          }
+                        ],
+                        "node": "(:)"
+                      }
+                    ],
+                    "node": "(:)"
+                  }
+                ],
+                "node": "(:)"
+              }
+            ],
+            "node": "(:)"
+          }
+        ],
+        "node": "(:)"
+      }
+    ],
+    "node": "Module"
+  }
+}

--- a/tools/json-ast/x/haskell/inspect.go
+++ b/tools/json-ast/x/haskell/inspect.go
@@ -1,0 +1,67 @@
+package haskell
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+//go:embed parse.hs
+var parseScript string
+
+type Program struct {
+	AST json.RawMessage `json:"ast"`
+}
+
+// Inspect parses the given Haskell source code using runghc and
+// returns a Program describing its structure.
+func Inspect(src string) (*Program, error) {
+	if _, err := exec.LookPath("runghc"); err != nil {
+		return nil, fmt.Errorf("runghc not installed")
+	}
+	tmp, err := os.CreateTemp("", "hs-src-*.hs")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tmp.WriteString(src); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, err
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	script, err := os.CreateTemp("", "parse-*.hs")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := script.WriteString(parseScript); err != nil {
+		script.Close()
+		os.Remove(script.Name())
+		return nil, err
+	}
+	script.Close()
+	defer os.Remove(script.Name())
+
+	cmd := exec.Command("runghc", script.Name(), tmp.Name())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(errBuf.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%v: %s", err, msg)
+		}
+		return nil, err
+	}
+	var raw json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		return nil, err
+	}
+	return &Program{AST: raw}, nil
+}

--- a/tools/json-ast/x/haskell/inspect_test.go
+++ b/tools/json-ast/x/haskell/inspect_test.go
@@ -1,0 +1,89 @@
+//go:build slow
+
+package haskell_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	haskell "mochi/tools/json-ast/x/haskell"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureHaskell(t *testing.T) {
+	if _, err := exec.LookPath("runghc"); err != nil {
+		t.Skip("runghc not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureHaskell(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "hs")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "haskell")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.hs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".hs")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := haskell.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".hs.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}

--- a/tools/json-ast/x/haskell/parse.hs
+++ b/tools/json-ast/x/haskell/parse.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+import System.Environment (getArgs)
+import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.Aeson (encode, Value(..), object, (.=))
+import qualified Language.Haskell.Exts as H
+import Data.Data
+import Data.Text (pack)
+
+conv :: Data a => a -> Value
+conv x
+  | Just s <- cast x :: Maybe String = String (pack s)
+  | Just i <- cast x :: Maybe Int    = Number (fromIntegral i)
+  | Just i <- cast x :: Maybe Integer= Number (fromInteger i)
+  | Just b <- cast x :: Maybe Bool   = Bool b
+  | Just d <- cast x :: Maybe Double = Number (realToFrac d)
+  | otherwise =
+      let con = showConstr (toConstr x)
+          children = gmapQ conv x
+      in object (["node" .= con] ++ if null children then [] else ["children" .= children])
+
+main :: IO ()
+main = do
+  [file] <- getArgs
+  src <- readFile file
+  let mode = H.defaultParseMode { H.parseFilename = "" }
+  case H.parseModuleWithMode mode src of
+    H.ParseFailed loc msg -> error (show loc ++ msg)
+    H.ParseOk modul -> BL.putStrLn (encode (conv (fmap (const ()) modul)))


### PR DESCRIPTION
## Summary
- overhaul Haskell inspector to emit a generic AST
- emit raw AST JSON from the new parse script
- refresh golden for `cross_join`

## Testing
- `go test ./tools/json-ast/x/haskell -tags slow -run '^TestInspect_Golden/cross_join$' -update -v`


------
https://chatgpt.com/codex/tasks/task_e_6889869da4c48320a6433e9baaa45136