### PR TITLE
Add tree-sitter-based Rust AST

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/marcboeker/go-duckdb v1.8.5
 	github.com/mark3labs/mcp-go v0.36.0
 	github.com/mattn/go-sqlite3 v1.14.28
+	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tliron/commonlog v0.2.20

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFRh6zSQ=
 github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=

--- a/tests/json-ast/x/rs/append_builtin.rs.json
+++ b/tests/json-ast/x/rs/append_builtin.rs.json
@@ -1,601 +1,199 @@
 {
   "file": {
-    "kind": "SOURCE_FILE",
+    "kind": "source_file",
     "start": 0,
     "end": 179,
     "children": [
       {
-        "kind": "FN",
+        "kind": "line_comment",
         "start": 0,
+        "end": 67
+      },
+      {
+        "kind": "function_item",
+        "start": 68,
         "end": 178,
         "children": [
           {
-            "kind": "COMMENT",
-            "start": 0,
-            "end": 67
-          },
-          {
-            "kind": "WHITESPACE",
-            "start": 67,
-            "end": 68
-          },
-          {
-            "kind": "FN_KW",
-            "start": 68,
-            "end": 70
-          },
-          {
-            "kind": "WHITESPACE",
-            "start": 70,
-            "end": 71
-          },
-          {
-            "kind": "NAME",
+            "kind": "identifier",
             "start": 71,
-            "end": 75,
-            "children": [
-              {
-                "kind": "IDENT",
-                "start": 71,
-                "end": 75
-              }
-            ]
+            "end": 75
           },
           {
-            "kind": "PARAM_LIST",
+            "kind": "parameters",
             "start": 75,
-            "end": 77,
-            "children": [
-              {
-                "kind": "L_PAREN",
-                "start": 75,
-                "end": 76
-              },
-              {
-                "kind": "R_PAREN",
-                "start": 76,
-                "end": 77
-              }
-            ]
+            "end": 77
           },
           {
-            "kind": "WHITESPACE",
-            "start": 77,
-            "end": 78
-          },
-          {
-            "kind": "BLOCK_EXPR",
+            "kind": "block",
             "start": 78,
             "end": 178,
             "children": [
               {
-                "kind": "STMT_LIST",
-                "start": 78,
-                "end": 178,
+                "kind": "let_declaration",
+                "start": 84,
+                "end": 113,
                 "children": [
                   {
-                    "kind": "L_CURLY",
-                    "start": 78,
-                    "end": 79
+                    "kind": "identifier",
+                    "start": 88,
+                    "end": 89
                   },
                   {
-                    "kind": "WHITESPACE",
-                    "start": 79,
-                    "end": 84
-                  },
-                  {
-                    "kind": "LET_STMT",
-                    "start": 84,
-                    "end": 113,
+                    "kind": "generic_type",
+                    "start": 91,
+                    "end": 99,
                     "children": [
                       {
-                        "kind": "LET_KW",
-                        "start": 84,
-                        "end": 87
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 87,
-                        "end": 88
-                      },
-                      {
-                        "kind": "IDENT_PAT",
-                        "start": 88,
-                        "end": 89,
-                        "children": [
-                          {
-                            "kind": "NAME",
-                            "start": 88,
-                            "end": 89,
-                            "children": [
-                              {
-                                "kind": "IDENT",
-                                "start": 88,
-                                "end": 89
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "COLON",
-                        "start": 89,
-                        "end": 90
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 90,
-                        "end": 91
-                      },
-                      {
-                        "kind": "PATH_TYPE",
+                        "kind": "type_identifier",
                         "start": 91,
+                        "end": 94
+                      },
+                      {
+                        "kind": "type_arguments",
+                        "start": 94,
                         "end": 99,
                         "children": [
                           {
-                            "kind": "PATH",
-                            "start": 91,
-                            "end": 99,
-                            "children": [
-                              {
-                                "kind": "PATH_SEGMENT",
-                                "start": 91,
-                                "end": 99,
-                                "children": [
-                                  {
-                                    "kind": "NAME_REF",
-                                    "start": 91,
-                                    "end": 94,
-                                    "children": [
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 91,
-                                        "end": 94
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "GENERIC_ARG_LIST",
-                                    "start": 94,
-                                    "end": 99,
-                                    "children": [
-                                      {
-                                        "kind": "L_ANGLE",
-                                        "start": 94,
-                                        "end": 95
-                                      },
-                                      {
-                                        "kind": "TYPE_ARG",
-                                        "start": 95,
-                                        "end": 98,
-                                        "children": [
-                                          {
-                                            "kind": "PATH_TYPE",
-                                            "start": 95,
-                                            "end": 98,
-                                            "children": [
-                                              {
-                                                "kind": "PATH",
-                                                "start": 95,
-                                                "end": 98,
-                                                "children": [
-                                                  {
-                                                    "kind": "PATH_SEGMENT",
-                                                    "start": 95,
-                                                    "end": 98,
-                                                    "children": [
-                                                      {
-                                                        "kind": "NAME_REF",
-                                                        "start": 95,
-                                                        "end": 98,
-                                                        "children": [
-                                                          {
-                                                            "kind": "IDENT",
-                                                            "start": 95,
-                                                            "end": 98
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "R_ANGLE",
-                                        "start": 98,
-                                        "end": 99
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
+                            "kind": "primitive_type",
+                            "start": 95,
+                            "end": 98
                           }
                         ]
-                      },
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "macro_invocation",
+                    "start": 102,
+                    "end": 112,
+                    "children": [
                       {
-                        "kind": "WHITESPACE",
-                        "start": 99,
-                        "end": 100
-                      },
-                      {
-                        "kind": "EQ",
-                        "start": 100,
-                        "end": 101
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 101,
-                        "end": 102
-                      },
-                      {
-                        "kind": "MACRO_EXPR",
+                        "kind": "identifier",
                         "start": 102,
+                        "end": 105
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 106,
                         "end": 112,
                         "children": [
                           {
-                            "kind": "MACRO_CALL",
-                            "start": 102,
-                            "end": 112,
-                            "children": [
-                              {
-                                "kind": "PATH",
-                                "start": 102,
-                                "end": 105,
-                                "children": [
-                                  {
-                                    "kind": "PATH_SEGMENT",
-                                    "start": 102,
-                                    "end": 105,
-                                    "children": [
-                                      {
-                                        "kind": "NAME_REF",
-                                        "start": 102,
-                                        "end": 105,
-                                        "children": [
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 102,
-                                            "end": 105
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "BANG",
-                                "start": 105,
-                                "end": 106
-                              },
-                              {
-                                "kind": "TOKEN_TREE",
-                                "start": 106,
-                                "end": 112,
-                                "children": [
-                                  {
-                                    "kind": "L_BRACK",
-                                    "start": 106,
-                                    "end": 107
-                                  },
-                                  {
-                                    "kind": "INT_NUMBER",
-                                    "start": 107,
-                                    "end": 108
-                                  },
-                                  {
-                                    "kind": "COMMA",
-                                    "start": 108,
-                                    "end": 109
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 109,
-                                    "end": 110
-                                  },
-                                  {
-                                    "kind": "INT_NUMBER",
-                                    "start": 110,
-                                    "end": 111
-                                  },
-                                  {
-                                    "kind": "R_BRACK",
-                                    "start": 111,
-                                    "end": 112
-                                  }
-                                ]
-                              }
-                            ]
+                            "kind": "integer_literal",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "integer_literal",
+                            "start": 110,
+                            "end": 111
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 112,
-                        "end": 113
                       }
                     ]
-                  },
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 118,
+                "end": 176,
+                "children": [
                   {
-                    "kind": "WHITESPACE",
-                    "start": 113,
-                    "end": 118
-                  },
-                  {
-                    "kind": "EXPR_STMT",
+                    "kind": "macro_invocation",
                     "start": 118,
-                    "end": 176,
+                    "end": 175,
                     "children": [
                       {
-                        "kind": "MACRO_EXPR",
+                        "kind": "identifier",
                         "start": 118,
+                        "end": 125
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 126,
                         "end": 175,
                         "children": [
                           {
-                            "kind": "MACRO_CALL",
-                            "start": 118,
-                            "end": 175,
+                            "kind": "string_literal",
+                            "start": 127,
+                            "end": 133,
                             "children": [
                               {
-                                "kind": "PATH",
-                                "start": 118,
-                                "end": 125,
+                                "kind": "string_content",
+                                "start": 128,
+                                "end": 132
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 135,
+                            "end": 174,
+                            "children": [
+                              {
+                                "kind": "mutable_specifier",
+                                "start": 141,
+                                "end": 144
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 145,
+                                "end": 146
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 149,
+                                "end": 150
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 151,
+                                "end": 156
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 156,
+                                "end": 158
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 160,
+                                "end": 161
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 162,
+                                "end": 166
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 166,
+                                "end": 169,
                                 "children": [
                                   {
-                                    "kind": "PATH_SEGMENT",
-                                    "start": 118,
-                                    "end": 125,
-                                    "children": [
-                                      {
-                                        "kind": "NAME_REF",
-                                        "start": 118,
-                                        "end": 125,
-                                        "children": [
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 118,
-                                            "end": 125
-                                          }
-                                        ]
-                                      }
-                                    ]
+                                    "kind": "integer_literal",
+                                    "start": 167,
+                                    "end": 168
                                   }
                                 ]
                               },
                               {
-                                "kind": "BANG",
-                                "start": 125,
-                                "end": 126
-                              },
-                              {
-                                "kind": "TOKEN_TREE",
-                                "start": 126,
-                                "end": 175,
-                                "children": [
-                                  {
-                                    "kind": "L_PAREN",
-                                    "start": 126,
-                                    "end": 127
-                                  },
-                                  {
-                                    "kind": "STRING",
-                                    "start": 127,
-                                    "end": 133
-                                  },
-                                  {
-                                    "kind": "COMMA",
-                                    "start": 133,
-                                    "end": 134
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 134,
-                                    "end": 135
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 135,
-                                    "end": 174,
-                                    "children": [
-                                      {
-                                        "kind": "L_CURLY",
-                                        "start": 135,
-                                        "end": 136
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 136,
-                                        "end": 137
-                                      },
-                                      {
-                                        "kind": "LET_KW",
-                                        "start": 137,
-                                        "end": 140
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 140,
-                                        "end": 141
-                                      },
-                                      {
-                                        "kind": "MUT_KW",
-                                        "start": 141,
-                                        "end": 144
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 144,
-                                        "end": 145
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 145,
-                                        "end": 146
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 146,
-                                        "end": 147
-                                      },
-                                      {
-                                        "kind": "EQ",
-                                        "start": 147,
-                                        "end": 148
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 148,
-                                        "end": 149
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 149,
-                                        "end": 150
-                                      },
-                                      {
-                                        "kind": "DOT",
-                                        "start": 150,
-                                        "end": 151
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 151,
-                                        "end": 156
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 156,
-                                        "end": 158,
-                                        "children": [
-                                          {
-                                            "kind": "L_PAREN",
-                                            "start": 156,
-                                            "end": 157
-                                          },
-                                          {
-                                            "kind": "R_PAREN",
-                                            "start": 157,
-                                            "end": 158
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "SEMICOLON",
-                                        "start": 158,
-                                        "end": 159
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 159,
-                                        "end": 160
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 160,
-                                        "end": 161
-                                      },
-                                      {
-                                        "kind": "DOT",
-                                        "start": 161,
-                                        "end": 162
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 162,
-                                        "end": 166
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 166,
-                                        "end": 169,
-                                        "children": [
-                                          {
-                                            "kind": "L_PAREN",
-                                            "start": 166,
-                                            "end": 167
-                                          },
-                                          {
-                                            "kind": "INT_NUMBER",
-                                            "start": 167,
-                                            "end": 168
-                                          },
-                                          {
-                                            "kind": "R_PAREN",
-                                            "start": 168,
-                                            "end": 169
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "SEMICOLON",
-                                        "start": 169,
-                                        "end": 170
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 170,
-                                        "end": 171
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 171,
-                                        "end": 172
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 172,
-                                        "end": 173
-                                      },
-                                      {
-                                        "kind": "R_CURLY",
-                                        "start": 173,
-                                        "end": 174
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "R_PAREN",
-                                    "start": 174,
-                                    "end": 175
-                                  }
-                                ]
+                                "kind": "identifier",
+                                "start": 171,
+                                "end": 172
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 175,
-                        "end": 176
                       }
                     ]
-                  },
-                  {
-                    "kind": "WHITESPACE",
-                    "start": 176,
-                    "end": 177
-                  },
-                  {
-                    "kind": "R_CURLY",
-                    "start": 177,
-                    "end": 178
                   }
                 ]
               }
             ]
           }
         ]
-      },
-      {
-        "kind": "WHITESPACE",
-        "start": 178,
-        "end": 179
       }
     ]
   }

--- a/tests/json-ast/x/rs/avg_builtin.rs.json
+++ b/tests/json-ast/x/rs/avg_builtin.rs.json
@@ -1,571 +1,198 @@
 {
   "file": {
-    "kind": "SOURCE_FILE",
+    "kind": "source_file",
     "start": 0,
     "end": 196,
     "children": [
       {
-        "kind": "FN",
+        "kind": "line_comment",
         "start": 0,
+        "end": 67
+      },
+      {
+        "kind": "function_item",
+        "start": 68,
         "end": 195,
         "children": [
           {
-            "kind": "COMMENT",
-            "start": 0,
-            "end": 67
-          },
-          {
-            "kind": "WHITESPACE",
-            "start": 67,
-            "end": 68
-          },
-          {
-            "kind": "FN_KW",
-            "start": 68,
-            "end": 70
-          },
-          {
-            "kind": "WHITESPACE",
-            "start": 70,
-            "end": 71
-          },
-          {
-            "kind": "NAME",
+            "kind": "identifier",
             "start": 71,
-            "end": 75,
-            "children": [
-              {
-                "kind": "IDENT",
-                "start": 71,
-                "end": 75
-              }
-            ]
+            "end": 75
           },
           {
-            "kind": "PARAM_LIST",
+            "kind": "parameters",
             "start": 75,
-            "end": 77,
-            "children": [
-              {
-                "kind": "L_PAREN",
-                "start": 75,
-                "end": 76
-              },
-              {
-                "kind": "R_PAREN",
-                "start": 76,
-                "end": 77
-              }
-            ]
+            "end": 77
           },
           {
-            "kind": "WHITESPACE",
-            "start": 77,
-            "end": 78
-          },
-          {
-            "kind": "BLOCK_EXPR",
+            "kind": "block",
             "start": 78,
             "end": 195,
             "children": [
               {
-                "kind": "STMT_LIST",
-                "start": 78,
-                "end": 195,
+                "kind": "expression_statement",
+                "start": 84,
+                "end": 193,
                 "children": [
                   {
-                    "kind": "L_CURLY",
-                    "start": 78,
-                    "end": 79
-                  },
-                  {
-                    "kind": "WHITESPACE",
-                    "start": 79,
-                    "end": 84
-                  },
-                  {
-                    "kind": "EXPR_STMT",
+                    "kind": "macro_invocation",
                     "start": 84,
-                    "end": 193,
+                    "end": 192,
                     "children": [
                       {
-                        "kind": "MACRO_EXPR",
+                        "kind": "identifier",
                         "start": 84,
+                        "end": 91
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 92,
                         "end": 192,
                         "children": [
                           {
-                            "kind": "MACRO_CALL",
-                            "start": 84,
-                            "end": 192,
+                            "kind": "string_literal",
+                            "start": 93,
+                            "end": 97,
                             "children": [
                               {
-                                "kind": "PATH",
-                                "start": 84,
-                                "end": 91,
+                                "kind": "string_content",
+                                "start": 94,
+                                "end": 96
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 99,
+                            "end": 191,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 105,
+                                "end": 108
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 111,
+                                "end": 114
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 115,
+                                "end": 124,
                                 "children": [
                                   {
-                                    "kind": "PATH_SEGMENT",
-                                    "start": 84,
-                                    "end": 91,
-                                    "children": [
-                                      {
-                                        "kind": "NAME_REF",
-                                        "start": 84,
-                                        "end": 91,
-                                        "children": [
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 84,
-                                            "end": 91
-                                          }
-                                        ]
-                                      }
-                                    ]
+                                    "kind": "integer_literal",
+                                    "start": 116,
+                                    "end": 117
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 119,
+                                    "end": 120
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 122,
+                                    "end": 123
                                   }
                                 ]
                               },
                               {
-                                "kind": "BANG",
-                                "start": 91,
-                                "end": 92
+                                "kind": "identifier",
+                                "start": 126,
+                                "end": 129
                               },
                               {
-                                "kind": "TOKEN_TREE",
-                                "start": 92,
-                                "end": 192,
+                                "kind": "identifier",
+                                "start": 130,
+                                "end": 134
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 134,
+                                "end": 136
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 137,
+                                "end": 140
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 140,
+                                "end": 155,
                                 "children": [
                                   {
-                                    "kind": "L_PAREN",
-                                    "start": 92,
-                                    "end": 93
+                                    "kind": "identifier",
+                                    "start": 142,
+                                    "end": 143
                                   },
                                   {
-                                    "kind": "STRING",
-                                    "start": 93,
-                                    "end": 97
+                                    "kind": "identifier",
+                                    "start": 146,
+                                    "end": 147
                                   },
                                   {
-                                    "kind": "COMMA",
-                                    "start": 97,
-                                    "end": 98
+                                    "kind": "primitive_type",
+                                    "start": 151,
+                                    "end": 154
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 156,
+                                "end": 159
+                              },
+                              {
+                                "kind": "primitive_type",
+                                "start": 162,
+                                "end": 165
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 166,
+                                "end": 168
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 171,
+                                "end": 189,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 172,
+                                    "end": 175
                                   },
                                   {
-                                    "kind": "WHITESPACE",
-                                    "start": 98,
-                                    "end": 99
+                                    "kind": "identifier",
+                                    "start": 176,
+                                    "end": 179
                                   },
                                   {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 99,
-                                    "end": 191,
-                                    "children": [
-                                      {
-                                        "kind": "L_CURLY",
-                                        "start": 99,
-                                        "end": 100
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 100,
-                                        "end": 101
-                                      },
-                                      {
-                                        "kind": "LET_KW",
-                                        "start": 101,
-                                        "end": 104
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 104,
-                                        "end": 105
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 105,
-                                        "end": 108
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 108,
-                                        "end": 109
-                                      },
-                                      {
-                                        "kind": "EQ",
-                                        "start": 109,
-                                        "end": 110
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 110,
-                                        "end": 111
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 111,
-                                        "end": 114
-                                      },
-                                      {
-                                        "kind": "BANG",
-                                        "start": 114,
-                                        "end": 115
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 115,
-                                        "end": 124,
-                                        "children": [
-                                          {
-                                            "kind": "L_BRACK",
-                                            "start": 115,
-                                            "end": 116
-                                          },
-                                          {
-                                            "kind": "INT_NUMBER",
-                                            "start": 116,
-                                            "end": 117
-                                          },
-                                          {
-                                            "kind": "COMMA",
-                                            "start": 117,
-                                            "end": 118
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 118,
-                                            "end": 119
-                                          },
-                                          {
-                                            "kind": "INT_NUMBER",
-                                            "start": 119,
-                                            "end": 120
-                                          },
-                                          {
-                                            "kind": "COMMA",
-                                            "start": 120,
-                                            "end": 121
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 121,
-                                            "end": 122
-                                          },
-                                          {
-                                            "kind": "INT_NUMBER",
-                                            "start": 122,
-                                            "end": 123
-                                          },
-                                          {
-                                            "kind": "R_BRACK",
-                                            "start": 123,
-                                            "end": 124
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "SEMICOLON",
-                                        "start": 124,
-                                        "end": 125
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 125,
-                                        "end": 126
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 126,
-                                        "end": 129
-                                      },
-                                      {
-                                        "kind": "DOT",
-                                        "start": 129,
-                                        "end": 130
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 130,
-                                        "end": 134
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 134,
-                                        "end": 136,
-                                        "children": [
-                                          {
-                                            "kind": "L_PAREN",
-                                            "start": 134,
-                                            "end": 135
-                                          },
-                                          {
-                                            "kind": "R_PAREN",
-                                            "start": 135,
-                                            "end": 136
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "DOT",
-                                        "start": 136,
-                                        "end": 137
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 137,
-                                        "end": 140
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 140,
-                                        "end": 155,
-                                        "children": [
-                                          {
-                                            "kind": "L_PAREN",
-                                            "start": 140,
-                                            "end": 141
-                                          },
-                                          {
-                                            "kind": "PIPE",
-                                            "start": 141,
-                                            "end": 142
-                                          },
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 142,
-                                            "end": 143
-                                          },
-                                          {
-                                            "kind": "PIPE",
-                                            "start": 143,
-                                            "end": 144
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 144,
-                                            "end": 145
-                                          },
-                                          {
-                                            "kind": "STAR",
-                                            "start": 145,
-                                            "end": 146
-                                          },
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 146,
-                                            "end": 147
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 147,
-                                            "end": 148
-                                          },
-                                          {
-                                            "kind": "AS_KW",
-                                            "start": 148,
-                                            "end": 150
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 150,
-                                            "end": 151
-                                          },
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 151,
-                                            "end": 154
-                                          },
-                                          {
-                                            "kind": "R_PAREN",
-                                            "start": 154,
-                                            "end": 155
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "DOT",
-                                        "start": 155,
-                                        "end": 156
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 156,
-                                        "end": 159
-                                      },
-                                      {
-                                        "kind": "COLON",
-                                        "start": 159,
-                                        "end": 160
-                                      },
-                                      {
-                                        "kind": "COLON",
-                                        "start": 160,
-                                        "end": 161
-                                      },
-                                      {
-                                        "kind": "L_ANGLE",
-                                        "start": 161,
-                                        "end": 162
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 162,
-                                        "end": 165
-                                      },
-                                      {
-                                        "kind": "R_ANGLE",
-                                        "start": 165,
-                                        "end": 166
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 166,
-                                        "end": 168,
-                                        "children": [
-                                          {
-                                            "kind": "L_PAREN",
-                                            "start": 166,
-                                            "end": 167
-                                          },
-                                          {
-                                            "kind": "R_PAREN",
-                                            "start": 167,
-                                            "end": 168
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 168,
-                                        "end": 169
-                                      },
-                                      {
-                                        "kind": "SLASH",
-                                        "start": 169,
-                                        "end": 170
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 170,
-                                        "end": 171
-                                      },
-                                      {
-                                        "kind": "TOKEN_TREE",
-                                        "start": 171,
-                                        "end": 189,
-                                        "children": [
-                                          {
-                                            "kind": "L_PAREN",
-                                            "start": 171,
-                                            "end": 172
-                                          },
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 172,
-                                            "end": 175
-                                          },
-                                          {
-                                            "kind": "DOT",
-                                            "start": 175,
-                                            "end": 176
-                                          },
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 176,
-                                            "end": 179
-                                          },
-                                          {
-                                            "kind": "TOKEN_TREE",
-                                            "start": 179,
-                                            "end": 181,
-                                            "children": [
-                                              {
-                                                "kind": "L_PAREN",
-                                                "start": 179,
-                                                "end": 180
-                                              },
-                                              {
-                                                "kind": "R_PAREN",
-                                                "start": 180,
-                                                "end": 181
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 181,
-                                            "end": 182
-                                          },
-                                          {
-                                            "kind": "AS_KW",
-                                            "start": 182,
-                                            "end": 184
-                                          },
-                                          {
-                                            "kind": "WHITESPACE",
-                                            "start": 184,
-                                            "end": 185
-                                          },
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 185,
-                                            "end": 188
-                                          },
-                                          {
-                                            "kind": "R_PAREN",
-                                            "start": 188,
-                                            "end": 189
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 189,
-                                        "end": 190
-                                      },
-                                      {
-                                        "kind": "R_CURLY",
-                                        "start": 190,
-                                        "end": 191
-                                      }
-                                    ]
+                                    "kind": "token_tree",
+                                    "start": 179,
+                                    "end": 181
                                   },
                                   {
-                                    "kind": "R_PAREN",
-                                    "start": 191,
-                                    "end": 192
+                                    "kind": "primitive_type",
+                                    "start": 185,
+                                    "end": 188
                                   }
                                 ]
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 192,
-                        "end": 193
                       }
                     ]
-                  },
-                  {
-                    "kind": "WHITESPACE",
-                    "start": 193,
-                    "end": 194
-                  },
-                  {
-                    "kind": "R_CURLY",
-                    "start": 194,
-                    "end": 195
                   }
                 ]
               }
             ]
           }
         ]
-      },
-      {
-        "kind": "WHITESPACE",
-        "start": 195,
-        "end": 196
       }
     ]
   }

--- a/tests/json-ast/x/rs/basic_compare.rs.json
+++ b/tests/json-ast/x/rs/basic_compare.rs.json
@@ -1,1001 +1,330 @@
 {
   "file": {
-    "kind": "SOURCE_FILE",
+    "kind": "source_file",
     "start": 0,
     "end": 257,
     "children": [
       {
-        "kind": "FN",
+        "kind": "line_comment",
         "start": 0,
+        "end": 67
+      },
+      {
+        "kind": "function_item",
+        "start": 68,
         "end": 256,
         "children": [
           {
-            "kind": "COMMENT",
-            "start": 0,
-            "end": 67
-          },
-          {
-            "kind": "WHITESPACE",
-            "start": 67,
-            "end": 68
-          },
-          {
-            "kind": "FN_KW",
-            "start": 68,
-            "end": 70
-          },
-          {
-            "kind": "WHITESPACE",
-            "start": 70,
-            "end": 71
-          },
-          {
-            "kind": "NAME",
+            "kind": "identifier",
             "start": 71,
-            "end": 75,
-            "children": [
-              {
-                "kind": "IDENT",
-                "start": 71,
-                "end": 75
-              }
-            ]
+            "end": 75
           },
           {
-            "kind": "PARAM_LIST",
+            "kind": "parameters",
             "start": 75,
-            "end": 77,
-            "children": [
-              {
-                "kind": "L_PAREN",
-                "start": 75,
-                "end": 76
-              },
-              {
-                "kind": "R_PAREN",
-                "start": 76,
-                "end": 77
-              }
-            ]
+            "end": 77
           },
           {
-            "kind": "WHITESPACE",
-            "start": 77,
-            "end": 78
-          },
-          {
-            "kind": "BLOCK_EXPR",
+            "kind": "block",
             "start": 78,
             "end": 256,
             "children": [
               {
-                "kind": "STMT_LIST",
-                "start": 78,
-                "end": 256,
+                "kind": "let_declaration",
+                "start": 84,
+                "end": 106,
                 "children": [
                   {
-                    "kind": "L_CURLY",
-                    "start": 78,
-                    "end": 79
+                    "kind": "identifier",
+                    "start": 88,
+                    "end": 89
                   },
                   {
-                    "kind": "WHITESPACE",
-                    "start": 79,
-                    "end": 84
+                    "kind": "primitive_type",
+                    "start": 91,
+                    "end": 94
                   },
                   {
-                    "kind": "LET_STMT",
-                    "start": 84,
-                    "end": 106,
+                    "kind": "parenthesized_expression",
+                    "start": 97,
+                    "end": 105,
                     "children": [
                       {
-                        "kind": "LET_KW",
-                        "start": 84,
-                        "end": 87
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 87,
-                        "end": 88
-                      },
-                      {
-                        "kind": "IDENT_PAT",
-                        "start": 88,
-                        "end": 89,
+                        "kind": "binary_expression",
+                        "start": 98,
+                        "end": 104,
                         "children": [
                           {
-                            "kind": "NAME",
-                            "start": 88,
-                            "end": 89,
-                            "children": [
-                              {
-                                "kind": "IDENT",
-                                "start": 88,
-                                "end": 89
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "COLON",
-                        "start": 89,
-                        "end": 90
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 90,
-                        "end": 91
-                      },
-                      {
-                        "kind": "PATH_TYPE",
-                        "start": 91,
-                        "end": 94,
-                        "children": [
-                          {
-                            "kind": "PATH",
-                            "start": 91,
-                            "end": 94,
-                            "children": [
-                              {
-                                "kind": "PATH_SEGMENT",
-                                "start": 91,
-                                "end": 94,
-                                "children": [
-                                  {
-                                    "kind": "NAME_REF",
-                                    "start": 91,
-                                    "end": 94,
-                                    "children": [
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 91,
-                                        "end": 94
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 94,
-                        "end": 95
-                      },
-                      {
-                        "kind": "EQ",
-                        "start": 95,
-                        "end": 96
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 96,
-                        "end": 97
-                      },
-                      {
-                        "kind": "PAREN_EXPR",
-                        "start": 97,
-                        "end": 105,
-                        "children": [
-                          {
-                            "kind": "L_PAREN",
-                            "start": 97,
-                            "end": 98
-                          },
-                          {
-                            "kind": "BIN_EXPR",
+                            "kind": "integer_literal",
                             "start": 98,
-                            "end": 104,
-                            "children": [
-                              {
-                                "kind": "LITERAL",
-                                "start": 98,
-                                "end": 100,
-                                "children": [
-                                  {
-                                    "kind": "INT_NUMBER",
-                                    "start": 98,
-                                    "end": 100
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "WHITESPACE",
-                                "start": 100,
-                                "end": 101
-                              },
-                              {
-                                "kind": "MINUS",
-                                "start": 101,
-                                "end": 102
-                              },
-                              {
-                                "kind": "WHITESPACE",
-                                "start": 102,
-                                "end": 103
-                              },
-                              {
-                                "kind": "LITERAL",
-                                "start": 103,
-                                "end": 104,
-                                "children": [
-                                  {
-                                    "kind": "INT_NUMBER",
-                                    "start": 103,
-                                    "end": 104
-                                  }
-                                ]
-                              }
-                            ]
+                            "end": 100
                           },
                           {
-                            "kind": "R_PAREN",
-                            "start": 104,
-                            "end": 105
+                            "kind": "integer_literal",
+                            "start": 103,
+                            "end": 104
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 105,
-                        "end": 106
                       }
                     ]
+                  }
+                ]
+              },
+              {
+                "kind": "let_declaration",
+                "start": 111,
+                "end": 132,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 115,
+                    "end": 116
                   },
                   {
-                    "kind": "WHITESPACE",
-                    "start": 106,
-                    "end": 111
+                    "kind": "primitive_type",
+                    "start": 118,
+                    "end": 121
                   },
                   {
-                    "kind": "LET_STMT",
-                    "start": 111,
-                    "end": 132,
+                    "kind": "parenthesized_expression",
+                    "start": 124,
+                    "end": 131,
                     "children": [
                       {
-                        "kind": "LET_KW",
-                        "start": 111,
-                        "end": 114
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 114,
-                        "end": 115
-                      },
-                      {
-                        "kind": "IDENT_PAT",
-                        "start": 115,
-                        "end": 116,
+                        "kind": "binary_expression",
+                        "start": 125,
+                        "end": 130,
                         "children": [
                           {
-                            "kind": "NAME",
-                            "start": 115,
-                            "end": 116,
-                            "children": [
-                              {
-                                "kind": "IDENT",
-                                "start": 115,
-                                "end": 116
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "COLON",
-                        "start": 116,
-                        "end": 117
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 117,
-                        "end": 118
-                      },
-                      {
-                        "kind": "PATH_TYPE",
-                        "start": 118,
-                        "end": 121,
-                        "children": [
-                          {
-                            "kind": "PATH",
-                            "start": 118,
-                            "end": 121,
-                            "children": [
-                              {
-                                "kind": "PATH_SEGMENT",
-                                "start": 118,
-                                "end": 121,
-                                "children": [
-                                  {
-                                    "kind": "NAME_REF",
-                                    "start": 118,
-                                    "end": 121,
-                                    "children": [
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 118,
-                                        "end": 121
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 121,
-                        "end": 122
-                      },
-                      {
-                        "kind": "EQ",
-                        "start": 122,
-                        "end": 123
-                      },
-                      {
-                        "kind": "WHITESPACE",
-                        "start": 123,
-                        "end": 124
-                      },
-                      {
-                        "kind": "PAREN_EXPR",
-                        "start": 124,
-                        "end": 131,
-                        "children": [
-                          {
-                            "kind": "L_PAREN",
-                            "start": 124,
-                            "end": 125
-                          },
-                          {
-                            "kind": "BIN_EXPR",
+                            "kind": "integer_literal",
                             "start": 125,
-                            "end": 130,
-                            "children": [
-                              {
-                                "kind": "LITERAL",
-                                "start": 125,
-                                "end": 126,
-                                "children": [
-                                  {
-                                    "kind": "INT_NUMBER",
-                                    "start": 125,
-                                    "end": 126
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "WHITESPACE",
-                                "start": 126,
-                                "end": 127
-                              },
-                              {
-                                "kind": "PLUS",
-                                "start": 127,
-                                "end": 128
-                              },
-                              {
-                                "kind": "WHITESPACE",
-                                "start": 128,
-                                "end": 129
-                              },
-                              {
-                                "kind": "LITERAL",
-                                "start": 129,
-                                "end": 130,
-                                "children": [
-                                  {
-                                    "kind": "INT_NUMBER",
-                                    "start": 129,
-                                    "end": 130
-                                  }
-                                ]
-                              }
-                            ]
+                            "end": 126
                           },
                           {
-                            "kind": "R_PAREN",
-                            "start": 130,
-                            "end": 131
+                            "kind": "integer_literal",
+                            "start": 129,
+                            "end": 130
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 131,
-                        "end": 132
                       }
                     ]
-                  },
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 137,
+                "end": 155,
+                "children": [
                   {
-                    "kind": "WHITESPACE",
-                    "start": 132,
-                    "end": 137
-                  },
-                  {
-                    "kind": "EXPR_STMT",
+                    "kind": "macro_invocation",
                     "start": 137,
-                    "end": 155,
+                    "end": 154,
                     "children": [
                       {
-                        "kind": "MACRO_EXPR",
+                        "kind": "identifier",
                         "start": 137,
+                        "end": 144
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 145,
                         "end": 154,
                         "children": [
                           {
-                            "kind": "MACRO_CALL",
-                            "start": 137,
-                            "end": 154,
+                            "kind": "string_literal",
+                            "start": 146,
+                            "end": 150,
                             "children": [
                               {
-                                "kind": "PATH",
-                                "start": 137,
-                                "end": 144,
-                                "children": [
-                                  {
-                                    "kind": "PATH_SEGMENT",
-                                    "start": 137,
-                                    "end": 144,
-                                    "children": [
-                                      {
-                                        "kind": "NAME_REF",
-                                        "start": 137,
-                                        "end": 144,
-                                        "children": [
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 137,
-                                            "end": 144
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "BANG",
-                                "start": 144,
-                                "end": 145
-                              },
-                              {
-                                "kind": "TOKEN_TREE",
-                                "start": 145,
-                                "end": 154,
-                                "children": [
-                                  {
-                                    "kind": "L_PAREN",
-                                    "start": 145,
-                                    "end": 146
-                                  },
-                                  {
-                                    "kind": "STRING",
-                                    "start": 146,
-                                    "end": 150
-                                  },
-                                  {
-                                    "kind": "COMMA",
-                                    "start": 150,
-                                    "end": 151
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 151,
-                                    "end": 152
-                                  },
-                                  {
-                                    "kind": "IDENT",
-                                    "start": 152,
-                                    "end": 153
-                                  },
-                                  {
-                                    "kind": "R_PAREN",
-                                    "start": 153,
-                                    "end": 154
-                                  }
-                                ]
+                                "kind": "string_content",
+                                "start": 147,
+                                "end": 149
                               }
                             ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 152,
+                            "end": 153
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 154,
-                        "end": 155
                       }
                     ]
-                  },
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 160,
+                "end": 205,
+                "children": [
                   {
-                    "kind": "WHITESPACE",
-                    "start": 155,
-                    "end": 160
-                  },
-                  {
-                    "kind": "EXPR_STMT",
+                    "kind": "macro_invocation",
                     "start": 160,
-                    "end": 205,
+                    "end": 204,
                     "children": [
                       {
-                        "kind": "MACRO_EXPR",
+                        "kind": "identifier",
                         "start": 160,
+                        "end": 167
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 168,
                         "end": 204,
                         "children": [
                           {
-                            "kind": "MACRO_CALL",
-                            "start": 160,
-                            "end": 204,
+                            "kind": "string_literal",
+                            "start": 169,
+                            "end": 173,
                             "children": [
                               {
-                                "kind": "PATH",
-                                "start": 160,
-                                "end": 167,
-                                "children": [
-                                  {
-                                    "kind": "PATH_SEGMENT",
-                                    "start": 160,
-                                    "end": 167,
-                                    "children": [
-                                      {
-                                        "kind": "NAME_REF",
-                                        "start": 160,
-                                        "end": 167,
-                                        "children": [
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 160,
-                                            "end": 167
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
+                                "kind": "string_content",
+                                "start": 170,
+                                "end": 172
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 178,
+                            "end": 186,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 179,
+                                "end": 180
                               },
                               {
-                                "kind": "BANG",
-                                "start": 167,
-                                "end": 168
-                              },
+                                "kind": "integer_literal",
+                                "start": 184,
+                                "end": 185
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 187,
+                            "end": 192,
+                            "children": [
                               {
-                                "kind": "TOKEN_TREE",
-                                "start": 168,
-                                "end": 204,
-                                "children": [
-                                  {
-                                    "kind": "L_PAREN",
-                                    "start": 168,
-                                    "end": 169
-                                  },
-                                  {
-                                    "kind": "STRING",
-                                    "start": 169,
-                                    "end": 173
-                                  },
-                                  {
-                                    "kind": "COMMA",
-                                    "start": 173,
-                                    "end": 174
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 174,
-                                    "end": 175
-                                  },
-                                  {
-                                    "kind": "IF_KW",
-                                    "start": 175,
-                                    "end": 177
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 177,
-                                    "end": 178
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 178,
-                                    "end": 186,
-                                    "children": [
-                                      {
-                                        "kind": "L_PAREN",
-                                        "start": 178,
-                                        "end": 179
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 179,
-                                        "end": 180
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 180,
-                                        "end": 181
-                                      },
-                                      {
-                                        "kind": "EQ",
-                                        "start": 181,
-                                        "end": 182
-                                      },
-                                      {
-                                        "kind": "EQ",
-                                        "start": 182,
-                                        "end": 183
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 183,
-                                        "end": 184
-                                      },
-                                      {
-                                        "kind": "INT_NUMBER",
-                                        "start": 184,
-                                        "end": 185
-                                      },
-                                      {
-                                        "kind": "R_PAREN",
-                                        "start": 185,
-                                        "end": 186
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 186,
-                                    "end": 187
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 187,
-                                    "end": 192,
-                                    "children": [
-                                      {
-                                        "kind": "L_CURLY",
-                                        "start": 187,
-                                        "end": 188
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 188,
-                                        "end": 189
-                                      },
-                                      {
-                                        "kind": "INT_NUMBER",
-                                        "start": 189,
-                                        "end": 190
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 190,
-                                        "end": 191
-                                      },
-                                      {
-                                        "kind": "R_CURLY",
-                                        "start": 191,
-                                        "end": 192
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 192,
-                                    "end": 193
-                                  },
-                                  {
-                                    "kind": "ELSE_KW",
-                                    "start": 193,
-                                    "end": 197
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 197,
-                                    "end": 198
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 198,
-                                    "end": 203,
-                                    "children": [
-                                      {
-                                        "kind": "L_CURLY",
-                                        "start": 198,
-                                        "end": 199
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 199,
-                                        "end": 200
-                                      },
-                                      {
-                                        "kind": "INT_NUMBER",
-                                        "start": 200,
-                                        "end": 201
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 201,
-                                        "end": 202
-                                      },
-                                      {
-                                        "kind": "R_CURLY",
-                                        "start": 202,
-                                        "end": 203
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "R_PAREN",
-                                    "start": 203,
-                                    "end": 204
-                                  }
-                                ]
+                                "kind": "integer_literal",
+                                "start": 189,
+                                "end": 190
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 193,
+                            "end": 197
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 198,
+                            "end": 203,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 200,
+                                "end": 201
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 204,
-                        "end": 205
                       }
                     ]
-                  },
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 210,
+                "end": 254,
+                "children": [
                   {
-                    "kind": "WHITESPACE",
-                    "start": 205,
-                    "end": 210
-                  },
-                  {
-                    "kind": "EXPR_STMT",
+                    "kind": "macro_invocation",
                     "start": 210,
-                    "end": 254,
+                    "end": 253,
                     "children": [
                       {
-                        "kind": "MACRO_EXPR",
+                        "kind": "identifier",
                         "start": 210,
+                        "end": 217
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 218,
                         "end": 253,
                         "children": [
                           {
-                            "kind": "MACRO_CALL",
-                            "start": 210,
-                            "end": 253,
+                            "kind": "string_literal",
+                            "start": 219,
+                            "end": 223,
                             "children": [
                               {
-                                "kind": "PATH",
-                                "start": 210,
-                                "end": 217,
-                                "children": [
-                                  {
-                                    "kind": "PATH_SEGMENT",
-                                    "start": 210,
-                                    "end": 217,
-                                    "children": [
-                                      {
-                                        "kind": "NAME_REF",
-                                        "start": 210,
-                                        "end": 217,
-                                        "children": [
-                                          {
-                                            "kind": "IDENT",
-                                            "start": 210,
-                                            "end": 217
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
+                                "kind": "string_content",
+                                "start": 220,
+                                "end": 222
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 228,
+                            "end": 235,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 229,
+                                "end": 230
                               },
                               {
-                                "kind": "BANG",
-                                "start": 217,
-                                "end": 218
-                              },
+                                "kind": "integer_literal",
+                                "start": 233,
+                                "end": 234
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 236,
+                            "end": 241,
+                            "children": [
                               {
-                                "kind": "TOKEN_TREE",
-                                "start": 218,
-                                "end": 253,
-                                "children": [
-                                  {
-                                    "kind": "L_PAREN",
-                                    "start": 218,
-                                    "end": 219
-                                  },
-                                  {
-                                    "kind": "STRING",
-                                    "start": 219,
-                                    "end": 223
-                                  },
-                                  {
-                                    "kind": "COMMA",
-                                    "start": 223,
-                                    "end": 224
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 224,
-                                    "end": 225
-                                  },
-                                  {
-                                    "kind": "IF_KW",
-                                    "start": 225,
-                                    "end": 227
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 227,
-                                    "end": 228
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 228,
-                                    "end": 235,
-                                    "children": [
-                                      {
-                                        "kind": "L_PAREN",
-                                        "start": 228,
-                                        "end": 229
-                                      },
-                                      {
-                                        "kind": "IDENT",
-                                        "start": 229,
-                                        "end": 230
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 230,
-                                        "end": 231
-                                      },
-                                      {
-                                        "kind": "L_ANGLE",
-                                        "start": 231,
-                                        "end": 232
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 232,
-                                        "end": 233
-                                      },
-                                      {
-                                        "kind": "INT_NUMBER",
-                                        "start": 233,
-                                        "end": 234
-                                      },
-                                      {
-                                        "kind": "R_PAREN",
-                                        "start": 234,
-                                        "end": 235
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 235,
-                                    "end": 236
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 236,
-                                    "end": 241,
-                                    "children": [
-                                      {
-                                        "kind": "L_CURLY",
-                                        "start": 236,
-                                        "end": 237
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 237,
-                                        "end": 238
-                                      },
-                                      {
-                                        "kind": "INT_NUMBER",
-                                        "start": 238,
-                                        "end": 239
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 239,
-                                        "end": 240
-                                      },
-                                      {
-                                        "kind": "R_CURLY",
-                                        "start": 240,
-                                        "end": 241
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 241,
-                                    "end": 242
-                                  },
-                                  {
-                                    "kind": "ELSE_KW",
-                                    "start": 242,
-                                    "end": 246
-                                  },
-                                  {
-                                    "kind": "WHITESPACE",
-                                    "start": 246,
-                                    "end": 247
-                                  },
-                                  {
-                                    "kind": "TOKEN_TREE",
-                                    "start": 247,
-                                    "end": 252,
-                                    "children": [
-                                      {
-                                        "kind": "L_CURLY",
-                                        "start": 247,
-                                        "end": 248
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 248,
-                                        "end": 249
-                                      },
-                                      {
-                                        "kind": "INT_NUMBER",
-                                        "start": 249,
-                                        "end": 250
-                                      },
-                                      {
-                                        "kind": "WHITESPACE",
-                                        "start": 250,
-                                        "end": 251
-                                      },
-                                      {
-                                        "kind": "R_CURLY",
-                                        "start": 251,
-                                        "end": 252
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "R_PAREN",
-                                    "start": 252,
-                                    "end": 253
-                                  }
-                                ]
+                                "kind": "integer_literal",
+                                "start": 238,
+                                "end": 239
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 242,
+                            "end": 246
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 247,
+                            "end": 252,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 249,
+                                "end": 250
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "SEMICOLON",
-                        "start": 253,
-                        "end": 254
                       }
                     ]
-                  },
-                  {
-                    "kind": "WHITESPACE",
-                    "start": 254,
-                    "end": 255
-                  },
-                  {
-                    "kind": "R_CURLY",
-                    "start": 255,
-                    "end": 256
                   }
                 ]
               }
             ]
           }
         ]
-      },
-      {
-        "kind": "WHITESPACE",
-        "start": 256,
-        "end": 257
       }
     ]
   }

--- a/tests/json-ast/x/rs/cross_join.rs.json
+++ b/tests/json-ast/x/rs/cross_join.rs.json
@@ -1,0 +1,3340 @@
+{
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 2561,
+    "children": [
+      {
+        "kind": "line_comment",
+        "start": 0,
+        "end": 67
+      },
+      {
+        "kind": "attribute_item",
+        "start": 68,
+        "end": 91,
+        "children": [
+          {
+            "kind": "attribute",
+            "start": 70,
+            "end": 90,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 70,
+                "end": 76
+              },
+              {
+                "kind": "token_tree",
+                "start": 76,
+                "end": 90,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 77,
+                    "end": 82
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 84,
+                    "end": 89
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "struct_item",
+        "start": 92,
+        "end": 147,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 99,
+            "end": 112
+          },
+          {
+            "kind": "field_declaration_list",
+            "start": 113,
+            "end": 147,
+            "children": [
+              {
+                "kind": "field_declaration",
+                "start": 119,
+                "end": 126,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 119,
+                    "end": 121
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 123,
+                    "end": 126
+                  }
+                ]
+              },
+              {
+                "kind": "field_declaration",
+                "start": 132,
+                "end": 144,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 132,
+                    "end": 136
+                  },
+                  {
+                    "kind": "type_identifier",
+                    "start": 138,
+                    "end": 144
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "impl_item",
+        "start": 148,
+        "end": 441,
+        "children": [
+          {
+            "kind": "scoped_type_identifier",
+            "start": 153,
+            "end": 170,
+            "children": [
+              {
+                "kind": "scoped_identifier",
+                "start": 153,
+                "end": 161,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 153,
+                    "end": 156
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 158,
+                    "end": 161
+                  }
+                ]
+              },
+              {
+                "kind": "type_identifier",
+                "start": 163,
+                "end": 170
+              }
+            ]
+          },
+          {
+            "kind": "type_identifier",
+            "start": 175,
+            "end": 188
+          },
+          {
+            "kind": "declaration_list",
+            "start": 189,
+            "end": 441,
+            "children": [
+              {
+                "kind": "function_item",
+                "start": 195,
+                "end": 439,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 198,
+                    "end": 201
+                  },
+                  {
+                    "kind": "parameters",
+                    "start": 201,
+                    "end": 241,
+                    "children": [
+                      {
+                        "kind": "self_parameter",
+                        "start": 202,
+                        "end": 207,
+                        "children": [
+                          {
+                            "kind": "self",
+                            "start": 203,
+                            "end": 207
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parameter",
+                        "start": 209,
+                        "end": 240,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 209,
+                            "end": 210
+                          },
+                          {
+                            "kind": "reference_type",
+                            "start": 212,
+                            "end": 240,
+                            "children": [
+                              {
+                                "kind": "mutable_specifier",
+                                "start": 213,
+                                "end": 216
+                              },
+                              {
+                                "kind": "generic_type",
+                                "start": 217,
+                                "end": 240,
+                                "children": [
+                                  {
+                                    "kind": "scoped_type_identifier",
+                                    "start": 217,
+                                    "end": 236,
+                                    "children": [
+                                      {
+                                        "kind": "scoped_identifier",
+                                        "start": 217,
+                                        "end": 225,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 217,
+                                            "end": 220
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 222,
+                                            "end": 225
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "type_identifier",
+                                        "start": 227,
+                                        "end": 236
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "type_arguments",
+                                    "start": 236,
+                                    "end": 240,
+                                    "children": [
+                                      {
+                                        "kind": "lifetime",
+                                        "start": 237,
+                                        "end": 239,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 238,
+                                            "end": 239
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "scoped_type_identifier",
+                    "start": 245,
+                    "end": 261,
+                    "children": [
+                      {
+                        "kind": "scoped_identifier",
+                        "start": 245,
+                        "end": 253,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 245,
+                            "end": 248
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 250,
+                            "end": 253
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "type_identifier",
+                        "start": 255,
+                        "end": 261
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 262,
+                    "end": 439,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 272,
+                        "end": 289,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 272,
+                            "end": 288,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 272,
+                                "end": 287,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 272,
+                                    "end": 277
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 278,
+                                    "end": 287,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 279,
+                                        "end": 280
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 282,
+                                        "end": 286,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 283,
+                                            "end": 285
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 298,
+                        "end": 332,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 298,
+                            "end": 331,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 298,
+                                "end": 330,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 298,
+                                    "end": 303
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 304,
+                                    "end": 330,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 305,
+                                        "end": 306
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 308,
+                                        "end": 320,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 309,
+                                            "end": 311
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 311,
+                                            "end": 313
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 313,
+                                            "end": 315
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 315,
+                                            "end": 319
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 322,
+                                        "end": 326
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 327,
+                                        "end": 329
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 341,
+                        "end": 358,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 341,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 341,
+                                "end": 356,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 341,
+                                    "end": 346
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 347,
+                                    "end": 356,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 348,
+                                        "end": 349
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 351,
+                                        "end": 355,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 352,
+                                            "end": 354
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 367,
+                        "end": 409,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 367,
+                            "end": 408,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 367,
+                                "end": 407,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 367,
+                                    "end": 372
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 373,
+                                    "end": 407,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 374,
+                                        "end": 375
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 377,
+                                        "end": 395,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 378,
+                                            "end": 380
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 380,
+                                            "end": 384
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 384,
+                                            "end": 386
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 386,
+                                            "end": 388
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 388,
+                                            "end": 390
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 390,
+                                            "end": 392
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 392,
+                                            "end": 394
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 397,
+                                        "end": 401
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 402,
+                                        "end": 406
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "macro_invocation",
+                        "start": 418,
+                        "end": 433,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 418,
+                            "end": 423
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 424,
+                            "end": 433,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 425,
+                                "end": 426
+                              },
+                              {
+                                "kind": "string_literal",
+                                "start": 428,
+                                "end": 432,
+                                "children": [
+                                  {
+                                    "kind": "string_content",
+                                    "start": 429,
+                                    "end": 431
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "attribute_item",
+        "start": 443,
+        "end": 466,
+        "children": [
+          {
+            "kind": "attribute",
+            "start": 445,
+            "end": 465,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 445,
+                "end": 451
+              },
+              {
+                "kind": "token_tree",
+                "start": 451,
+                "end": 465,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 452,
+                    "end": 457
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 459,
+                    "end": 464
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "struct_item",
+        "start": 467,
+        "end": 538,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 474,
+            "end": 484
+          },
+          {
+            "kind": "field_declaration_list",
+            "start": 485,
+            "end": 538,
+            "children": [
+              {
+                "kind": "field_declaration",
+                "start": 491,
+                "end": 498,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 491,
+                    "end": 493
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 495,
+                    "end": 498
+                  }
+                ]
+              },
+              {
+                "kind": "field_declaration",
+                "start": 504,
+                "end": 519,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 504,
+                    "end": 514
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 516,
+                    "end": 519
+                  }
+                ]
+              },
+              {
+                "kind": "field_declaration",
+                "start": 525,
+                "end": 535,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 525,
+                    "end": 530
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 532,
+                    "end": 535
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "impl_item",
+        "start": 539,
+        "end": 912,
+        "children": [
+          {
+            "kind": "scoped_type_identifier",
+            "start": 544,
+            "end": 561,
+            "children": [
+              {
+                "kind": "scoped_identifier",
+                "start": 544,
+                "end": 552,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 544,
+                    "end": 547
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 549,
+                    "end": 552
+                  }
+                ]
+              },
+              {
+                "kind": "type_identifier",
+                "start": 554,
+                "end": 561
+              }
+            ]
+          },
+          {
+            "kind": "type_identifier",
+            "start": 566,
+            "end": 576
+          },
+          {
+            "kind": "declaration_list",
+            "start": 577,
+            "end": 912,
+            "children": [
+              {
+                "kind": "function_item",
+                "start": 583,
+                "end": 910,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 586,
+                    "end": 589
+                  },
+                  {
+                    "kind": "parameters",
+                    "start": 589,
+                    "end": 629,
+                    "children": [
+                      {
+                        "kind": "self_parameter",
+                        "start": 590,
+                        "end": 595,
+                        "children": [
+                          {
+                            "kind": "self",
+                            "start": 591,
+                            "end": 595
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parameter",
+                        "start": 597,
+                        "end": 628,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 597,
+                            "end": 598
+                          },
+                          {
+                            "kind": "reference_type",
+                            "start": 600,
+                            "end": 628,
+                            "children": [
+                              {
+                                "kind": "mutable_specifier",
+                                "start": 601,
+                                "end": 604
+                              },
+                              {
+                                "kind": "generic_type",
+                                "start": 605,
+                                "end": 628,
+                                "children": [
+                                  {
+                                    "kind": "scoped_type_identifier",
+                                    "start": 605,
+                                    "end": 624,
+                                    "children": [
+                                      {
+                                        "kind": "scoped_identifier",
+                                        "start": 605,
+                                        "end": 613,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 605,
+                                            "end": 608
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 610,
+                                            "end": 613
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "type_identifier",
+                                        "start": 615,
+                                        "end": 624
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "type_arguments",
+                                    "start": 624,
+                                    "end": 628,
+                                    "children": [
+                                      {
+                                        "kind": "lifetime",
+                                        "start": 625,
+                                        "end": 627,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 626,
+                                            "end": 627
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "scoped_type_identifier",
+                    "start": 633,
+                    "end": 649,
+                    "children": [
+                      {
+                        "kind": "scoped_identifier",
+                        "start": 633,
+                        "end": 641,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 633,
+                            "end": 636
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 638,
+                            "end": 641
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "type_identifier",
+                        "start": 643,
+                        "end": 649
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 650,
+                    "end": 910,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 660,
+                        "end": 677,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 660,
+                            "end": 676,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 660,
+                                "end": 675,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 660,
+                                    "end": 665
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 666,
+                                    "end": 675,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 667,
+                                        "end": 668
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 670,
+                                        "end": 674,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 671,
+                                            "end": 673
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 686,
+                        "end": 720,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 686,
+                            "end": 719,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 686,
+                                "end": 718,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 686,
+                                    "end": 691
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 692,
+                                    "end": 718,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 693,
+                                        "end": 694
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 696,
+                                        "end": 708,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 697,
+                                            "end": 699
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 699,
+                                            "end": 701
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 701,
+                                            "end": 703
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 703,
+                                            "end": 707
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 710,
+                                        "end": 714
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 715,
+                                        "end": 717
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 729,
+                        "end": 746,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 729,
+                            "end": 745,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 729,
+                                "end": 744,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 729,
+                                    "end": 734
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 735,
+                                    "end": 744,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 736,
+                                        "end": 737
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 739,
+                                        "end": 743,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 740,
+                                            "end": 742
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 755,
+                        "end": 805,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 755,
+                            "end": 804,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 755,
+                                "end": 803,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 755,
+                                    "end": 760
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 761,
+                                    "end": 803,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 762,
+                                        "end": 763
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 765,
+                                        "end": 785,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 766,
+                                            "end": 768
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 768,
+                                            "end": 778
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 778,
+                                            "end": 780
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 780,
+                                            "end": 784
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 787,
+                                        "end": 791
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 792,
+                                        "end": 802
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 814,
+                        "end": 831,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 814,
+                            "end": 830,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 814,
+                                "end": 829,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 814,
+                                    "end": 819
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 820,
+                                    "end": 829,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 821,
+                                        "end": 822
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 824,
+                                        "end": 828,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 825,
+                                            "end": 827
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 840,
+                        "end": 880,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 840,
+                            "end": 879,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 840,
+                                "end": 878,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 840,
+                                    "end": 845
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 846,
+                                    "end": 878,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 847,
+                                        "end": 848
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 850,
+                                        "end": 865,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 851,
+                                            "end": 853
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 853,
+                                            "end": 858
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 858,
+                                            "end": 860
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 860,
+                                            "end": 864
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 867,
+                                        "end": 871
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 872,
+                                        "end": 877
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "macro_invocation",
+                        "start": 889,
+                        "end": 904,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 889,
+                            "end": 894
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 895,
+                            "end": 904,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 896,
+                                "end": 897
+                              },
+                              {
+                                "kind": "string_literal",
+                                "start": 899,
+                                "end": 903,
+                                "children": [
+                                  {
+                                    "kind": "string_content",
+                                    "start": 900,
+                                    "end": 902
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "attribute_item",
+        "start": 914,
+        "end": 937,
+        "children": [
+          {
+            "kind": "attribute",
+            "start": 916,
+            "end": 936,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 916,
+                "end": 922
+              },
+              {
+                "kind": "token_tree",
+                "start": 922,
+                "end": 936,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 923,
+                    "end": 928
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 930,
+                    "end": 935
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "struct_item",
+        "start": 938,
+        "end": 1055,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 945,
+            "end": 954
+          },
+          {
+            "kind": "field_declaration_list",
+            "start": 955,
+            "end": 1055,
+            "children": [
+              {
+                "kind": "field_declaration",
+                "start": 961,
+                "end": 973,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 961,
+                    "end": 968
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 970,
+                    "end": 973
+                  }
+                ]
+              },
+              {
+                "kind": "field_declaration",
+                "start": 979,
+                "end": 999,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 979,
+                    "end": 994
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 996,
+                    "end": 999
+                  }
+                ]
+              },
+              {
+                "kind": "field_declaration",
+                "start": 1005,
+                "end": 1031,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 1005,
+                    "end": 1023
+                  },
+                  {
+                    "kind": "type_identifier",
+                    "start": 1025,
+                    "end": 1031
+                  }
+                ]
+              },
+              {
+                "kind": "field_declaration",
+                "start": 1037,
+                "end": 1052,
+                "children": [
+                  {
+                    "kind": "field_identifier",
+                    "start": 1037,
+                    "end": 1047
+                  },
+                  {
+                    "kind": "primitive_type",
+                    "start": 1049,
+                    "end": 1052
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "impl_item",
+        "start": 1056,
+        "end": 1563,
+        "children": [
+          {
+            "kind": "scoped_type_identifier",
+            "start": 1061,
+            "end": 1078,
+            "children": [
+              {
+                "kind": "scoped_identifier",
+                "start": 1061,
+                "end": 1069,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 1061,
+                    "end": 1064
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 1066,
+                    "end": 1069
+                  }
+                ]
+              },
+              {
+                "kind": "type_identifier",
+                "start": 1071,
+                "end": 1078
+              }
+            ]
+          },
+          {
+            "kind": "type_identifier",
+            "start": 1083,
+            "end": 1092
+          },
+          {
+            "kind": "declaration_list",
+            "start": 1093,
+            "end": 1563,
+            "children": [
+              {
+                "kind": "function_item",
+                "start": 1099,
+                "end": 1561,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 1102,
+                    "end": 1105
+                  },
+                  {
+                    "kind": "parameters",
+                    "start": 1105,
+                    "end": 1145,
+                    "children": [
+                      {
+                        "kind": "self_parameter",
+                        "start": 1106,
+                        "end": 1111,
+                        "children": [
+                          {
+                            "kind": "self",
+                            "start": 1107,
+                            "end": 1111
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parameter",
+                        "start": 1113,
+                        "end": 1144,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1113,
+                            "end": 1114
+                          },
+                          {
+                            "kind": "reference_type",
+                            "start": 1116,
+                            "end": 1144,
+                            "children": [
+                              {
+                                "kind": "mutable_specifier",
+                                "start": 1117,
+                                "end": 1120
+                              },
+                              {
+                                "kind": "generic_type",
+                                "start": 1121,
+                                "end": 1144,
+                                "children": [
+                                  {
+                                    "kind": "scoped_type_identifier",
+                                    "start": 1121,
+                                    "end": 1140,
+                                    "children": [
+                                      {
+                                        "kind": "scoped_identifier",
+                                        "start": 1121,
+                                        "end": 1129,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1121,
+                                            "end": 1124
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1126,
+                                            "end": 1129
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "type_identifier",
+                                        "start": 1131,
+                                        "end": 1140
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "type_arguments",
+                                    "start": 1140,
+                                    "end": 1144,
+                                    "children": [
+                                      {
+                                        "kind": "lifetime",
+                                        "start": 1141,
+                                        "end": 1143,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1142,
+                                            "end": 1143
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "scoped_type_identifier",
+                    "start": 1149,
+                    "end": 1165,
+                    "children": [
+                      {
+                        "kind": "scoped_identifier",
+                        "start": 1149,
+                        "end": 1157,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1149,
+                            "end": 1152
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1154,
+                            "end": 1157
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "type_identifier",
+                        "start": 1159,
+                        "end": 1165
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 1166,
+                    "end": 1561,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 1176,
+                        "end": 1193,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1176,
+                            "end": 1192,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1176,
+                                "end": 1191,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1176,
+                                    "end": 1181
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1182,
+                                    "end": 1191,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1183,
+                                        "end": 1184
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1186,
+                                        "end": 1190,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1187,
+                                            "end": 1189
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1202,
+                        "end": 1246,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1202,
+                            "end": 1245,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1202,
+                                "end": 1244,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1202,
+                                    "end": 1207
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1208,
+                                    "end": 1244,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1209,
+                                        "end": 1210
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1212,
+                                        "end": 1229,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1213,
+                                            "end": 1215
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1215,
+                                            "end": 1222
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1222,
+                                            "end": 1224
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1224,
+                                            "end": 1228
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 1231,
+                                        "end": 1235
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1236,
+                                        "end": 1243
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1255,
+                        "end": 1272,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1255,
+                            "end": 1271,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1255,
+                                "end": 1270,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1255,
+                                    "end": 1260
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1261,
+                                    "end": 1270,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1262,
+                                        "end": 1263
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1265,
+                                        "end": 1269,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1266,
+                                            "end": 1268
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1281,
+                        "end": 1341,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1281,
+                            "end": 1340,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1281,
+                                "end": 1339,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1281,
+                                    "end": 1286
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1287,
+                                    "end": 1339,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1288,
+                                        "end": 1289
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1291,
+                                        "end": 1316,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1292,
+                                            "end": 1294
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1294,
+                                            "end": 1309
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1309,
+                                            "end": 1311
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1311,
+                                            "end": 1315
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 1318,
+                                        "end": 1322
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1323,
+                                        "end": 1338
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1350,
+                        "end": 1367,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1350,
+                            "end": 1366,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1350,
+                                "end": 1365,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1350,
+                                    "end": 1355
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1356,
+                                    "end": 1365,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1357,
+                                        "end": 1358
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1360,
+                                        "end": 1364,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1361,
+                                            "end": 1363
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1376,
+                        "end": 1446,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1376,
+                            "end": 1445,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1376,
+                                "end": 1444,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1376,
+                                    "end": 1381
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1382,
+                                    "end": 1444,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1383,
+                                        "end": 1384
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1386,
+                                        "end": 1418,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1387,
+                                            "end": 1389
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1389,
+                                            "end": 1407
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1407,
+                                            "end": 1409
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1409,
+                                            "end": 1411
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1411,
+                                            "end": 1413
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1413,
+                                            "end": 1415
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1415,
+                                            "end": 1417
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 1420,
+                                        "end": 1424
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1425,
+                                        "end": 1443
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1455,
+                        "end": 1472,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1455,
+                            "end": 1471,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1455,
+                                "end": 1470,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1455,
+                                    "end": 1460
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1461,
+                                    "end": 1470,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1462,
+                                        "end": 1463
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1465,
+                                        "end": 1469,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1466,
+                                            "end": 1468
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 1481,
+                        "end": 1531,
+                        "children": [
+                          {
+                            "kind": "try_expression",
+                            "start": 1481,
+                            "end": 1530,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 1481,
+                                "end": 1529,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1481,
+                                    "end": 1486
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 1487,
+                                    "end": 1529,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1488,
+                                        "end": 1489
+                                      },
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 1491,
+                                        "end": 1511,
+                                        "children": [
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1492,
+                                            "end": 1494
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1494,
+                                            "end": 1504
+                                          },
+                                          {
+                                            "kind": "escape_sequence",
+                                            "start": 1504,
+                                            "end": 1506
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1506,
+                                            "end": 1510
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "self",
+                                        "start": 1513,
+                                        "end": 1517
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1518,
+                                        "end": 1528
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "macro_invocation",
+                        "start": 1540,
+                        "end": 1555,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1540,
+                            "end": 1545
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1546,
+                            "end": 1555,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1547,
+                                "end": 1548
+                              },
+                              {
+                                "kind": "string_literal",
+                                "start": 1550,
+                                "end": 1554,
+                                "children": [
+                                  {
+                                    "kind": "string_content",
+                                    "start": 1551,
+                                    "end": 1553
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_item",
+        "start": 1565,
+        "end": 2560,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 1568,
+            "end": 1572
+          },
+          {
+            "kind": "parameters",
+            "start": 1572,
+            "end": 1574
+          },
+          {
+            "kind": "block",
+            "start": 1575,
+            "end": 2560,
+            "children": [
+              {
+                "kind": "let_declaration",
+                "start": 1581,
+                "end": 1778,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 1585,
+                    "end": 1594
+                  },
+                  {
+                    "kind": "generic_type",
+                    "start": 1596,
+                    "end": 1614,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 1596,
+                        "end": 1599
+                      },
+                      {
+                        "kind": "type_arguments",
+                        "start": 1599,
+                        "end": 1614,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 1600,
+                            "end": 1613
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "macro_invocation",
+                    "start": 1617,
+                    "end": 1777,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 1617,
+                        "end": 1620
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 1621,
+                        "end": 1777,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1622,
+                            "end": 1635
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1636,
+                            "end": 1672,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1637,
+                                "end": 1639
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1641,
+                                "end": 1642
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1644,
+                                "end": 1648
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1650,
+                                "end": 1656
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1658,
+                                "end": 1662
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 1662,
+                                "end": 1671,
+                                "children": [
+                                  {
+                                    "kind": "string_literal",
+                                    "start": 1663,
+                                    "end": 1670,
+                                    "children": [
+                                      {
+                                        "kind": "string_content",
+                                        "start": 1664,
+                                        "end": 1669
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1674,
+                            "end": 1687
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1688,
+                            "end": 1722,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1689,
+                                "end": 1691
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1693,
+                                "end": 1694
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1696,
+                                "end": 1700
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1702,
+                                "end": 1708
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1710,
+                                "end": 1714
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 1714,
+                                "end": 1721,
+                                "children": [
+                                  {
+                                    "kind": "string_literal",
+                                    "start": 1715,
+                                    "end": 1720,
+                                    "children": [
+                                      {
+                                        "kind": "string_content",
+                                        "start": 1716,
+                                        "end": 1719
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1724,
+                            "end": 1737
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1738,
+                            "end": 1776,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1739,
+                                "end": 1741
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1743,
+                                "end": 1744
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1746,
+                                "end": 1750
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1752,
+                                "end": 1758
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1760,
+                                "end": 1764
+                              },
+                              {
+                                "kind": "token_tree",
+                                "start": 1764,
+                                "end": 1775,
+                                "children": [
+                                  {
+                                    "kind": "string_literal",
+                                    "start": 1765,
+                                    "end": 1774,
+                                    "children": [
+                                      {
+                                        "kind": "string_content",
+                                        "start": 1766,
+                                        "end": 1773
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "let_declaration",
+                "start": 1783,
+                "end": 1965,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 1787,
+                    "end": 1793
+                  },
+                  {
+                    "kind": "generic_type",
+                    "start": 1795,
+                    "end": 1810,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 1795,
+                        "end": 1798
+                      },
+                      {
+                        "kind": "type_arguments",
+                        "start": 1798,
+                        "end": 1810,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 1799,
+                            "end": 1809
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "macro_invocation",
+                    "start": 1813,
+                    "end": 1964,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 1813,
+                        "end": 1816
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 1817,
+                        "end": 1964,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1818,
+                            "end": 1828
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1829,
+                            "end": 1865,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1830,
+                                "end": 1832
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1834,
+                                "end": 1837
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1839,
+                                "end": 1849
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1851,
+                                "end": 1852
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1854,
+                                "end": 1859
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1861,
+                                "end": 1864
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1867,
+                            "end": 1877
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1878,
+                            "end": 1914,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1879,
+                                "end": 1881
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1883,
+                                "end": 1886
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1888,
+                                "end": 1898
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1900,
+                                "end": 1901
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1903,
+                                "end": 1908
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1910,
+                                "end": 1913
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1916,
+                            "end": 1926
+                          },
+                          {
+                            "kind": "token_tree",
+                            "start": 1927,
+                            "end": 1963,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1928,
+                                "end": 1930
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1932,
+                                "end": 1935
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1937,
+                                "end": 1947
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1949,
+                                "end": 1950
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1952,
+                                "end": 1957
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 1959,
+                                "end": 1962
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "let_declaration",
+                "start": 1970,
+                "end": 2248,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 1974,
+                    "end": 1980
+                  },
+                  {
+                    "kind": "generic_type",
+                    "start": 1982,
+                    "end": 1996,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 1982,
+                        "end": 1985
+                      },
+                      {
+                        "kind": "type_arguments",
+                        "start": 1985,
+                        "end": 1996,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 1986,
+                            "end": 1995
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 1999,
+                    "end": 2247,
+                    "children": [
+                      {
+                        "kind": "let_declaration",
+                        "start": 2001,
+                        "end": 2041,
+                        "children": [
+                          {
+                            "kind": "mutable_specifier",
+                            "start": 2005,
+                            "end": 2008
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 2009,
+                            "end": 2011
+                          },
+                          {
+                            "kind": "generic_type",
+                            "start": 2013,
+                            "end": 2027,
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "start": 2013,
+                                "end": 2016
+                              },
+                              {
+                                "kind": "type_arguments",
+                                "start": 2016,
+                                "end": 2027,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 2017,
+                                    "end": 2026
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_expression",
+                            "start": 2030,
+                            "end": 2040,
+                            "children": [
+                              {
+                                "kind": "scoped_identifier",
+                                "start": 2030,
+                                "end": 2038,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2030,
+                                    "end": 2033
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2035,
+                                    "end": 2038
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "arguments",
+                                "start": 2038,
+                                "end": 2040
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 2042,
+                        "end": 2242,
+                        "children": [
+                          {
+                            "kind": "for_expression",
+                            "start": 2042,
+                            "end": 2242,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2046,
+                                "end": 2047
+                              },
+                              {
+                                "kind": "reference_expression",
+                                "start": 2051,
+                                "end": 2058,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2052,
+                                    "end": 2058
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "block",
+                                "start": 2059,
+                                "end": 2242,
+                                "children": [
+                                  {
+                                    "kind": "expression_statement",
+                                    "start": 2061,
+                                    "end": 2240,
+                                    "children": [
+                                      {
+                                        "kind": "for_expression",
+                                        "start": 2061,
+                                        "end": 2240,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2065,
+                                            "end": 2066
+                                          },
+                                          {
+                                            "kind": "reference_expression",
+                                            "start": 2070,
+                                            "end": 2080,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 2071,
+                                                "end": 2080
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "block",
+                                            "start": 2081,
+                                            "end": 2240,
+                                            "children": [
+                                              {
+                                                "kind": "expression_statement",
+                                                "start": 2083,
+                                                "end": 2238,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 2083,
+                                                    "end": 2237,
+                                                    "children": [
+                                                      {
+                                                        "kind": "field_expression",
+                                                        "start": 2083,
+                                                        "end": 2090,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 2083,
+                                                            "end": 2085
+                                                          },
+                                                          {
+                                                            "kind": "field_identifier",
+                                                            "start": 2086,
+                                                            "end": 2090
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "arguments",
+                                                        "start": 2090,
+                                                        "end": 2237,
+                                                        "children": [
+                                                          {
+                                                            "kind": "struct_expression",
+                                                            "start": 2091,
+                                                            "end": 2236,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 2091,
+                                                                "end": 2100
+                                                              },
+                                                              {
+                                                                "kind": "field_initializer_list",
+                                                                "start": 2101,
+                                                                "end": 2236,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "field_initializer",
+                                                                    "start": 2102,
+                                                                    "end": 2123,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "field_identifier",
+                                                                        "start": 2102,
+                                                                        "end": 2109
+                                                                      },
+                                                                      {
+                                                                        "kind": "field_expression",
+                                                                        "start": 2111,
+                                                                        "end": 2123,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 2111,
+                                                                            "end": 2120,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "field_expression",
+                                                                                "start": 2111,
+                                                                                "end": 2118,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 2111,
+                                                                                    "end": 2112
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "field_identifier",
+                                                                                    "start": 2113,
+                                                                                    "end": 2118
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "arguments",
+                                                                                "start": 2118,
+                                                                                "end": 2120
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "field_identifier",
+                                                                            "start": 2121,
+                                                                            "end": 2123
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "field_initializer",
+                                                                    "start": 2125,
+                                                                    "end": 2162,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "field_identifier",
+                                                                        "start": 2125,
+                                                                        "end": 2140
+                                                                      },
+                                                                      {
+                                                                        "kind": "field_expression",
+                                                                        "start": 2142,
+                                                                        "end": 2162,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 2142,
+                                                                            "end": 2151,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "field_expression",
+                                                                                "start": 2142,
+                                                                                "end": 2149,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 2142,
+                                                                                    "end": 2143
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "field_identifier",
+                                                                                    "start": 2144,
+                                                                                    "end": 2149
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "arguments",
+                                                                                "start": 2149,
+                                                                                "end": 2151
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "field_identifier",
+                                                                            "start": 2152,
+                                                                            "end": 2162
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "field_initializer",
+                                                                    "start": 2164,
+                                                                    "end": 2206,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "field_identifier",
+                                                                        "start": 2164,
+                                                                        "end": 2182
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_expression",
+                                                                        "start": 2184,
+                                                                        "end": 2206,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "field_expression",
+                                                                            "start": 2184,
+                                                                            "end": 2204,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "field_expression",
+                                                                                "start": 2184,
+                                                                                "end": 2198,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 2184,
+                                                                                    "end": 2193,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "field_expression",
+                                                                                        "start": 2184,
+                                                                                        "end": 2191,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "identifier",
+                                                                                            "start": 2184,
+                                                                                            "end": 2185
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "field_identifier",
+                                                                                            "start": 2186,
+                                                                                            "end": 2191
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "arguments",
+                                                                                        "start": 2191,
+                                                                                        "end": 2193
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "field_identifier",
+                                                                                    "start": 2194,
+                                                                                    "end": 2198
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "field_identifier",
+                                                                                "start": 2199,
+                                                                                "end": 2204
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "arguments",
+                                                                            "start": 2204,
+                                                                            "end": 2206
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "field_initializer",
+                                                                    "start": 2208,
+                                                                    "end": 2235,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "field_identifier",
+                                                                        "start": 2208,
+                                                                        "end": 2218
+                                                                      },
+                                                                      {
+                                                                        "kind": "field_expression",
+                                                                        "start": 2220,
+                                                                        "end": 2235,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 2220,
+                                                                            "end": 2229,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "field_expression",
+                                                                                "start": 2220,
+                                                                                "end": 2227,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 2220,
+                                                                                    "end": 2221
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "field_identifier",
+                                                                                    "start": 2222,
+                                                                                    "end": 2227
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "arguments",
+                                                                                "start": 2227,
+                                                                                "end": 2229
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "field_identifier",
+                                                                            "start": 2230,
+                                                                            "end": 2235
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 2243,
+                        "end": 2245
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 2253,
+                "end": 2316,
+                "children": [
+                  {
+                    "kind": "macro_invocation",
+                    "start": 2253,
+                    "end": 2315,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 2253,
+                        "end": 2260
+                      },
+                      {
+                        "kind": "token_tree",
+                        "start": 2261,
+                        "end": 2315,
+                        "children": [
+                          {
+                            "kind": "string_literal",
+                            "start": 2262,
+                            "end": 2266,
+                            "children": [
+                              {
+                                "kind": "string_content",
+                                "start": 2263,
+                                "end": 2265
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string_literal",
+                            "start": 2268,
+                            "end": 2314,
+                            "children": [
+                              {
+                                "kind": "string_content",
+                                "start": 2269,
+                                "end": 2313
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 2321,
+                "end": 2558,
+                "children": [
+                  {
+                    "kind": "for_expression",
+                    "start": 2321,
+                    "end": 2558,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 2325,
+                        "end": 2330
+                      },
+                      {
+                        "kind": "reference_expression",
+                        "start": 2334,
+                        "end": 2341,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 2335,
+                            "end": 2341
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "block",
+                        "start": 2342,
+                        "end": 2558,
+                        "children": [
+                          {
+                            "kind": "expression_statement",
+                            "start": 2352,
+                            "end": 2552,
+                            "children": [
+                              {
+                                "kind": "macro_invocation",
+                                "start": 2352,
+                                "end": 2551,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2352,
+                                    "end": 2359
+                                  },
+                                  {
+                                    "kind": "token_tree",
+                                    "start": 2360,
+                                    "end": 2551,
+                                    "children": [
+                                      {
+                                        "kind": "string_literal",
+                                        "start": 2361,
+                                        "end": 2365,
+                                        "children": [
+                                          {
+                                            "kind": "string_content",
+                                            "start": 2362,
+                                            "end": 2364
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 2367,
+                                        "end": 2373
+                                      },
+                                      {
+                                        "kind": "token_tree",
+                                        "start": 2374,
+                                        "end": 2539,
+                                        "children": [
+                                          {
+                                            "kind": "string_literal",
+                                            "start": 2375,
+                                            "end": 2400,
+                                            "children": [
+                                              {
+                                                "kind": "string_content",
+                                                "start": 2376,
+                                                "end": 2399
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "string_literal",
+                                            "start": 2402,
+                                            "end": 2409,
+                                            "children": [
+                                              {
+                                                "kind": "string_content",
+                                                "start": 2403,
+                                                "end": 2408
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2411,
+                                            "end": 2416
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2417,
+                                            "end": 2424
+                                          },
+                                          {
+                                            "kind": "string_literal",
+                                            "start": 2426,
+                                            "end": 2440,
+                                            "children": [
+                                              {
+                                                "kind": "string_content",
+                                                "start": 2427,
+                                                "end": 2439
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2442,
+                                            "end": 2447
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2448,
+                                            "end": 2463
+                                          },
+                                          {
+                                            "kind": "string_literal",
+                                            "start": 2465,
+                                            "end": 2477,
+                                            "children": [
+                                              {
+                                                "kind": "string_content",
+                                                "start": 2466,
+                                                "end": 2476
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2479,
+                                            "end": 2484
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2485,
+                                            "end": 2495
+                                          },
+                                          {
+                                            "kind": "string_literal",
+                                            "start": 2497,
+                                            "end": 2512,
+                                            "children": [
+                                              {
+                                                "kind": "string_content",
+                                                "start": 2498,
+                                                "end": 2511
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2514,
+                                            "end": 2519
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2520,
+                                            "end": 2538
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 2540,
+                                        "end": 2548
+                                      },
+                                      {
+                                        "kind": "token_tree",
+                                        "start": 2548,
+                                        "end": 2550
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tools/json-ast/x/rs/inspect.go
+++ b/tools/json-ast/x/rs/inspect.go
@@ -1,14 +1,10 @@
 package rs
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"os/exec"
-	"strconv"
-	"strings"
-	"time"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	rust "github.com/smacker/go-tree-sitter/rust"
 )
 
 // Node represents a node in the Rust syntax tree.
@@ -24,113 +20,23 @@ type Program struct {
 	File *Node `json:"file"`
 }
 
-// Inspect parses the given Rust source code using rust-analyzer and returns
+// Inspect parses the given Rust source code using tree-sitter and returns
 // a Program describing its syntax tree.
 func Inspect(src string) (*Program, error) {
-	if _, err := exec.LookPath("rust-analyzer"); err != nil {
-		return nil, fmt.Errorf("rust-analyzer not installed: %w", err)
-	}
-	out, err := runRustAnalyzerParse("rust-analyzer", src)
-	if err != nil {
-		return nil, err
-	}
-	tree := parseTree(out)
-	return &Program{File: tree}, nil
+	p := sitter.NewParser()
+	p.SetLanguage(rust.GetLanguage())
+	tree := p.Parse(nil, []byte(src))
+	return &Program{File: toNode(tree.RootNode())}, nil
 }
 
-func runRustAnalyzerParse(cmd, src string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	c := exec.CommandContext(ctx, cmd, "parse")
-	c.Stdin = strings.NewReader(src)
-	var stdout, stderr bytes.Buffer
-	c.Stdout = &stdout
-	c.Stderr = &stderr
-	if err := c.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg != "" {
-			return "", fmt.Errorf("%v: %s", err, msg)
-		}
-		return "", err
-	}
-	return stdout.String(), nil
-}
-
-type rawNode struct {
-	kind     string
-	start    int
-	end      int
-	children []*rawNode
-}
-
-func parseLine(line string) (indent int, kind string, start, end int, ok bool) {
-	i := 0
-	for i < len(line) && line[i] == ' ' {
-		i++
-	}
-	indent = i / 2
-	rest := line[i:]
-	at := strings.IndexByte(rest, '@')
-	if at < 0 {
-		return
-	}
-	kind = rest[:at]
-	rest = rest[at+1:]
-	dots := strings.Index(rest, "..")
-	if dots < 0 {
-		return
-	}
-	s, err := strconv.Atoi(rest[:dots])
-	if err != nil {
-		return
-	}
-	start = s
-	rest = rest[dots+2:]
-	endStr := rest
-	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
-		endStr = rest[:sp]
-	}
-	e, err := strconv.Atoi(endStr)
-	if err != nil {
-		return
-	}
-	end = e
-	ok = true
-	return
-}
-
-func parseTree(out string) *Node {
-	root := &rawNode{kind: "ROOT"}
-	stack := []*rawNode{root}
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		indent, kind, start, end, ok := parseLine(line)
-		if !ok {
-			continue
-		}
-		n := &rawNode{kind: kind, start: start, end: end}
-		for len(stack) > indent+1 {
-			stack = stack[:len(stack)-1]
-		}
-		parent := stack[len(stack)-1]
-		parent.children = append(parent.children, n)
-		stack = append(stack, n)
-	}
-	if len(root.children) > 0 {
-		return toNode(root.children[0])
-	}
-	return toNode(root)
-}
-
-func toNode(n *rawNode) *Node {
+func toNode(n *sitter.Node) *Node {
 	if n == nil {
 		return nil
 	}
-	out := &Node{Kind: n.kind, Start: n.start, End: n.end}
-	for _, c := range n.children {
-		out.Children = append(out.Children, toNode(c))
+	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		out.Children = append(out.Children, toNode(child))
 	}
 	return out
 }

--- a/tools/json-ast/x/rs/inspect_test.go
+++ b/tools/json-ast/x/rs/inspect_test.go
@@ -42,14 +42,14 @@ func shouldUpdate() bool {
 	return f != nil && f.Value.String() == "true"
 }
 
-func ensureRustAnalyzer(t *testing.T) {
-	if _, err := exec.LookPath("rust-analyzer"); err != nil {
-		t.Skip("rust-analyzer not installed")
+func ensureTreeSitter(t *testing.T) {
+	if _, err := exec.LookPath("tree-sitter"); err != nil {
+		t.Skip("tree-sitter not installed")
 	}
 }
 
 func TestInspect_Golden(t *testing.T) {
-	ensureRustAnalyzer(t)
+	ensureTreeSitter(t)
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "rs")
 	outDir := filepath.Join(root, "tests", "json-ast", "x", "rs")


### PR DESCRIPTION
## Summary
- switch Rust AST inspector to use tree-sitter
- update tests to require tree-sitter
- refresh golden files

## Testing
- `go test ./tools/json-ast/x/rs -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_688986ae80f48320b17faffbb746927f