### PR TITLE
Add nested Prolog AST inspection

### DIFF
--- a/tests/json-ast/x/prolog/cross_join.prolog.json
+++ b/tests/json-ast/x/prolog/cross_join.prolog.json
@@ -1,0 +1,1339 @@
+{
+  "clauses": [
+    {
+      "name": ":-",
+      "params": [
+        "style_check(-singleton)"
+      ],
+      "goal": true,
+      "start": 0,
+      "end": 27
+    },
+    {
+      "name": ":-",
+      "params": [
+        "initialization main"
+      ],
+      "goal": true,
+      "start": 27,
+      "end": 52
+    },
+    {
+      "name": "main",
+      "params": [],
+      "goal": {
+        "args": [
+          {
+            "args": [
+              {
+                "var": "Customers"
+              },
+              [
+                {
+                  "args": [
+                    {
+                      "args": [
+                        {
+                          "args": [
+                            "id",
+                            1
+                          ],
+                          "functor": ":"
+                        },
+                        {
+                          "args": [
+                            "name",
+                            "Alice"
+                          ],
+                          "functor": ":"
+                        }
+                      ],
+                      "functor": ","
+                    }
+                  ],
+                  "functor": "{}"
+                },
+                {
+                  "args": [
+                    {
+                      "args": [
+                        {
+                          "args": [
+                            "id",
+                            2
+                          ],
+                          "functor": ":"
+                        },
+                        {
+                          "args": [
+                            "name",
+                            "Bob"
+                          ],
+                          "functor": ":"
+                        }
+                      ],
+                      "functor": ","
+                    }
+                  ],
+                  "functor": "{}"
+                },
+                {
+                  "args": [
+                    {
+                      "args": [
+                        {
+                          "args": [
+                            "id",
+                            3
+                          ],
+                          "functor": ":"
+                        },
+                        {
+                          "args": [
+                            "name",
+                            "Charlie"
+                          ],
+                          "functor": ":"
+                        }
+                      ],
+                      "functor": ","
+                    }
+                  ],
+                  "functor": "{}"
+                }
+              ]
+            ],
+            "functor": "="
+          },
+          {
+            "args": [
+              {
+                "args": [
+                  {
+                    "var": "Orders"
+                  },
+                  [
+                    {
+                      "args": [
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                "id",
+                                100
+                              ],
+                              "functor": ":"
+                            },
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "customerId",
+                                    1
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    "total",
+                                    250
+                                  ],
+                                  "functor": ":"
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": ","
+                        }
+                      ],
+                      "functor": "{}"
+                    },
+                    {
+                      "args": [
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                "id",
+                                101
+                              ],
+                              "functor": ":"
+                            },
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "customerId",
+                                    2
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    "total",
+                                    125
+                                  ],
+                                  "functor": ":"
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": ","
+                        }
+                      ],
+                      "functor": "{}"
+                    },
+                    {
+                      "args": [
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                "id",
+                                102
+                              ],
+                              "functor": ":"
+                            },
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "customerId",
+                                    1
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    "total",
+                                    300
+                                  ],
+                                  "functor": ":"
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": ","
+                        }
+                      ],
+                      "functor": "{}"
+                    }
+                  ]
+                ],
+                "functor": "="
+              },
+              {
+                "args": [
+                  {
+                    "args": [
+                      {
+                        "var": "Result"
+                      },
+                      [
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    100
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        1
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Alice"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            250
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    100
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        1
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Bob"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            250
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    100
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        1
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Charlie"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            250
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    101
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        2
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Alice"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            125
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    101
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        2
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Bob"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            125
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    101
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        2
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Charlie"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            125
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    102
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        1
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Alice"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            300
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    102
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        1
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Bob"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            300
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        },
+                        {
+                          "args": [
+                            {
+                              "args": [
+                                {
+                                  "args": [
+                                    "orderId",
+                                    102
+                                  ],
+                                  "functor": ":"
+                                },
+                                {
+                                  "args": [
+                                    {
+                                      "args": [
+                                        "orderCustomerId",
+                                        1
+                                      ],
+                                      "functor": ":"
+                                    },
+                                    {
+                                      "args": [
+                                        {
+                                          "args": [
+                                            "pairedCustomerName",
+                                            "Charlie"
+                                          ],
+                                          "functor": ":"
+                                        },
+                                        {
+                                          "args": [
+                                            "orderTotal",
+                                            300
+                                          ],
+                                          "functor": ":"
+                                        }
+                                      ],
+                                      "functor": ","
+                                    }
+                                  ],
+                                  "functor": ","
+                                }
+                              ],
+                              "functor": ","
+                            }
+                          ],
+                          "functor": "{}"
+                        }
+                      ]
+                    ],
+                    "functor": "="
+                  },
+                  {
+                    "args": [
+                      {
+                        "args": [
+                          "--- Cross Join: All order-customer pairs ---"
+                        ],
+                        "functor": "writeln"
+                      },
+                      {
+                        "args": [
+                          {
+                            "args": [
+                              {
+                                "var": "Entry"
+                              },
+                              {
+                                "args": [
+                                  {
+                                    "args": [
+                                      {
+                                        "args": [
+                                          "orderId",
+                                          100
+                                        ],
+                                        "functor": ":"
+                                      },
+                                      {
+                                        "args": [
+                                          {
+                                            "args": [
+                                              "orderCustomerId",
+                                              1
+                                            ],
+                                            "functor": ":"
+                                          },
+                                          {
+                                            "args": [
+                                              {
+                                                "args": [
+                                                  "pairedCustomerName",
+                                                  "Alice"
+                                                ],
+                                                "functor": ":"
+                                              },
+                                              {
+                                                "args": [
+                                                  "orderTotal",
+                                                  250
+                                                ],
+                                                "functor": ":"
+                                              }
+                                            ],
+                                            "functor": ","
+                                          }
+                                        ],
+                                        "functor": ","
+                                      }
+                                    ],
+                                    "functor": ","
+                                  }
+                                ],
+                                "functor": "{}"
+                              }
+                            ],
+                            "functor": "="
+                          },
+                          {
+                            "args": [
+                              {
+                                "args": [
+                                  "Order 100 (customerId: 1 , total: $ 250 ) paired with Alice"
+                                ],
+                                "functor": "writeln"
+                              },
+                              {
+                                "args": [
+                                  {
+                                    "args": [
+                                      {
+                                        "var": "Entry1"
+                                      },
+                                      {
+                                        "args": [
+                                          {
+                                            "args": [
+                                              {
+                                                "args": [
+                                                  "orderId",
+                                                  100
+                                                ],
+                                                "functor": ":"
+                                              },
+                                              {
+                                                "args": [
+                                                  {
+                                                    "args": [
+                                                      "orderCustomerId",
+                                                      1
+                                                    ],
+                                                    "functor": ":"
+                                                  },
+                                                  {
+                                                    "args": [
+                                                      {
+                                                        "args": [
+                                                          "pairedCustomerName",
+                                                          "Bob"
+                                                        ],
+                                                        "functor": ":"
+                                                      },
+                                                      {
+                                                        "args": [
+                                                          "orderTotal",
+                                                          250
+                                                        ],
+                                                        "functor": ":"
+                                                      }
+                                                    ],
+                                                    "functor": ","
+                                                  }
+                                                ],
+                                                "functor": ","
+                                              }
+                                            ],
+                                            "functor": ","
+                                          }
+                                        ],
+                                        "functor": "{}"
+                                      }
+                                    ],
+                                    "functor": "="
+                                  },
+                                  {
+                                    "args": [
+                                      {
+                                        "args": [
+                                          "Order 100 (customerId: 1 , total: $ 250 ) paired with Bob"
+                                        ],
+                                        "functor": "writeln"
+                                      },
+                                      {
+                                        "args": [
+                                          {
+                                            "args": [
+                                              {
+                                                "var": "Entry2"
+                                              },
+                                              {
+                                                "args": [
+                                                  {
+                                                    "args": [
+                                                      {
+                                                        "args": [
+                                                          "orderId",
+                                                          100
+                                                        ],
+                                                        "functor": ":"
+                                                      },
+                                                      {
+                                                        "args": [
+                                                          {
+                                                            "args": [
+                                                              "orderCustomerId",
+                                                              1
+                                                            ],
+                                                            "functor": ":"
+                                                          },
+                                                          {
+                                                            "args": [
+                                                              {
+                                                                "args": [
+                                                                  "pairedCustomerName",
+                                                                  "Charlie"
+                                                                ],
+                                                                "functor": ":"
+                                                              },
+                                                              {
+                                                                "args": [
+                                                                  "orderTotal",
+                                                                  250
+                                                                ],
+                                                                "functor": ":"
+                                                              }
+                                                            ],
+                                                            "functor": ","
+                                                          }
+                                                        ],
+                                                        "functor": ","
+                                                      }
+                                                    ],
+                                                    "functor": ","
+                                                  }
+                                                ],
+                                                "functor": "{}"
+                                              }
+                                            ],
+                                            "functor": "="
+                                          },
+                                          {
+                                            "args": [
+                                              {
+                                                "args": [
+                                                  "Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie"
+                                                ],
+                                                "functor": "writeln"
+                                              },
+                                              {
+                                                "args": [
+                                                  {
+                                                    "args": [
+                                                      {
+                                                        "var": "Entry3"
+                                                      },
+                                                      {
+                                                        "args": [
+                                                          {
+                                                            "args": [
+                                                              {
+                                                                "args": [
+                                                                  "orderId",
+                                                                  101
+                                                                ],
+                                                                "functor": ":"
+                                                              },
+                                                              {
+                                                                "args": [
+                                                                  {
+                                                                    "args": [
+                                                                      "orderCustomerId",
+                                                                      2
+                                                                    ],
+                                                                    "functor": ":"
+                                                                  },
+                                                                  {
+                                                                    "args": [
+                                                                      {
+                                                                        "args": [
+                                                                          "pairedCustomerName",
+                                                                          "Alice"
+                                                                        ],
+                                                                        "functor": ":"
+                                                                      },
+                                                                      {
+                                                                        "args": [
+                                                                          "orderTotal",
+                                                                          125
+                                                                        ],
+                                                                        "functor": ":"
+                                                                      }
+                                                                    ],
+                                                                    "functor": ","
+                                                                  }
+                                                                ],
+                                                                "functor": ","
+                                                              }
+                                                            ],
+                                                            "functor": ","
+                                                          }
+                                                        ],
+                                                        "functor": "{}"
+                                                      }
+                                                    ],
+                                                    "functor": "="
+                                                  },
+                                                  {
+                                                    "args": [
+                                                      {
+                                                        "args": [
+                                                          "Order 101 (customerId: 2 , total: $ 125 ) paired with Alice"
+                                                        ],
+                                                        "functor": "writeln"
+                                                      },
+                                                      {
+                                                        "args": [
+                                                          {
+                                                            "args": [
+                                                              {
+                                                                "var": "Entry4"
+                                                              },
+                                                              {
+                                                                "args": [
+                                                                  {
+                                                                    "args": [
+                                                                      {
+                                                                        "args": [
+                                                                          "orderId",
+                                                                          101
+                                                                        ],
+                                                                        "functor": ":"
+                                                                      },
+                                                                      {
+                                                                        "args": [
+                                                                          {
+                                                                            "args": [
+                                                                              "orderCustomerId",
+                                                                              2
+                                                                            ],
+                                                                            "functor": ":"
+                                                                          },
+                                                                          {
+                                                                            "args": [
+                                                                              {
+                                                                                "args": [
+                                                                                  "pairedCustomerName",
+                                                                                  "Bob"
+                                                                                ],
+                                                                                "functor": ":"
+                                                                              },
+                                                                              {
+                                                                                "args": [
+                                                                                  "orderTotal",
+                                                                                  125
+                                                                                ],
+                                                                                "functor": ":"
+                                                                              }
+                                                                            ],
+                                                                            "functor": ","
+                                                                          }
+                                                                        ],
+                                                                        "functor": ","
+                                                                      }
+                                                                    ],
+                                                                    "functor": ","
+                                                                  }
+                                                                ],
+                                                                "functor": "{}"
+                                                              }
+                                                            ],
+                                                            "functor": "="
+                                                          },
+                                                          {
+                                                            "args": [
+                                                              {
+                                                                "args": [
+                                                                  "Order 101 (customerId: 2 , total: $ 125 ) paired with Bob"
+                                                                ],
+                                                                "functor": "writeln"
+                                                              },
+                                                              {
+                                                                "args": [
+                                                                  {
+                                                                    "args": [
+                                                                      {
+                                                                        "var": "Entry5"
+                                                                      },
+                                                                      {
+                                                                        "args": [
+                                                                          {
+                                                                            "args": [
+                                                                              {
+                                                                                "args": [
+                                                                                  "orderId",
+                                                                                  101
+                                                                                ],
+                                                                                "functor": ":"
+                                                                              },
+                                                                              {
+                                                                                "args": [
+                                                                                  {
+                                                                                    "args": [
+                                                                                      "orderCustomerId",
+                                                                                      2
+                                                                                    ],
+                                                                                    "functor": ":"
+                                                                                  },
+                                                                                  {
+                                                                                    "args": [
+                                                                                      {
+                                                                                        "args": [
+                                                                                          "pairedCustomerName",
+                                                                                          "Charlie"
+                                                                                        ],
+                                                                                        "functor": ":"
+                                                                                      },
+                                                                                      {
+                                                                                        "args": [
+                                                                                          "orderTotal",
+                                                                                          125
+                                                                                        ],
+                                                                                        "functor": ":"
+                                                                                      }
+                                                                                    ],
+                                                                                    "functor": ","
+                                                                                  }
+                                                                                ],
+                                                                                "functor": ","
+                                                                              }
+                                                                            ],
+                                                                            "functor": ","
+                                                                          }
+                                                                        ],
+                                                                        "functor": "{}"
+                                                                      }
+                                                                    ],
+                                                                    "functor": "="
+                                                                  },
+                                                                  {
+                                                                    "args": [
+                                                                      {
+                                                                        "args": [
+                                                                          "Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie"
+                                                                        ],
+                                                                        "functor": "writeln"
+                                                                      },
+                                                                      {
+                                                                        "args": [
+                                                                          {
+                                                                            "args": [
+                                                                              {
+                                                                                "var": "Entry6"
+                                                                              },
+                                                                              {
+                                                                                "args": [
+                                                                                  {
+                                                                                    "args": [
+                                                                                      {
+                                                                                        "args": [
+                                                                                          "orderId",
+                                                                                          102
+                                                                                        ],
+                                                                                        "functor": ":"
+                                                                                      },
+                                                                                      {
+                                                                                        "args": [
+                                                                                          {
+                                                                                            "args": [
+                                                                                              "orderCustomerId",
+                                                                                              1
+                                                                                            ],
+                                                                                            "functor": ":"
+                                                                                          },
+                                                                                          {
+                                                                                            "args": [
+                                                                                              {
+                                                                                                "args": [
+                                                                                                  "pairedCustomerName",
+                                                                                                  "Alice"
+                                                                                                ],
+                                                                                                "functor": ":"
+                                                                                              },
+                                                                                              {
+                                                                                                "args": [
+                                                                                                  "orderTotal",
+                                                                                                  300
+                                                                                                ],
+                                                                                                "functor": ":"
+                                                                                              }
+                                                                                            ],
+                                                                                            "functor": ","
+                                                                                          }
+                                                                                        ],
+                                                                                        "functor": ","
+                                                                                      }
+                                                                                    ],
+                                                                                    "functor": ","
+                                                                                  }
+                                                                                ],
+                                                                                "functor": "{}"
+                                                                              }
+                                                                            ],
+                                                                            "functor": "="
+                                                                          },
+                                                                          {
+                                                                            "args": [
+                                                                              {
+                                                                                "args": [
+                                                                                  "Order 102 (customerId: 1 , total: $ 300 ) paired with Alice"
+                                                                                ],
+                                                                                "functor": "writeln"
+                                                                              },
+                                                                              {
+                                                                                "args": [
+                                                                                  {
+                                                                                    "args": [
+                                                                                      {
+                                                                                        "var": "Entry7"
+                                                                                      },
+                                                                                      {
+                                                                                        "args": [
+                                                                                          {
+                                                                                            "args": [
+                                                                                              {
+                                                                                                "args": [
+                                                                                                  "orderId",
+                                                                                                  102
+                                                                                                ],
+                                                                                                "functor": ":"
+                                                                                              },
+                                                                                              {
+                                                                                                "args": [
+                                                                                                  {
+                                                                                                    "args": [
+                                                                                                      "orderCustomerId",
+                                                                                                      1
+                                                                                                    ],
+                                                                                                    "functor": ":"
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "args": [
+                                                                                                      {
+                                                                                                        "args": [
+                                                                                                          "pairedCustomerName",
+                                                                                                          "Bob"
+                                                                                                        ],
+                                                                                                        "functor": ":"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "args": [
+                                                                                                          "orderTotal",
+                                                                                                          300
+                                                                                                        ],
+                                                                                                        "functor": ":"
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "functor": ","
+                                                                                                  }
+                                                                                                ],
+                                                                                                "functor": ","
+                                                                                              }
+                                                                                            ],
+                                                                                            "functor": ","
+                                                                                          }
+                                                                                        ],
+                                                                                        "functor": "{}"
+                                                                                      }
+                                                                                    ],
+                                                                                    "functor": "="
+                                                                                  },
+                                                                                  {
+                                                                                    "args": [
+                                                                                      {
+                                                                                        "args": [
+                                                                                          "Order 102 (customerId: 1 , total: $ 300 ) paired with Bob"
+                                                                                        ],
+                                                                                        "functor": "writeln"
+                                                                                      },
+                                                                                      {
+                                                                                        "args": [
+                                                                                          {
+                                                                                            "args": [
+                                                                                              {
+                                                                                                "var": "Entry8"
+                                                                                              },
+                                                                                              {
+                                                                                                "args": [
+                                                                                                  {
+                                                                                                    "args": [
+                                                                                                      {
+                                                                                                        "args": [
+                                                                                                          "orderId",
+                                                                                                          102
+                                                                                                        ],
+                                                                                                        "functor": ":"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "args": [
+                                                                                                          {
+                                                                                                            "args": [
+                                                                                                              "orderCustomerId",
+                                                                                                              1
+                                                                                                            ],
+                                                                                                            "functor": ":"
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "args": [
+                                                                                                              {
+                                                                                                                "args": [
+                                                                                                                  "pairedCustomerName",
+                                                                                                                  "Charlie"
+                                                                                                                ],
+                                                                                                                "functor": ":"
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "args": [
+                                                                                                                  "orderTotal",
+                                                                                                                  300
+                                                                                                                ],
+                                                                                                                "functor": ":"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "functor": ","
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "functor": ","
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "functor": ","
+                                                                                                  }
+                                                                                                ],
+                                                                                                "functor": "{}"
+                                                                                              }
+                                                                                            ],
+                                                                                            "functor": "="
+                                                                                          },
+                                                                                          {
+                                                                                            "args": [
+                                                                                              "Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie"
+                                                                                            ],
+                                                                                            "functor": "writeln"
+                                                                                          }
+                                                                                        ],
+                                                                                        "functor": ","
+                                                                                      }
+                                                                                    ],
+                                                                                    "functor": ","
+                                                                                  }
+                                                                                ],
+                                                                                "functor": ","
+                                                                              }
+                                                                            ],
+                                                                            "functor": ","
+                                                                          }
+                                                                        ],
+                                                                        "functor": ","
+                                                                      }
+                                                                    ],
+                                                                    "functor": ","
+                                                                  }
+                                                                ],
+                                                                "functor": ","
+                                                              }
+                                                            ],
+                                                            "functor": ","
+                                                          }
+                                                        ],
+                                                        "functor": ","
+                                                      }
+                                                    ],
+                                                    "functor": ","
+                                                  }
+                                                ],
+                                                "functor": ","
+                                              }
+                                            ],
+                                            "functor": ","
+                                          }
+                                        ],
+                                        "functor": ","
+                                      }
+                                    ],
+                                    "functor": ","
+                                  }
+                                ],
+                                "functor": ","
+                              }
+                            ],
+                            "functor": ","
+                          }
+                        ],
+                        "functor": ","
+                      }
+                    ],
+                    "functor": ","
+                  }
+                ],
+                "functor": ","
+              }
+            ],
+            "functor": ","
+          }
+        ],
+        "functor": ","
+      },
+      "start": 52,
+      "end": 2632
+    }
+  ]
+}

--- a/tests/transpiler/x/prolog/cross_join.pl
+++ b/tests/transpiler/x/prolog/cross_join.pl
@@ -1,0 +1,26 @@
+:- style_check(-singleton).
+:- initialization(main).
+
+main :-
+    Customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}, {id: 3, name: "Charlie"}],
+    Orders = [{id: 100, customerId: 1, total: 250}, {id: 101, customerId: 2, total: 125}, {id: 102, customerId: 1, total: 300}],
+    Result = [{orderId: 100, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 250}, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 250}, {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 250}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Alice", orderTotal: 125}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Bob", orderTotal: 125}, {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Charlie", orderTotal: 125}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 300}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 300}, {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 300}],
+    writeln("--- Cross Join: All order-customer pairs ---"),
+    Entry = {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 250},
+    writeln("Order 100 (customerId: 1 , total: $ 250 ) paired with Alice"),
+    Entry1 = {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 250},
+    writeln("Order 100 (customerId: 1 , total: $ 250 ) paired with Bob"),
+    Entry2 = {orderId: 100, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 250},
+    writeln("Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie"),
+    Entry3 = {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Alice", orderTotal: 125},
+    writeln("Order 101 (customerId: 2 , total: $ 125 ) paired with Alice"),
+    Entry4 = {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Bob", orderTotal: 125},
+    writeln("Order 101 (customerId: 2 , total: $ 125 ) paired with Bob"),
+    Entry5 = {orderId: 101, orderCustomerId: 2, pairedCustomerName: "Charlie", orderTotal: 125},
+    writeln("Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie"),
+    Entry6 = {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Alice", orderTotal: 300},
+    writeln("Order 102 (customerId: 1 , total: $ 300 ) paired with Alice"),
+    Entry7 = {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Bob", orderTotal: 300},
+    writeln("Order 102 (customerId: 1 , total: $ 300 ) paired with Bob"),
+    Entry8 = {orderId: 102, orderCustomerId: 1, pairedCustomerName: "Charlie", orderTotal: 300},
+    writeln("Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie").

--- a/tools/json-ast/x/prolog/inspect.go
+++ b/tools/json-ast/x/prolog/inspect.go
@@ -1,0 +1,186 @@
+package prolog
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+//go:embed pl_ast.pl
+var plScript string
+
+// Program represents a parsed Prolog source file.
+type Program struct {
+	Clauses []Clause `json:"clauses"`
+}
+
+// Term holds a generic Prolog term in raw JSON form.
+// Term represents a Prolog term.  It tries to decode the JSON produced by the
+// SWI-Prolog script into a more structured form.
+type Term struct {
+	// For variables {"var":"Name"}
+	Var string `json:"var,omitempty"`
+
+	// For compound terms {"functor":"=", "args":[...]}
+	Functor string `json:"functor,omitempty"`
+	Args    []Term `json:"args,omitempty"`
+
+	// For lists [a,b,c]
+	List []Term `json:"-"`
+
+	// For atoms or strings "foo"
+	Atom string `json:"-"`
+
+	// For numbers 1, 1.5 ...
+	Number *float64 `json:"-"`
+
+	// For booleans true/false
+	Bool *bool `json:"-"`
+}
+
+// UnmarshalJSON decodes the various JSON forms of a term.
+func (t *Term) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	// clear fields
+	t.Var = ""
+	t.Functor = ""
+	t.Args = nil
+	t.List = nil
+	t.Atom = ""
+	t.Number = nil
+	t.Bool = nil
+
+	switch b[0] {
+	case '{':
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return err
+		}
+		if v, ok := obj["var"]; ok {
+			if err := json.Unmarshal(v, &t.Var); err != nil {
+				return err
+			}
+			return nil
+		}
+		if f, ok := obj["functor"]; ok {
+			if err := json.Unmarshal(f, &t.Functor); err != nil {
+				return err
+			}
+			if a, ok := obj["args"]; ok {
+				if err := json.Unmarshal(a, &t.Args); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		// Treat as a dict object
+		for k, v := range obj {
+			var child Term
+			if err := json.Unmarshal(v, &child); err != nil {
+				return err
+			}
+			t.Functor = "{}"
+			t.Args = append(t.Args, Term{Functor: ":", Args: []Term{{Atom: k}, child}})
+		}
+		return nil
+	case '[':
+		return json.Unmarshal(b, &t.List)
+	case '"':
+		return json.Unmarshal(b, &t.Atom)
+	case 't', 'f':
+		// boolean literal
+		var v bool
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		t.Bool = &v
+		return nil
+	default:
+		var num float64
+		if err := json.Unmarshal(b, &num); err == nil {
+			t.Number = &num
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown term: %s", string(b))
+}
+
+// MarshalJSON encodes the term back to the JSON format understood by the
+// golden files.
+func (t Term) MarshalJSON() ([]byte, error) {
+	switch {
+	case t.Var != "":
+		return json.Marshal(struct {
+			Var string `json:"var"`
+		}{t.Var})
+	case t.Functor != "":
+		return json.Marshal(struct {
+			Args    []Term `json:"args,omitempty"`
+			Functor string `json:"functor"`
+		}{t.Args, t.Functor})
+	case t.List != nil:
+		return json.Marshal(t.List)
+	case t.Number != nil:
+		return json.Marshal(*t.Number)
+	case t.Bool != nil:
+		return json.Marshal(*t.Bool)
+	default:
+		return json.Marshal(t.Atom)
+	}
+}
+
+// Clause describes a single predicate clause.
+type Clause struct {
+	Name   string `json:"name"`
+	Params []Term `json:"params"`
+	Goal   Term   `json:"goal"`
+	Start  int    `json:"start"`
+	End    int    `json:"end"`
+}
+
+// Inspect parses the given Prolog source code using swipl and returns a Program describing its AST.
+func Inspect(src string) (*Program, error) {
+	exe := os.Getenv("SWIPL")
+	if exe == "" {
+		exe = "swipl"
+	}
+	if _, err := exec.LookPath(exe); err != nil {
+		return nil, fmt.Errorf("%s not installed", exe)
+	}
+
+	tmp, err := os.CreateTemp("", "pl-*.pl")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tmp.WriteString(plScript); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, err
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	cmd := exec.Command(exe, "-q", "-f", tmp.Name(), "-t", "main")
+	cmd.Stdin = strings.NewReader(src)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if errBuf.Len() > 0 {
+			return nil, fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
+		}
+		return nil, err
+	}
+
+	var prog Program
+	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
+}

--- a/tools/json-ast/x/prolog/inspect_test.go
+++ b/tools/json-ast/x/prolog/inspect_test.go
@@ -1,0 +1,93 @@
+//go:build slow
+
+package prolog_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	prolog "mochi/tools/json-ast/x/prolog"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureSWIPL(t *testing.T) {
+	exe := os.Getenv("SWIPL")
+	if exe == "" {
+		exe = "swipl"
+	}
+	if _, err := exec.LookPath(exe); err != nil {
+		t.Skip("swipl not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureSWIPL(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "prolog")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "prolog")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.pl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".pl")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := prolog.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".prolog.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}

--- a/tools/json-ast/x/prolog/pl_ast.pl
+++ b/tools/json-ast/x/prolog/pl_ast.pl
@@ -1,0 +1,74 @@
+:- use_module(library(http/json)).
+
+main :-
+    read_stream_to_codes(user_input, Codes),
+    open_chars_stream(Codes, S),
+    read_terms(S, Terms),
+    json_write_dict(current_output, _{clauses:Terms}),
+    nl,
+    close(S),
+    halt.
+
+read_terms(S, [C|Cs]) :-
+    stream_property(S, position(StartPos)),
+    read_term(S, Term, [variable_names(Vs), syntax_errors(quiet)]),
+    stream_property(S, position(EndPos)),
+    Term \== end_of_file, !,
+    clause_ast(Term, Vs, StartPos, EndPos, C),
+    read_terms(S, Cs).
+read_terms(_, []).
+
+clause_ast((Head :- Body), Vs, Start, End, Dict) :-
+    head_info(Head, Vs, Name, Params),
+    term_json(Vs, Body, Goal),
+    stream_position_data(char_count, Start, StartChar),
+    stream_position_data(char_count, End, EndChar),
+    Dict = _{name:Name, params:Params, goal:Goal, start:StartChar, end:EndChar}.
+clause_ast(Head, Vs, Start, End, Dict) :-
+    head_info(Head, Vs, Name, Params),
+    stream_position_data(char_count, Start, StartChar),
+    stream_position_data(char_count, End, EndChar),
+    Dict = _{name:Name, params:Params, goal:true, start:StartChar, end:EndChar}.
+
+head_info(Term, Vs, Name, Params) :-
+    Term =.. [Name|Args],
+    maplist(arg_name(Vs), Args, Params).
+
+arg_name(Vs, Var, Name) :- var(Var), !,
+    var_name(Vs, Var, Name).
+arg_name(_, Term, Name) :-
+    ( number(Term) -> Name = Term
+    ; string(Term) -> Name = Term
+    ; with_output_to(string(S), write_term(Term, [quoted(true),fullstop(false),spacing(next_argument)])),
+      normalize_space(atom(Name), S)
+    ).
+
+var_name(Vs, Var, Name) :-
+    ( member(Name0=Var0, Vs), Var == Var0 -> Name = Name0 ; Name = '_' ).
+
+term_json(Vs, Term, JSON) :-
+    var(Term), !,
+    var_name(Vs, Term, Name),
+    JSON = _{var:Name}.
+term_json(_, Term, Term) :-
+    ( number(Term) ; string(Term) ), !.
+term_json(_, Term, Atom) :-
+    atom(Term), !,
+    Atom = Term.
+term_json(Vs, Term, List) :-
+    is_list(Term), !,
+    maplist(term_json(Vs), Term, List).
+term_json(Vs, Term, Dict) :-
+    is_dict(Term), !,
+    dict_pairs(Term, Tag, Pairs),
+    maplist(pair_json(Vs), Pairs, JsonPairs),
+    dict_create(Dict, Tag, JsonPairs).
+term_json(Vs, Term, Dict) :-
+    Term =.. [F|Args],
+    maplist(term_json(Vs), Args, JArgs),
+    Dict = _{functor:F, args:JArgs}.
+
+pair_json(Vs, K-V, K-J) :-
+    term_json(Vs, V, J).
+
+:- initialization(main, main).


### PR DESCRIPTION
## Summary
- add support for nested Prolog AST representation
- record clause bodies as structured goals
- store raw JSON for terms to preserve full structure
- regenerate golden file for sample Prolog program

## Testing
- `go test ./tools/json-ast/x/prolog -run TestInspect_Golden -update -tags slow`
- `go test ./tools/json-ast/x/prolog -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_688986a8e2088320ba56727b4066af66