### PR TITLE
Enhance Swift AST inspector

### DIFF
--- a/tests/json-ast/x/swift/cross_join.swift.json
+++ b/tests/json-ast/x/swift/cross_join.swift.json
@@ -1,111 +1,6471 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
+  "file": {
+    "kind": "source_file",
+    "children": [
+      {
+        "kind": "compiler_version"
+      },
+      {
+        "kind": "top_level_code_decl",
         "range": {
           "start": 71,
           "end": 170
+        },
+        "children": [
+          {
+            "kind": "brace_stmt",
+            "range": {
+              "start": 71,
+              "end": 170
+            },
+            "children": [
+              {
+                "kind": "pattern_binding_decl",
+                "range": {
+                  "start": 71,
+                  "end": 170
+                },
+                "children": [
+                  {
+                    "kind": "pattern_entry",
+                    "children": [
+                      {
+                        "kind": "pattern_named",
+                        "name": "customers",
+                        "type": "$sSSypXSDXSaD"
+                      },
+                      {
+                        "kind": "array_expr",
+                        "type": "$sSSypXSDXSaD",
+                        "range": {
+                          "start": 87,
+                          "end": 170
+                        },
+                        "children": [
+                          {
+                            "kind": "decl_ref",
+                            "children": [
+                              {
+                                "kind": "substitution_map",
+                                "children": [
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSypXSDD"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSypXSDD"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "substitution"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSypXSDD",
+                            "range": {
+                              "start": 88,
+                              "end": 113
+                            },
+                            "children": [
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 89,
+                                  "end": 95
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 89,
+                                      "end": 89
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 95,
+                                      "end": 95
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "integer_literal_expr",
+                                        "type": "$sSiD",
+                                        "range": {
+                                          "start": 95,
+                                          "end": 95
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 98,
+                                  "end": 106
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 98,
+                                      "end": 98
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 106,
+                                      "end": 106
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 106,
+                                          "end": 106
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSypXSDD",
+                            "range": {
+                              "start": 116,
+                              "end": 139
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 117,
+                                  "end": 123
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 117,
+                                      "end": 117
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 123,
+                                      "end": 123
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "integer_literal_expr",
+                                        "type": "$sSiD",
+                                        "range": {
+                                          "start": 123,
+                                          "end": 123
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 126,
+                                  "end": 134
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 126,
+                                      "end": 126
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 134,
+                                      "end": 134
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 134,
+                                          "end": 134
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSypXSDD",
+                            "range": {
+                              "start": 142,
+                              "end": 169
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 143,
+                                  "end": 149
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 143,
+                                      "end": 143
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 149,
+                                      "end": 149
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "integer_literal_expr",
+                                        "type": "$sSiD",
+                                        "range": {
+                                          "start": 149,
+                                          "end": 149
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 152,
+                                  "end": 160
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 152,
+                                      "end": 152
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 160,
+                                      "end": 160
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 160,
+                                          "end": 160
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "array_expr",
+                        "type": "$sSSypXSDXSaD",
+                        "range": {
+                          "start": 87,
+                          "end": 170
+                        },
+                        "children": [
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSypXSDD",
+                            "range": {
+                              "start": 88,
+                              "end": 113
+                            },
+                            "children": [
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 89,
+                                  "end": 95
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 89,
+                                      "end": 89
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 95,
+                                      "end": 95
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "integer_literal_expr",
+                                        "type": "$sSiD",
+                                        "range": {
+                                          "start": 95,
+                                          "end": 95
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 98,
+                                  "end": 106
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 98,
+                                      "end": 98
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 106,
+                                      "end": 106
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 106,
+                                          "end": 106
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSypXSDD",
+                            "range": {
+                              "start": 116,
+                              "end": 139
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 117,
+                                  "end": 123
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 117,
+                                      "end": 117
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 123,
+                                      "end": 123
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "integer_literal_expr",
+                                        "type": "$sSiD",
+                                        "range": {
+                                          "start": 123,
+                                          "end": 123
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 126,
+                                  "end": 134
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 126,
+                                      "end": 126
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 134,
+                                      "end": 134
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 134,
+                                          "end": 134
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSypXSDD",
+                            "range": {
+                              "start": 142,
+                              "end": 169
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "self_conformance",
+                                            "type": "$sypD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 143,
+                                  "end": 149
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 143,
+                                      "end": 143
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 149,
+                                      "end": 149
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSiD"
+                                      },
+                                      {
+                                        "kind": "integer_literal_expr",
+                                        "type": "$sSiD",
+                                        "range": {
+                                          "start": 149,
+                                          "end": 149
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_yptD",
+                                "range": {
+                                  "start": 152,
+                                  "end": 160
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 152,
+                                      "end": 152
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 160,
+                                      "end": 160
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 160,
+                                          "end": 160
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "decl_ref",
+                            "children": [
+                              {
+                                "kind": "substitution_map",
+                                "children": [
+                                  {
+                                    "kind": "substitution"
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSypXSDD"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSypXSDD"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "var_decl",
+        "name": "customers",
+        "range": {
+          "start": 75,
+          "end": 75
         }
       },
-      "range": {
-        "start": 71,
-        "end": 170
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "customers"
-        }
-      },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
+      {
+        "kind": "top_level_code_decl",
         "range": {
           "start": 172,
           "end": 316
+        },
+        "children": [
+          {
+            "kind": "brace_stmt",
+            "range": {
+              "start": 172,
+              "end": 316
+            },
+            "children": [
+              {
+                "kind": "pattern_binding_decl",
+                "range": {
+                  "start": 172,
+                  "end": 316
+                },
+                "children": [
+                  {
+                    "kind": "pattern_entry",
+                    "children": [
+                      {
+                        "kind": "array_expr",
+                        "type": "$sSSSiXSDXSaD",
+                        "range": {
+                          "start": 185,
+                          "end": 316
+                        },
+                        "children": [
+                          {
+                            "kind": "decl_ref",
+                            "children": [
+                              {
+                                "kind": "substitution_map",
+                                "children": [
+                                  {
+                                    "kind": "substitution"
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSSiXSDD"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSSiXSDD"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSSiXSDD",
+                            "range": {
+                              "start": 186,
+                              "end": 227
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 187,
+                                  "end": 193
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 187,
+                                      "end": 187
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 193,
+                                      "end": 193
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 198,
+                                  "end": 212
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 198,
+                                      "end": 198
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 212,
+                                      "end": 212
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 215,
+                                  "end": 224
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 215,
+                                      "end": 215
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 224,
+                                      "end": 224
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSSiXSDD",
+                            "range": {
+                              "start": 230,
+                              "end": 271
+                            },
+                            "children": [
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 231,
+                                  "end": 237
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 231,
+                                      "end": 231
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 237,
+                                      "end": 237
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 242,
+                                  "end": 256
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 242,
+                                      "end": 242
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 256,
+                                      "end": 256
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 259,
+                                  "end": 268
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 259,
+                                      "end": 259
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 268,
+                                      "end": 268
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSSiXSDD",
+                            "range": {
+                              "start": 274,
+                              "end": 315
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 275,
+                                  "end": 281
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 275,
+                                      "end": 275
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 281,
+                                      "end": 281
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 286,
+                                  "end": 300
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 286,
+                                      "end": 286
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 300,
+                                      "end": 300
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 303,
+                                  "end": 312
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 303,
+                                      "end": 303
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 312,
+                                      "end": 312
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "array_expr",
+                        "type": "$sSSSiXSDXSaD",
+                        "range": {
+                          "start": 185,
+                          "end": 316
+                        },
+                        "children": [
+                          {
+                            "kind": "decl_ref",
+                            "children": [
+                              {
+                                "kind": "substitution_map",
+                                "children": [
+                                  {
+                                    "kind": "substitution"
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSSiXSDD"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "conformance",
+                                    "type": "$sxD",
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSSiXSDD"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSSiXSDD",
+                            "range": {
+                              "start": 186,
+                              "end": 227
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 187,
+                                  "end": 193
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 187,
+                                      "end": 187
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 193,
+                                      "end": 193
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 198,
+                                  "end": 212
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 198,
+                                      "end": 198
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 212,
+                                      "end": 212
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 215,
+                                  "end": 224
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 215,
+                                      "end": 215
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 224,
+                                      "end": 224
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSSiXSDD",
+                            "range": {
+                              "start": 230,
+                              "end": 271
+                            },
+                            "children": [
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 231,
+                                  "end": 237
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 231,
+                                      "end": 231
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 237,
+                                      "end": 237
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 242,
+                                  "end": 256
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 242,
+                                      "end": 242
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 256,
+                                      "end": 256
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 259,
+                                  "end": 268
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 259,
+                                      "end": 259
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 268,
+                                      "end": 268
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "dictionary_expr",
+                            "type": "$sSSSiXSDD",
+                            "range": {
+                              "start": 274,
+                              "end": 315
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "normal_conformance",
+                                            "type": "$sSSD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sq_D",
+                                        "children": [
+                                          {
+                                            "kind": "builtin_conformance",
+                                            "type": "$sSiD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 275,
+                                  "end": 281
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 275,
+                                      "end": 275
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 281,
+                                      "end": 281
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 286,
+                                  "end": 300
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 286,
+                                      "end": 286
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 300,
+                                      "end": 300
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expr",
+                                "type": "$sSS_SitD",
+                                "range": {
+                                  "start": 303,
+                                  "end": 312
+                                },
+                                "children": [
+                                  {
+                                    "kind": "string_literal_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 303,
+                                      "end": 303
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal_expr",
+                                    "type": "$sSiD",
+                                    "range": {
+                                      "start": 312,
+                                      "end": 312
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "pattern_named",
+                        "name": "orders",
+                        "type": "$sSSSiXSDXSaD"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "var_decl",
+        "name": "orders",
+        "range": {
+          "start": 176,
+          "end": 176
         }
       },
-      "range": {
-        "start": 172,
-        "end": 316
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "orders"
-        }
-      },
-      "range": {
-        "start": 176,
-        "end": 176
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
+      {
+        "kind": "top_level_code_decl",
         "range": {
           "start": 318,
           "end": 602
+        },
+        "children": [
+          {
+            "kind": "brace_stmt",
+            "range": {
+              "start": 318,
+              "end": 602
+            },
+            "children": [
+              {
+                "kind": "pattern_binding_decl",
+                "range": {
+                  "start": 318,
+                  "end": 602
+                },
+                "children": [
+                  {
+                    "kind": "pattern_entry",
+                    "children": [
+                      {
+                        "kind": "call_expr",
+                        "type": "$sSSypXSDXSaD",
+                        "range": {
+                          "start": 331,
+                          "end": 602
+                        },
+                        "children": [
+                          {
+                            "kind": "paren_expr",
+                            "type": "$sSSypXSDXSayXED",
+                            "range": {
+                              "start": 331,
+                              "end": 600
+                            },
+                            "children": [
+                              {
+                                "kind": "closure_expr",
+                                "type": "$sSSypXSDXSayXED",
+                                "range": {
+                                  "start": 332,
+                                  "end": 599
+                                },
+                                "children": [
+                                  {
+                                    "kind": "captured_value",
+                                    "children": [
+                                      {
+                                        "kind": "var_decl",
+                                        "name": "orders",
+                                        "range": {
+                                          "start": 176,
+                                          "end": 176
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "captured_value",
+                                    "children": [
+                                      {
+                                        "kind": "var_decl",
+                                        "name": "customers",
+                                        "range": {
+                                          "start": 75,
+                                          "end": 75
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "parameter_list",
+                                    "range": {
+                                      "start": 332,
+                                      "end": 332
+                                    }
+                                  },
+                                  {
+                                    "kind": "brace_stmt",
+                                    "range": {
+                                      "start": 332,
+                                      "end": 599
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "pattern_binding_decl",
+                                        "range": {
+                                          "start": 334,
+                                          "end": 363
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "pattern_entry",
+                                            "children": [
+                                              {
+                                                "kind": "pattern_typed",
+                                                "type": "$sSSypXSDXSaD",
+                                                "children": [
+                                                  {
+                                                    "kind": "pattern_named",
+                                                    "name": "_res",
+                                                    "type": "$sSSypXSDXSaD"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "array_expr",
+                                                "type": "$sSSypXSDXSaD",
+                                                "range": {
+                                                  "start": 362,
+                                                  "end": 363
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "substitution"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "array_expr",
+                                                "type": "$sSSypXSDXSaD",
+                                                "range": {
+                                                  "start": 362,
+                                                  "end": 363
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "var_decl",
+                                        "name": "_res",
+                                        "range": {
+                                          "start": 338,
+                                          "end": 338
+                                        }
+                                      },
+                                      {
+                                        "kind": "for_each_stmt",
+                                        "range": {
+                                          "start": 365,
+                                          "end": 585
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "call_expr",
+                                            "type": "$sSSSiXSDXSqD",
+                                            "range": {
+                                              "start": 365,
+                                              "end": 365
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "dot_syntax_call_expr",
+                                                "type": "$sSSSiXSDXSqycD",
+                                                "range": {
+                                                  "start": 365,
+                                                  "end": 365
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "type": "$sySSSiXSDXSqycs16IndexingIteratorVySSSiXSDXSaGzcD",
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution_map",
+                                                            "children": [
+                                                              {
+                                                                "kind": "substitution"
+                                                              },
+                                                              {
+                                                                "kind": "conformance",
+                                                                "type": "$sxD",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "specialized_conformance",
+                                                                    "type": "$sSSSiXSDXSaD"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "argument_list",
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument",
+                                                        "children": [
+                                                          {
+                                                            "kind": "inout_expr",
+                                                            "type": "$ss16IndexingIteratorVySSSiXSDXSaGzD",
+                                                            "range": {
+                                                              "start": 365,
+                                                              "end": 365
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "declref_expr",
+                                                                "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
+                                                                "range": {
+                                                                  "start": 365,
+                                                                  "end": 365
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "decl_ref"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "argument_list"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "brace_stmt",
+                                            "range": {
+                                              "start": 381,
+                                              "end": 585
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "for_each_stmt",
+                                                "range": {
+                                                  "start": 387,
+                                                  "end": 583
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "pattern_named",
+                                                    "name": "c",
+                                                    "type": "$sSSypXSDD"
+                                                  },
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "pattern_binding_decl",
+                                                    "children": [
+                                                      {
+                                                        "kind": "pattern_entry",
+                                                        "children": [
+                                                          {
+                                                            "kind": "pattern_named",
+                                                            "name": "$c$generator",
+                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD"
+                                                          },
+                                                          {
+                                                            "kind": "call_expr",
+                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                                            "range": {
+                                                              "start": 396,
+                                                              "end": 396
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "dot_syntax_call_expr",
+                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
+                                                                "range": {
+                                                                  "start": 396,
+                                                                  "end": 396
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution_map",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sxD",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "specialized_conformance",
+                                                                                    "type": "$sSSypXSDXSaD"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "argument_list",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "argument",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "declref_expr",
+                                                                            "type": "$sSSypXSDXSaD",
+                                                                            "range": {
+                                                                              "start": 396,
+                                                                              "end": 396
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "argument_list"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "call_expr",
+                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                                            "range": {
+                                                              "start": 396,
+                                                              "end": 396
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "dot_syntax_call_expr",
+                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
+                                                                "range": {
+                                                                  "start": 396,
+                                                                  "end": 396
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution_map",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sxD",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "specialized_conformance",
+                                                                                    "type": "$sSSypXSDXSaD"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "argument_list",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "argument",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "declref_expr",
+                                                                            "type": "$sSSypXSDXSaD",
+                                                                            "range": {
+                                                                              "start": 396,
+                                                                              "end": 396
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "argument_list"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expr",
+                                                    "type": "$sSSypXSDXSqD",
+                                                    "range": {
+                                                      "start": 387,
+                                                      "end": 387
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument_list"
+                                                      },
+                                                      {
+                                                        "kind": "dot_syntax_call_expr",
+                                                        "type": "$sSSypXSDXSqycD",
+                                                        "range": {
+                                                          "start": 387,
+                                                          "end": 387
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "declref_expr",
+                                                            "type": "$sySSypXSDXSqycs16IndexingIteratorVySSypXSDXSaGzcD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "substitution_map",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution"
+                                                                      },
+                                                                      {
+                                                                        "kind": "conformance",
+                                                                        "type": "$sxD",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "specialized_conformance",
+                                                                            "type": "$sSSypXSDXSaD"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "inout_expr",
+                                                                    "type": "$ss16IndexingIteratorVySSypXSDXSaGzD",
+                                                                    "range": {
+                                                                      "start": 387,
+                                                                      "end": 387
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "declref_expr",
+                                                                        "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                                                        "range": {
+                                                                          "start": 387,
+                                                                          "end": 387
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "decl_ref"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "brace_stmt",
+                                                    "range": {
+                                                      "start": 406,
+                                                      "end": 583
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "call_expr",
+                                                        "type": "$sytD",
+                                                        "range": {
+                                                          "start": 416,
+                                                          "end": 577
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "dot_syntax_call_expr",
+                                                            "type": "$syySSypXSDncD",
+                                                            "range": {
+                                                              "start": 416,
+                                                              "end": 421
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "declref_expr",
+                                                                "type": "$syySSypXSDncSaySSypXSDGzcD",
+                                                                "range": {
+                                                                  "start": 421,
+                                                                  "end": 421
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "decl_ref",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution_map",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution"
+                                                                          },
+                                                                          {
+                                                                            "kind": "conformance",
+                                                                            "type": "$sxD",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSSypXSDD"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "conformance",
+                                                                            "type": "$sxD",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSSypXSDD"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "argument_list",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "argument",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "inout_expr",
+                                                                        "type": "$sSaySSypXSDGzD",
+                                                                        "range": {
+                                                                          "start": 416,
+                                                                          "end": 416
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "declref_expr",
+                                                                            "type": "$sSSypXSDXSaD",
+                                                                            "range": {
+                                                                              "start": 416,
+                                                                              "end": 416
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "dictionary_expr",
+                                                                    "type": "$sSSypXSDD",
+                                                                    "range": {
+                                                                      "start": 428,
+                                                                      "end": 576
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution_map",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sxD",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "normal_conformance",
+                                                                                    "type": "$sSSD"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sq_D",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "self_conformance",
+                                                                                    "type": "$sypD"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sq_D",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "self_conformance",
+                                                                                    "type": "$sypD"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 429,
+                                                                          "end": 457
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 429,
+                                                                              "end": 429
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "erasure_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 440,
+                                                                              "end": 457
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "paren_expr",
+                                                                                "type": "$sSiD",
+                                                                                "range": {
+                                                                                  "start": 440,
+                                                                                  "end": 457
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "forced_checked_cast_expr",
+                                                                                    "type": "$sSiD",
+                                                                                    "range": {
+                                                                                      "start": 441,
+                                                                                      "end": 454
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "force_value_expr",
+                                                                                        "type": "$sSiD",
+                                                                                        "range": {
+                                                                                          "start": 441,
+                                                                                          "end": 448
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "subscript_expr",
+                                                                                            "type": "$sSiXSqD",
+                                                                                            "range": {
+                                                                                              "start": 441,
+                                                                                              "end": 447
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "substitution_map",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sxD",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "normal_conformance",
+                                                                                                            "type": "$sSSD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "declref_expr",
+                                                                                                "type": "$sSSSiXSDD",
+                                                                                                "range": {
+                                                                                                  "start": 441,
+                                                                                                  "end": 441
+                                                                                                },
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "decl_ref"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "argument_list",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "argument",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "string_literal_expr",
+                                                                                                        "type": "$sSSD",
+                                                                                                        "range": {
+                                                                                                          "start": 443,
+                                                                                                          "end": 443
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "decl_ref"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 460,
+                                                                          "end": 504
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 460,
+                                                                              "end": 460
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "erasure_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 479,
+                                                                              "end": 504
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "paren_expr",
+                                                                                "type": "$sSiD",
+                                                                                "range": {
+                                                                                  "start": 479,
+                                                                                  "end": 504
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "forced_checked_cast_expr",
+                                                                                    "type": "$sSiD",
+                                                                                    "range": {
+                                                                                      "start": 480,
+                                                                                      "end": 501
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "force_value_expr",
+                                                                                        "type": "$sSiD",
+                                                                                        "range": {
+                                                                                          "start": 480,
+                                                                                          "end": 495
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "subscript_expr",
+                                                                                            "type": "$sSiXSqD",
+                                                                                            "range": {
+                                                                                              "start": 480,
+                                                                                              "end": 494
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "substitution_map",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sxD",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "normal_conformance",
+                                                                                                            "type": "$sSSD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "declref_expr",
+                                                                                                "type": "$sSSSiXSDD",
+                                                                                                "range": {
+                                                                                                  "start": 480,
+                                                                                                  "end": 480
+                                                                                                },
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "decl_ref"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "argument_list",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "argument",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "string_literal_expr",
+                                                                                                        "type": "$sSSD",
+                                                                                                        "range": {
+                                                                                                          "start": 482,
+                                                                                                          "end": 482
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "decl_ref"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 507,
+                                                                          "end": 538
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 507,
+                                                                              "end": 507
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "force_value_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 529,
+                                                                              "end": 538
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "subscript_expr",
+                                                                                "type": "$sypXSqD",
+                                                                                "range": {
+                                                                                  "start": 529,
+                                                                                  "end": 537
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "decl_ref",
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "substitution_map",
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "substitution"
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "substitution"
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "conformance",
+                                                                                            "type": "$sxD",
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "normal_conformance",
+                                                                                                "type": "$sSSD"
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "conformance",
+                                                                                            "type": "$sq_D",
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "self_conformance",
+                                                                                                "type": "$sypD"
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "conformance",
+                                                                                            "type": "$sq_D",
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "self_conformance",
+                                                                                                "type": "$sypD"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "declref_expr",
+                                                                                    "type": "$sSSypXSDD",
+                                                                                    "range": {
+                                                                                      "start": 529,
+                                                                                      "end": 529
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "decl_ref"
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "argument_list",
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "argument",
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "string_literal_expr",
+                                                                                            "type": "$sSSD",
+                                                                                            "range": {
+                                                                                              "start": 531,
+                                                                                              "end": 531
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 541,
+                                                                          "end": 575
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 541,
+                                                                              "end": 541
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "erasure_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 555,
+                                                                              "end": 575
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "paren_expr",
+                                                                                "type": "$sSiD",
+                                                                                "range": {
+                                                                                  "start": 555,
+                                                                                  "end": 575
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "forced_checked_cast_expr",
+                                                                                    "type": "$sSiD",
+                                                                                    "range": {
+                                                                                      "start": 556,
+                                                                                      "end": 572
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "force_value_expr",
+                                                                                        "type": "$sSiD",
+                                                                                        "range": {
+                                                                                          "start": 556,
+                                                                                          "end": 566
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "subscript_expr",
+                                                                                            "type": "$sSiXSqD",
+                                                                                            "range": {
+                                                                                              "start": 556,
+                                                                                              "end": 565
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "substitution_map",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sxD",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "normal_conformance",
+                                                                                                            "type": "$sSSD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "declref_expr",
+                                                                                                "type": "$sSSSiXSDD",
+                                                                                                "range": {
+                                                                                                  "start": 556,
+                                                                                                  "end": 556
+                                                                                                },
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "decl_ref"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "argument_list",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "argument",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "string_literal_expr",
+                                                                                                        "type": "$sSSD",
+                                                                                                        "range": {
+                                                                                                          "start": 558,
+                                                                                                          "end": 558
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "decl_ref"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "pattern_named",
+                                            "name": "o",
+                                            "type": "$sSSSiXSDD"
+                                          },
+                                          {
+                                            "kind": "declref_expr",
+                                            "children": [
+                                              {
+                                                "kind": "decl_ref"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "pattern_binding_decl",
+                                            "children": [
+                                              {
+                                                "kind": "pattern_entry",
+                                                "children": [
+                                                  {
+                                                    "kind": "pattern_named",
+                                                    "name": "$o$generator",
+                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD"
+                                                  },
+                                                  {
+                                                    "kind": "call_expr",
+                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
+                                                    "range": {
+                                                      "start": 374,
+                                                      "end": 374
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "dot_syntax_call_expr",
+                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
+                                                        "range": {
+                                                          "start": 374,
+                                                          "end": 374
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "declref_expr",
+                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "substitution_map",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution"
+                                                                      },
+                                                                      {
+                                                                        "kind": "conformance",
+                                                                        "type": "$sxD",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "specialized_conformance",
+                                                                            "type": "$sSSSiXSDXSaD"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sSSSiXSDXSaD",
+                                                                    "range": {
+                                                                      "start": 374,
+                                                                      "end": 374
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "argument_list"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expr",
+                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
+                                                    "range": {
+                                                      "start": 374,
+                                                      "end": 374
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "dot_syntax_call_expr",
+                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
+                                                        "range": {
+                                                          "start": 374,
+                                                          "end": 374
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "declref_expr",
+                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "substitution_map",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution"
+                                                                      },
+                                                                      {
+                                                                        "kind": "conformance",
+                                                                        "type": "$sxD",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "specialized_conformance",
+                                                                            "type": "$sSSSiXSDXSaD"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sSSSiXSDXSaD",
+                                                                    "range": {
+                                                                      "start": 374,
+                                                                      "end": 374
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "argument_list"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "return_stmt",
+                                        "range": {
+                                          "start": 587,
+                                          "end": 594
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "load_expr",
+                                            "type": "$sSSypXSDXSaD",
+                                            "range": {
+                                              "start": 594,
+                                              "end": 594
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "declref_expr",
+                                                "type": "$sSSypXSDXSaD",
+                                                "range": {
+                                                  "start": 594,
+                                                  "end": 594
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "pattern_named",
+                        "name": "result",
+                        "type": "$sSSypXSDXSaD"
+                      },
+                      {
+                        "kind": "call_expr",
+                        "type": "$sSSypXSDXSaD",
+                        "range": {
+                          "start": 331,
+                          "end": 602
+                        },
+                        "children": [
+                          {
+                            "kind": "argument_list"
+                          },
+                          {
+                            "kind": "paren_expr",
+                            "type": "$sSSypXSDXSayXED",
+                            "range": {
+                              "start": 331,
+                              "end": 600
+                            },
+                            "children": [
+                              {
+                                "kind": "closure_expr",
+                                "type": "$sSSypXSDXSayXED",
+                                "range": {
+                                  "start": 332,
+                                  "end": 599
+                                },
+                                "children": [
+                                  {
+                                    "kind": "captured_value",
+                                    "children": [
+                                      {
+                                        "kind": "var_decl",
+                                        "name": "orders",
+                                        "range": {
+                                          "start": 176,
+                                          "end": 176
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "captured_value",
+                                    "children": [
+                                      {
+                                        "kind": "var_decl",
+                                        "name": "customers",
+                                        "range": {
+                                          "start": 75,
+                                          "end": 75
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "parameter_list",
+                                    "range": {
+                                      "start": 332,
+                                      "end": 332
+                                    }
+                                  },
+                                  {
+                                    "kind": "brace_stmt",
+                                    "range": {
+                                      "start": 332,
+                                      "end": 599
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "pattern_binding_decl",
+                                        "range": {
+                                          "start": 334,
+                                          "end": 363
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "pattern_entry",
+                                            "children": [
+                                              {
+                                                "kind": "pattern_typed",
+                                                "type": "$sSSypXSDXSaD",
+                                                "children": [
+                                                  {
+                                                    "kind": "pattern_named",
+                                                    "name": "_res",
+                                                    "type": "$sSSypXSDXSaD"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "array_expr",
+                                                "type": "$sSSypXSDXSaD",
+                                                "range": {
+                                                  "start": 362,
+                                                  "end": 363
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "array_expr",
+                                                "type": "$sSSypXSDXSaD",
+                                                "range": {
+                                                  "start": 362,
+                                                  "end": 363
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "builtin_conformance",
+                                                                "type": "$sSSypXSDD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "substitution"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "var_decl",
+                                        "name": "_res",
+                                        "range": {
+                                          "start": 338,
+                                          "end": 338
+                                        }
+                                      },
+                                      {
+                                        "kind": "for_each_stmt",
+                                        "range": {
+                                          "start": 365,
+                                          "end": 585
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "call_expr",
+                                            "type": "$sSSSiXSDXSqD",
+                                            "range": {
+                                              "start": 365,
+                                              "end": 365
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "dot_syntax_call_expr",
+                                                "type": "$sSSSiXSDXSqycD",
+                                                "range": {
+                                                  "start": 365,
+                                                  "end": 365
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "type": "$sySSSiXSDXSqycs16IndexingIteratorVySSSiXSDXSaGzcD",
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution_map",
+                                                            "children": [
+                                                              {
+                                                                "kind": "substitution"
+                                                              },
+                                                              {
+                                                                "kind": "conformance",
+                                                                "type": "$sxD",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "specialized_conformance",
+                                                                    "type": "$sSSSiXSDXSaD"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "argument_list",
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument",
+                                                        "children": [
+                                                          {
+                                                            "kind": "inout_expr",
+                                                            "type": "$ss16IndexingIteratorVySSSiXSDXSaGzD",
+                                                            "range": {
+                                                              "start": 365,
+                                                              "end": 365
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "declref_expr",
+                                                                "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
+                                                                "range": {
+                                                                  "start": 365,
+                                                                  "end": 365
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "decl_ref"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "argument_list"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "brace_stmt",
+                                            "range": {
+                                              "start": 381,
+                                              "end": 585
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "for_each_stmt",
+                                                "range": {
+                                                  "start": 387,
+                                                  "end": 583
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "brace_stmt",
+                                                    "range": {
+                                                      "start": 406,
+                                                      "end": 583
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "call_expr",
+                                                        "type": "$sytD",
+                                                        "range": {
+                                                          "start": 416,
+                                                          "end": 577
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "dot_syntax_call_expr",
+                                                            "type": "$syySSypXSDncD",
+                                                            "range": {
+                                                              "start": 416,
+                                                              "end": 421
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "declref_expr",
+                                                                "type": "$syySSypXSDncSaySSypXSDGzcD",
+                                                                "range": {
+                                                                  "start": 421,
+                                                                  "end": 421
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "decl_ref",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution_map",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution"
+                                                                          },
+                                                                          {
+                                                                            "kind": "conformance",
+                                                                            "type": "$sxD",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSSypXSDD"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "conformance",
+                                                                            "type": "$sxD",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSSypXSDD"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "argument_list",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "argument",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "inout_expr",
+                                                                        "type": "$sSaySSypXSDGzD",
+                                                                        "range": {
+                                                                          "start": 416,
+                                                                          "end": 416
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "declref_expr",
+                                                                            "type": "$sSSypXSDXSaD",
+                                                                            "range": {
+                                                                              "start": 416,
+                                                                              "end": 416
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "dictionary_expr",
+                                                                    "type": "$sSSypXSDD",
+                                                                    "range": {
+                                                                      "start": 428,
+                                                                      "end": 576
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution_map",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sxD",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "normal_conformance",
+                                                                                    "type": "$sSSD"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sq_D",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "self_conformance",
+                                                                                    "type": "$sypD"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sq_D",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "self_conformance",
+                                                                                    "type": "$sypD"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 429,
+                                                                          "end": 457
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 429,
+                                                                              "end": 429
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "erasure_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 440,
+                                                                              "end": 457
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "paren_expr",
+                                                                                "type": "$sSiD",
+                                                                                "range": {
+                                                                                  "start": 440,
+                                                                                  "end": 457
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "forced_checked_cast_expr",
+                                                                                    "type": "$sSiD",
+                                                                                    "range": {
+                                                                                      "start": 441,
+                                                                                      "end": 454
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "force_value_expr",
+                                                                                        "type": "$sSiD",
+                                                                                        "range": {
+                                                                                          "start": 441,
+                                                                                          "end": 448
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "subscript_expr",
+                                                                                            "type": "$sSiXSqD",
+                                                                                            "range": {
+                                                                                              "start": 441,
+                                                                                              "end": 447
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "substitution_map",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sxD",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "normal_conformance",
+                                                                                                            "type": "$sSSD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "declref_expr",
+                                                                                                "type": "$sSSSiXSDD",
+                                                                                                "range": {
+                                                                                                  "start": 441,
+                                                                                                  "end": 441
+                                                                                                },
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "decl_ref"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "argument_list",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "argument",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "string_literal_expr",
+                                                                                                        "type": "$sSSD",
+                                                                                                        "range": {
+                                                                                                          "start": 443,
+                                                                                                          "end": 443
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "decl_ref"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 460,
+                                                                          "end": 504
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 460,
+                                                                              "end": 460
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "erasure_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 479,
+                                                                              "end": 504
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "paren_expr",
+                                                                                "type": "$sSiD",
+                                                                                "range": {
+                                                                                  "start": 479,
+                                                                                  "end": 504
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "forced_checked_cast_expr",
+                                                                                    "type": "$sSiD",
+                                                                                    "range": {
+                                                                                      "start": 480,
+                                                                                      "end": 501
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "force_value_expr",
+                                                                                        "type": "$sSiD",
+                                                                                        "range": {
+                                                                                          "start": 480,
+                                                                                          "end": 495
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "subscript_expr",
+                                                                                            "type": "$sSiXSqD",
+                                                                                            "range": {
+                                                                                              "start": 480,
+                                                                                              "end": 494
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "substitution_map",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sxD",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "normal_conformance",
+                                                                                                            "type": "$sSSD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "declref_expr",
+                                                                                                "type": "$sSSSiXSDD",
+                                                                                                "range": {
+                                                                                                  "start": 480,
+                                                                                                  "end": 480
+                                                                                                },
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "decl_ref"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "argument_list",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "argument",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "string_literal_expr",
+                                                                                                        "type": "$sSSD",
+                                                                                                        "range": {
+                                                                                                          "start": 482,
+                                                                                                          "end": 482
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "decl_ref"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 507,
+                                                                          "end": 538
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 507,
+                                                                              "end": 507
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "force_value_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 529,
+                                                                              "end": 538
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "subscript_expr",
+                                                                                "type": "$sypXSqD",
+                                                                                "range": {
+                                                                                  "start": 529,
+                                                                                  "end": 537
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "declref_expr",
+                                                                                    "type": "$sSSypXSDD",
+                                                                                    "range": {
+                                                                                      "start": 529,
+                                                                                      "end": 529
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "decl_ref"
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "argument_list",
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "argument",
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "string_literal_expr",
+                                                                                            "type": "$sSSD",
+                                                                                            "range": {
+                                                                                              "start": 531,
+                                                                                              "end": 531
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "decl_ref",
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "substitution_map",
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "substitution"
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "substitution"
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "conformance",
+                                                                                            "type": "$sxD",
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "normal_conformance",
+                                                                                                "type": "$sSSD"
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "conformance",
+                                                                                            "type": "$sq_D",
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "self_conformance",
+                                                                                                "type": "$sypD"
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "conformance",
+                                                                                            "type": "$sq_D",
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "self_conformance",
+                                                                                                "type": "$sypD"
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expr",
+                                                                        "type": "$sSS_yptD",
+                                                                        "range": {
+                                                                          "start": 541,
+                                                                          "end": 575
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "string_literal_expr",
+                                                                            "type": "$sSSD",
+                                                                            "range": {
+                                                                              "start": 541,
+                                                                              "end": 541
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "erasure_expr",
+                                                                            "type": "$sypD",
+                                                                            "range": {
+                                                                              "start": 555,
+                                                                              "end": 575
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "builtin_conformance",
+                                                                                "type": "$sSiD"
+                                                                              },
+                                                                              {
+                                                                                "kind": "paren_expr",
+                                                                                "type": "$sSiD",
+                                                                                "range": {
+                                                                                  "start": 555,
+                                                                                  "end": 575
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "forced_checked_cast_expr",
+                                                                                    "type": "$sSiD",
+                                                                                    "range": {
+                                                                                      "start": 556,
+                                                                                      "end": 572
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "force_value_expr",
+                                                                                        "type": "$sSiD",
+                                                                                        "range": {
+                                                                                          "start": 556,
+                                                                                          "end": 566
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "subscript_expr",
+                                                                                            "type": "$sSiXSqD",
+                                                                                            "range": {
+                                                                                              "start": 556,
+                                                                                              "end": 565
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "decl_ref",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "substitution_map",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sxD",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "normal_conformance",
+                                                                                                            "type": "$sSSD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "conformance",
+                                                                                                        "type": "$sq_D",
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "builtin_conformance",
+                                                                                                            "type": "$sSiD"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "substitution"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "declref_expr",
+                                                                                                "type": "$sSSSiXSDD",
+                                                                                                "range": {
+                                                                                                  "start": 556,
+                                                                                                  "end": 556
+                                                                                                },
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "decl_ref"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "argument_list",
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "argument",
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "string_literal_expr",
+                                                                                                        "type": "$sSSD",
+                                                                                                        "range": {
+                                                                                                          "start": 558,
+                                                                                                          "end": 558
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "decl_ref"
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "pattern_named",
+                                                    "name": "c",
+                                                    "type": "$sSSypXSDD"
+                                                  },
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "pattern_binding_decl",
+                                                    "children": [
+                                                      {
+                                                        "kind": "pattern_entry",
+                                                        "children": [
+                                                          {
+                                                            "kind": "pattern_named",
+                                                            "name": "$c$generator",
+                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD"
+                                                          },
+                                                          {
+                                                            "kind": "call_expr",
+                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                                            "range": {
+                                                              "start": 396,
+                                                              "end": 396
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "dot_syntax_call_expr",
+                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
+                                                                "range": {
+                                                                  "start": 396,
+                                                                  "end": 396
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution_map",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sxD",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "specialized_conformance",
+                                                                                    "type": "$sSSypXSDXSaD"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "argument_list",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "argument",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "declref_expr",
+                                                                            "type": "$sSSypXSDXSaD",
+                                                                            "range": {
+                                                                              "start": 396,
+                                                                              "end": 396
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "argument_list"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "call_expr",
+                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                                            "range": {
+                                                              "start": 396,
+                                                              "end": 396
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument_list"
+                                                              },
+                                                              {
+                                                                "kind": "dot_syntax_call_expr",
+                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
+                                                                "range": {
+                                                                  "start": 396,
+                                                                  "end": 396
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "substitution_map",
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "substitution"
+                                                                              },
+                                                                              {
+                                                                                "kind": "conformance",
+                                                                                "type": "$sxD",
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "specialized_conformance",
+                                                                                    "type": "$sSSypXSDXSaD"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "argument_list",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "argument",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "declref_expr",
+                                                                            "type": "$sSSypXSDXSaD",
+                                                                            "range": {
+                                                                              "start": 396,
+                                                                              "end": 396
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "decl_ref"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expr",
+                                                    "type": "$sSSypXSDXSqD",
+                                                    "range": {
+                                                      "start": 387,
+                                                      "end": 387
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "dot_syntax_call_expr",
+                                                        "type": "$sSSypXSDXSqycD",
+                                                        "range": {
+                                                          "start": 387,
+                                                          "end": 387
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "inout_expr",
+                                                                    "type": "$ss16IndexingIteratorVySSypXSDXSaGzD",
+                                                                    "range": {
+                                                                      "start": 387,
+                                                                      "end": 387
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "declref_expr",
+                                                                        "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                                                        "range": {
+                                                                          "start": 387,
+                                                                          "end": 387
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "decl_ref"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "declref_expr",
+                                                            "type": "$sySSypXSDXSqycs16IndexingIteratorVySSypXSDXSaGzcD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "substitution_map",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution"
+                                                                      },
+                                                                      {
+                                                                        "kind": "conformance",
+                                                                        "type": "$sxD",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "specialized_conformance",
+                                                                            "type": "$sSSypXSDXSaD"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "argument_list"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "pattern_named",
+                                            "name": "o",
+                                            "type": "$sSSSiXSDD"
+                                          },
+                                          {
+                                            "kind": "declref_expr",
+                                            "children": [
+                                              {
+                                                "kind": "decl_ref"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "pattern_binding_decl",
+                                            "children": [
+                                              {
+                                                "kind": "pattern_entry",
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expr",
+                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
+                                                    "range": {
+                                                      "start": 374,
+                                                      "end": 374
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "dot_syntax_call_expr",
+                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
+                                                        "range": {
+                                                          "start": 374,
+                                                          "end": 374
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "declref_expr",
+                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "substitution_map",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "substitution"
+                                                                      },
+                                                                      {
+                                                                        "kind": "conformance",
+                                                                        "type": "$sxD",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "specialized_conformance",
+                                                                            "type": "$sSSSiXSDXSaD"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sSSSiXSDXSaD",
+                                                                    "range": {
+                                                                      "start": 374,
+                                                                      "end": 374
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "argument_list"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expr",
+                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
+                                                    "range": {
+                                                      "start": 374,
+                                                      "end": 374
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "dot_syntax_call_expr",
+                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
+                                                        "range": {
+                                                          "start": 374,
+                                                          "end": 374
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "children": [
+                                                              {
+                                                                "kind": "argument",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "declref_expr",
+                                                                    "type": "$sSSSiXSDXSaD",
+                                                                    "range": {
+                                                                      "start": 374,
+                                                                      "end": 374
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "decl_ref"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "declref_expr",
+                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "substitution_map",
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "conformance",
+                                                                        "type": "$sxD",
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "specialized_conformance",
+                                                                            "type": "$sSSSiXSDXSaD"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "substitution"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "argument_list"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "pattern_named",
+                                                    "name": "$o$generator",
+                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "return_stmt",
+                                        "range": {
+                                          "start": 587,
+                                          "end": 594
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "load_expr",
+                                            "type": "$sSSypXSDXSaD",
+                                            "range": {
+                                              "start": 594,
+                                              "end": 594
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "declref_expr",
+                                                "type": "$sSSypXSDXSaD",
+                                                "range": {
+                                                  "start": 594,
+                                                  "end": 594
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "var_decl",
+        "name": "result",
+        "range": {
+          "start": 322,
+          "end": 322
         }
       },
-      "range": {
-        "start": 318,
-        "end": 602
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "result"
-        }
-      },
-      "range": {
-        "start": 322,
-        "end": 322
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
+      {
+        "kind": "top_level_code_decl",
         "range": {
           "start": 604,
           "end": 656
-        }
+        },
+        "children": [
+          {
+            "kind": "brace_stmt",
+            "range": {
+              "start": 604,
+              "end": 656
+            },
+            "children": [
+              {
+                "kind": "call_expr",
+                "type": "$sytD",
+                "range": {
+                  "start": 604,
+                  "end": 656
+                },
+                "children": [
+                  {
+                    "kind": "declref_expr",
+                    "type": "$s_9separator10terminatoryypd_S2StcD",
+                    "range": {
+                      "start": 604,
+                      "end": 604
+                    },
+                    "children": [
+                      {
+                        "kind": "decl_ref"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "argument_list",
+                    "children": [
+                      {
+                        "kind": "argument",
+                        "children": [
+                          {
+                            "kind": "vararg_expansion_expr",
+                            "type": "$sypXSaD",
+                            "range": {
+                              "start": 610,
+                              "end": 610
+                            },
+                            "children": [
+                              {
+                                "kind": "array_expr",
+                                "type": "$sypXSaD",
+                                "range": {
+                                  "start": 610,
+                                  "end": 610
+                                },
+                                "children": [
+                                  {
+                                    "kind": "erasure_expr",
+                                    "type": "$sypD",
+                                    "range": {
+                                      "start": 610,
+                                      "end": 610
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "builtin_conformance",
+                                        "type": "$sSSD"
+                                      },
+                                      {
+                                        "kind": "string_literal_expr",
+                                        "type": "$sSSD",
+                                        "range": {
+                                          "start": 610,
+                                          "end": 610
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument",
+                        "children": [
+                          {
+                            "kind": "default_argument_expr",
+                            "type": "$sSSD",
+                            "range": {
+                              "start": 609,
+                              "end": 609
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument",
+                        "children": [
+                          {
+                            "kind": "default_argument_expr",
+                            "type": "$sSSD",
+                            "range": {
+                              "start": 609,
+                              "end": 609
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 604,
-        "end": 656
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
+      {
+        "kind": "top_level_code_decl",
         "range": {
           "start": 658,
           "end": 844
-        }
-      },
-      "range": {
-        "start": 658,
-        "end": 844
+        },
+        "children": [
+          {
+            "kind": "brace_stmt",
+            "range": {
+              "start": 658,
+              "end": 844
+            },
+            "children": [
+              {
+                "kind": "for_each_stmt",
+                "range": {
+                  "start": 658,
+                  "end": 844
+                },
+                "children": [
+                  {
+                    "kind": "pattern_named",
+                    "name": "entry",
+                    "type": "$sSSypXSDD"
+                  },
+                  {
+                    "kind": "declref_expr",
+                    "children": [
+                      {
+                        "kind": "decl_ref"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pattern_binding_decl",
+                    "children": [
+                      {
+                        "kind": "pattern_entry",
+                        "children": [
+                          {
+                            "kind": "pattern_named",
+                            "name": "$entry$generator",
+                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD"
+                          },
+                          {
+                            "kind": "call_expr",
+                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                            "range": {
+                              "start": 671,
+                              "end": 671
+                            },
+                            "children": [
+                              {
+                                "kind": "dot_syntax_call_expr",
+                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
+                                "range": {
+                                  "start": 671,
+                                  "end": 671
+                                },
+                                "children": [
+                                  {
+                                    "kind": "declref_expr",
+                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref",
+                                        "children": [
+                                          {
+                                            "kind": "substitution_map",
+                                            "children": [
+                                              {
+                                                "kind": "substitution"
+                                              },
+                                              {
+                                                "kind": "conformance",
+                                                "type": "$sxD",
+                                                "children": [
+                                                  {
+                                                    "kind": "specialized_conformance",
+                                                    "type": "$sSSypXSDXSaD"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "children": [
+                                      {
+                                        "kind": "argument",
+                                        "children": [
+                                          {
+                                            "kind": "declref_expr",
+                                            "type": "$sSSypXSDXSaD",
+                                            "range": {
+                                              "start": 671,
+                                              "end": 671
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "decl_ref"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_expr",
+                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                            "range": {
+                              "start": 671,
+                              "end": 671
+                            },
+                            "children": [
+                              {
+                                "kind": "dot_syntax_call_expr",
+                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
+                                "range": {
+                                  "start": 671,
+                                  "end": 671
+                                },
+                                "children": [
+                                  {
+                                    "kind": "declref_expr",
+                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref",
+                                        "children": [
+                                          {
+                                            "kind": "substitution_map",
+                                            "children": [
+                                              {
+                                                "kind": "substitution"
+                                              },
+                                              {
+                                                "kind": "conformance",
+                                                "type": "$sxD",
+                                                "children": [
+                                                  {
+                                                    "kind": "specialized_conformance",
+                                                    "type": "$sSSypXSDXSaD"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "children": [
+                                      {
+                                        "kind": "argument",
+                                        "children": [
+                                          {
+                                            "kind": "declref_expr",
+                                            "type": "$sSSypXSDXSaD",
+                                            "range": {
+                                              "start": 671,
+                                              "end": 671
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "decl_ref"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call_expr",
+                    "type": "$sSSypXSDXSqD",
+                    "range": {
+                      "start": 658,
+                      "end": 658
+                    },
+                    "children": [
+                      {
+                        "kind": "dot_syntax_call_expr",
+                        "type": "$sSSypXSDXSqycD",
+                        "range": {
+                          "start": 658,
+                          "end": 658
+                        },
+                        "children": [
+                          {
+                            "kind": "declref_expr",
+                            "type": "$sySSypXSDXSqycs16IndexingIteratorVySSypXSDXSaGzcD",
+                            "children": [
+                              {
+                                "kind": "decl_ref",
+                                "children": [
+                                  {
+                                    "kind": "substitution_map",
+                                    "children": [
+                                      {
+                                        "kind": "substitution"
+                                      },
+                                      {
+                                        "kind": "conformance",
+                                        "type": "$sxD",
+                                        "children": [
+                                          {
+                                            "kind": "specialized_conformance",
+                                            "type": "$sSSypXSDXSaD"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "children": [
+                              {
+                                "kind": "argument",
+                                "children": [
+                                  {
+                                    "kind": "inout_expr",
+                                    "type": "$ss16IndexingIteratorVySSypXSDXSaGzD",
+                                    "range": {
+                                      "start": 658,
+                                      "end": 658
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "declref_expr",
+                                        "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
+                                        "range": {
+                                          "start": 658,
+                                          "end": 658
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "decl_ref"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "brace_stmt",
+                    "range": {
+                      "start": 678,
+                      "end": 844
+                    },
+                    "children": [
+                      {
+                        "kind": "call_expr",
+                        "type": "$sytD",
+                        "range": {
+                          "start": 684,
+                          "end": 842
+                        },
+                        "children": [
+                          {
+                            "kind": "declref_expr",
+                            "type": "$s_9separator10terminatoryypd_S2StcD",
+                            "range": {
+                              "start": 684,
+                              "end": 684
+                            },
+                            "children": [
+                              {
+                                "kind": "decl_ref"
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "children": [
+                              {
+                                "kind": "argument",
+                                "children": [
+                                  {
+                                    "kind": "vararg_expansion_expr",
+                                    "type": "$sypXSaD",
+                                    "range": {
+                                      "start": 690,
+                                      "end": 841
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "array_expr",
+                                        "type": "$sypXSaD",
+                                        "range": {
+                                          "start": 690,
+                                          "end": 841
+                                        },
+                                        "children": [
+                                          {
+                                            "kind": "erasure_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 690,
+                                              "end": 690
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "string_literal_expr",
+                                                "type": "$sSSD",
+                                                "range": {
+                                                  "start": 690,
+                                                  "end": 690
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "force_value_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 699,
+                                              "end": 715
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "subscript_expr",
+                                                "type": "$sypXSqD",
+                                                "range": {
+                                                  "start": 699,
+                                                  "end": 714
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "normal_conformance",
+                                                                "type": "$sSSD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "type": "$sSSypXSDD",
+                                                    "range": {
+                                                      "start": 699,
+                                                      "end": 699
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "argument_list",
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument",
+                                                        "children": [
+                                                          {
+                                                            "kind": "string_literal_expr",
+                                                            "type": "$sSSD",
+                                                            "range": {
+                                                              "start": 705,
+                                                              "end": 705
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "erasure_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 718,
+                                              "end": 718
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "string_literal_expr",
+                                                "type": "$sSSD",
+                                                "range": {
+                                                  "start": 718,
+                                                  "end": 718
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "force_value_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 734,
+                                              "end": 758
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "subscript_expr",
+                                                "type": "$sypXSqD",
+                                                "range": {
+                                                  "start": 734,
+                                                  "end": 757
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "type": "$sSSypXSDD",
+                                                    "range": {
+                                                      "start": 734,
+                                                      "end": 734
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "argument_list",
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument",
+                                                        "children": [
+                                                          {
+                                                            "kind": "string_literal_expr",
+                                                            "type": "$sSSD",
+                                                            "range": {
+                                                              "start": 740,
+                                                              "end": 740
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "normal_conformance",
+                                                                "type": "$sSSD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "erasure_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 761,
+                                              "end": 761
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "string_literal_expr",
+                                                "type": "$sSSD",
+                                                "range": {
+                                                  "start": 761,
+                                                  "end": 761
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "force_value_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 775,
+                                              "end": 794
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "subscript_expr",
+                                                "type": "$sypXSqD",
+                                                "range": {
+                                                  "start": 775,
+                                                  "end": 793
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "argument_list",
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument",
+                                                        "children": [
+                                                          {
+                                                            "kind": "string_literal_expr",
+                                                            "type": "$sSSD",
+                                                            "range": {
+                                                              "start": 781,
+                                                              "end": 781
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "normal_conformance",
+                                                                "type": "$sSSD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "type": "$sSSypXSDD",
+                                                    "range": {
+                                                      "start": 775,
+                                                      "end": 775
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "erasure_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 797,
+                                              "end": 797
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "builtin_conformance",
+                                                "type": "$sSSD"
+                                              },
+                                              {
+                                                "kind": "string_literal_expr",
+                                                "type": "$sSSD",
+                                                "range": {
+                                                  "start": 797,
+                                                  "end": 797
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "decl_ref"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "force_value_expr",
+                                            "type": "$sypD",
+                                            "range": {
+                                              "start": 814,
+                                              "end": 841
+                                            },
+                                            "children": [
+                                              {
+                                                "kind": "subscript_expr",
+                                                "type": "$sypXSqD",
+                                                "range": {
+                                                  "start": 814,
+                                                  "end": 840
+                                                },
+                                                "children": [
+                                                  {
+                                                    "kind": "argument_list",
+                                                    "children": [
+                                                      {
+                                                        "kind": "argument",
+                                                        "children": [
+                                                          {
+                                                            "kind": "string_literal_expr",
+                                                            "type": "$sSSD",
+                                                            "range": {
+                                                              "start": 820,
+                                                              "end": 820
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "kind": "decl_ref"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "decl_ref",
+                                                    "children": [
+                                                      {
+                                                        "kind": "substitution_map",
+                                                        "children": [
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "substitution"
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sxD",
+                                                            "children": [
+                                                              {
+                                                                "kind": "normal_conformance",
+                                                                "type": "$sSSD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "conformance",
+                                                            "type": "$sq_D",
+                                                            "children": [
+                                                              {
+                                                                "kind": "self_conformance",
+                                                                "type": "$sypD"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "declref_expr",
+                                                    "type": "$sSSypXSDD",
+                                                    "range": {
+                                                      "start": 814,
+                                                      "end": 814
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "kind": "decl_ref"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument",
+                                "children": [
+                                  {
+                                    "kind": "default_argument_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 689,
+                                      "end": 689
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument",
+                                "children": [
+                                  {
+                                    "kind": "default_argument_expr",
+                                    "type": "$sSSD",
+                                    "range": {
+                                      "start": 689,
+                                      "end": 689
+                                    },
+                                    "children": [
+                                      {
+                                        "kind": "decl_ref"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- capture full Swift AST including nested statements and expressions
- return hierarchical AST nodes instead of top-level declarations
- regenerate golden output for `cross_join.swift`

## Testing
- `go build ./tools/json-ast/x/swift`
- `go test ./tools/json-ast/x/swift -run Inspect_Golden/cross_join -update -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688986b474908320ab77705aab0b428f