### PR TITLE
Improve Racket inspector types

### DIFF
--- a/tools/json-ast/x/rkt/inspect.go
+++ b/tools/json-ast/x/rkt/inspect.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
@@ -17,14 +18,115 @@ var racketParser string
 
 // Form represents a top-level form parsed from Racket source.
 type Form struct {
-	Datum any `json:"datum"`
-	Line  int `json:"line"`
-	Col   int `json:"col"`
+	Datum *Datum `json:"datum"`
+	Line  int    `json:"line"`
+	Col   int    `json:"col"`
 }
 
 // Program represents a parsed Racket source file.
 type Program struct {
 	Forms []Form `json:"forms"`
+}
+
+// DatumKind describes the type of value stored in a Datum.
+type DatumKind int
+
+const (
+	kindSymbol DatumKind = iota
+	kindList
+	kindString
+	kindNumber
+	kindBool
+	kindNull
+)
+
+// Datum represents a parsed Racket datum in a type-safe manner.
+type Datum struct {
+	Kind DatumKind
+	Sym  string
+	List []*Datum
+	Str  string
+	Num  json.Number
+	Bool bool
+}
+
+func (d Datum) MarshalJSON() ([]byte, error) {
+	switch d.Kind {
+	case kindSymbol:
+		return json.Marshal(map[string]string{"sym": d.Sym})
+	case kindList:
+		return json.Marshal(d.List)
+	case kindString:
+		return json.Marshal(d.Str)
+	case kindNumber:
+		return json.Marshal(d.Num)
+	case kindBool:
+		return json.Marshal(d.Bool)
+	case kindNull:
+		return []byte("null"), nil
+	default:
+		return []byte("null"), nil
+	}
+}
+
+func (d *Datum) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
+		return err
+	}
+	nd, err := datumFromIface(v)
+	if err != nil {
+		return err
+	}
+	*d = nd
+	return nil
+}
+
+func datumFromIface(v interface{}) (Datum, error) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		if s, ok := val["sym"]; ok && len(val) == 1 {
+			return Datum{Kind: kindSymbol, Sym: fmt.Sprint(s)}, nil
+		}
+		// Treat generic objects as list of key/value pairs.
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		list := make([]*Datum, 0, len(val)*2)
+		for _, k := range keys {
+			kd := Datum{Kind: kindString, Str: k}
+			vd, err := datumFromIface(val[k])
+			if err != nil {
+				return Datum{}, err
+			}
+			list = append(list, &kd, &vd)
+		}
+		return Datum{Kind: kindList, List: list}, nil
+	case []interface{}:
+		list := make([]*Datum, len(val))
+		for i, e := range val {
+			child, err := datumFromIface(e)
+			if err != nil {
+				return Datum{}, err
+			}
+			list[i] = &child
+		}
+		return Datum{Kind: kindList, List: list}, nil
+	case string:
+		return Datum{Kind: kindString, Str: val}, nil
+	case json.Number:
+		return Datum{Kind: kindNumber, Num: val}, nil
+	case bool:
+		return Datum{Kind: kindBool, Bool: val}, nil
+	case nil:
+		return Datum{Kind: kindNull}, nil
+	default:
+		return Datum{Kind: kindString, Str: fmt.Sprint(val)}, nil
+	}
 }
 
 // Inspect parses the provided Racket source code and returns a Program
@@ -63,9 +165,21 @@ func parse(src string) (*Program, error) {
 		}
 		return nil, err
 	}
-	var forms []Form
-	if err := json.Unmarshal(out.Bytes(), &forms); err != nil {
+	var rawForms []struct {
+		Datum json.RawMessage `json:"datum"`
+		Line  int             `json:"line"`
+		Col   int             `json:"col"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &rawForms); err != nil {
 		return nil, err
+	}
+	forms := make([]Form, len(rawForms))
+	for i, rf := range rawForms {
+		var d Datum
+		if err := json.Unmarshal(rf.Datum, &d); err != nil {
+			return nil, err
+		}
+		forms[i] = Form{Datum: &d, Line: rf.Line, Col: rf.Col}
 	}
 	return &Program{Forms: forms}, nil
 }


### PR DESCRIPTION
## Summary
- add a typed `Datum` structure for Racket AST inspection
- convert parsed forms into `Datum` and keep JSON output unchanged

## Testing
- `go test ./tools/json-ast/x/rkt -run TestInspect_Golden -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_688986acc19c832099d5a402560dec2b