### PR TITLE
Use Kastree for Kotlin AST

### DIFF
--- a/tests/json-ast/x/kotlin/cross_join.kt.json
+++ b/tests/json-ast/x/kotlin/cross_join.kt.json
@@ -1,0 +1,2324 @@
+{
+  "file": {
+    "type": "KtFile",
+    "start": 0,
+    "end": 1116,
+    "children": [
+      {
+        "type": "KtPackageDirective",
+        "start": 0,
+        "end": 0
+      },
+      {
+        "type": "KtImportList",
+        "start": 0,
+        "end": 0
+      },
+      {
+        "type": "KtNamedFunction",
+        "start": 0,
+        "end": 1116,
+        "children": [
+          {
+            "type": "KtParameterList",
+            "text": "()",
+            "start": 8,
+            "end": 10
+          },
+          {
+            "type": "KtBlockExpression",
+            "start": 11,
+            "end": 1116,
+            "children": [
+              {
+                "type": "KtProperty",
+                "start": 17,
+                "end": 216,
+                "children": [
+                  {
+                    "type": "KtTypeReference",
+                    "start": 32,
+                    "end": 68,
+                    "children": [
+                      {
+                        "type": "KtUserType",
+                        "start": 32,
+                        "end": 68,
+                        "children": [
+                          {
+                            "type": "KtNameReferenceExpression",
+                            "text": "MutableList",
+                            "start": 32,
+                            "end": 43
+                          },
+                          {
+                            "type": "KtTypeArgumentList",
+                            "start": 43,
+                            "end": 68,
+                            "children": [
+                              {
+                                "type": "KtTypeProjection",
+                                "start": 44,
+                                "end": 67,
+                                "children": [
+                                  {
+                                    "type": "KtTypeReference",
+                                    "start": 44,
+                                    "end": 67,
+                                    "children": [
+                                      {
+                                        "type": "KtUserType",
+                                        "start": 44,
+                                        "end": 67,
+                                        "children": [
+                                          {
+                                            "type": "KtNameReferenceExpression",
+                                            "text": "MutableMap",
+                                            "start": 44,
+                                            "end": 54
+                                          },
+                                          {
+                                            "type": "KtTypeArgumentList",
+                                            "text": "\u003cString, Any\u003e",
+                                            "start": 54,
+                                            "end": 67,
+                                            "children": [
+                                              {
+                                                "type": "KtTypeProjection",
+                                                "text": "String",
+                                                "start": 55,
+                                                "end": 61,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeReference",
+                                                    "text": "String",
+                                                    "start": 55,
+                                                    "end": 61,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtUserType",
+                                                        "text": "String",
+                                                        "start": 55,
+                                                        "end": 61,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "String",
+                                                            "start": 55,
+                                                            "end": 61
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtTypeProjection",
+                                                "text": "Any",
+                                                "start": 63,
+                                                "end": 66,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeReference",
+                                                    "text": "Any",
+                                                    "start": 63,
+                                                    "end": 66,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtUserType",
+                                                        "text": "Any",
+                                                        "start": 63,
+                                                        "end": 66,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "Any",
+                                                            "start": 63,
+                                                            "end": 66
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "KtCallExpression",
+                    "start": 71,
+                    "end": 216,
+                    "children": [
+                      {
+                        "type": "KtNameReferenceExpression",
+                        "text": "mutableListOf",
+                        "start": 71,
+                        "end": 84
+                      },
+                      {
+                        "type": "KtValueArgumentList",
+                        "start": 84,
+                        "end": 216,
+                        "children": [
+                          {
+                            "type": "KtValueArgument",
+                            "start": 85,
+                            "end": 127,
+                            "children": [
+                              {
+                                "type": "KtCallExpression",
+                                "start": 85,
+                                "end": 127,
+                                "children": [
+                                  {
+                                    "type": "KtNameReferenceExpression",
+                                    "text": "mutableMapOf",
+                                    "start": 85,
+                                    "end": 97
+                                  },
+                                  {
+                                    "type": "KtValueArgumentList",
+                                    "start": 97,
+                                    "end": 127,
+                                    "children": [
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"id\" to 1",
+                                        "start": 98,
+                                        "end": 107,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"id\" to 1",
+                                            "start": 98,
+                                            "end": 107,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"id\"",
+                                                "start": 98,
+                                                "end": 102,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "id",
+                                                    "start": 99,
+                                                    "end": 101
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 103,
+                                                "end": 105
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "1",
+                                                "start": 106,
+                                                "end": 107
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"name\" to \"Alice\"",
+                                        "start": 109,
+                                        "end": 126,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"name\" to \"Alice\"",
+                                            "start": 109,
+                                            "end": 126,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"name\"",
+                                                "start": 109,
+                                                "end": 115,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "name",
+                                                    "start": 110,
+                                                    "end": 114
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 116,
+                                                "end": 118
+                                              },
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"Alice\"",
+                                                "start": 119,
+                                                "end": 126,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "Alice",
+                                                    "start": 120,
+                                                    "end": 125
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "KtValueArgument",
+                            "start": 129,
+                            "end": 169,
+                            "children": [
+                              {
+                                "type": "KtCallExpression",
+                                "start": 129,
+                                "end": 169,
+                                "children": [
+                                  {
+                                    "type": "KtNameReferenceExpression",
+                                    "text": "mutableMapOf",
+                                    "start": 129,
+                                    "end": 141
+                                  },
+                                  {
+                                    "type": "KtValueArgumentList",
+                                    "start": 141,
+                                    "end": 169,
+                                    "children": [
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"id\" to 2",
+                                        "start": 142,
+                                        "end": 151,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"id\" to 2",
+                                            "start": 142,
+                                            "end": 151,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"id\"",
+                                                "start": 142,
+                                                "end": 146,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "id",
+                                                    "start": 143,
+                                                    "end": 145
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 147,
+                                                "end": 149
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "2",
+                                                "start": 150,
+                                                "end": 151
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"name\" to \"Bob\"",
+                                        "start": 153,
+                                        "end": 168,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"name\" to \"Bob\"",
+                                            "start": 153,
+                                            "end": 168,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"name\"",
+                                                "start": 153,
+                                                "end": 159,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "name",
+                                                    "start": 154,
+                                                    "end": 158
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 160,
+                                                "end": 162
+                                              },
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"Bob\"",
+                                                "start": 163,
+                                                "end": 168,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "Bob",
+                                                    "start": 164,
+                                                    "end": 167
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "KtValueArgument",
+                            "start": 171,
+                            "end": 215,
+                            "children": [
+                              {
+                                "type": "KtCallExpression",
+                                "start": 171,
+                                "end": 215,
+                                "children": [
+                                  {
+                                    "type": "KtNameReferenceExpression",
+                                    "text": "mutableMapOf",
+                                    "start": 171,
+                                    "end": 183
+                                  },
+                                  {
+                                    "type": "KtValueArgumentList",
+                                    "start": 183,
+                                    "end": 215,
+                                    "children": [
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"id\" to 3",
+                                        "start": 184,
+                                        "end": 193,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"id\" to 3",
+                                            "start": 184,
+                                            "end": 193,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"id\"",
+                                                "start": 184,
+                                                "end": 188,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "id",
+                                                    "start": 185,
+                                                    "end": 187
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 189,
+                                                "end": 191
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "3",
+                                                "start": 192,
+                                                "end": 193
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"name\" to \"Charlie\"",
+                                        "start": 195,
+                                        "end": 214,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"name\" to \"Charlie\"",
+                                            "start": 195,
+                                            "end": 214,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"name\"",
+                                                "start": 195,
+                                                "end": 201,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "name",
+                                                    "start": 196,
+                                                    "end": 200
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 202,
+                                                "end": 204
+                                              },
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"Charlie\"",
+                                                "start": 205,
+                                                "end": 214,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "Charlie",
+                                                    "start": 206,
+                                                    "end": 213
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "KtProperty",
+                "start": 221,
+                "end": 471,
+                "children": [
+                  {
+                    "type": "KtTypeReference",
+                    "start": 233,
+                    "end": 269,
+                    "children": [
+                      {
+                        "type": "KtUserType",
+                        "start": 233,
+                        "end": 269,
+                        "children": [
+                          {
+                            "type": "KtNameReferenceExpression",
+                            "text": "MutableList",
+                            "start": 233,
+                            "end": 244
+                          },
+                          {
+                            "type": "KtTypeArgumentList",
+                            "start": 244,
+                            "end": 269,
+                            "children": [
+                              {
+                                "type": "KtTypeProjection",
+                                "start": 245,
+                                "end": 268,
+                                "children": [
+                                  {
+                                    "type": "KtTypeReference",
+                                    "start": 245,
+                                    "end": 268,
+                                    "children": [
+                                      {
+                                        "type": "KtUserType",
+                                        "start": 245,
+                                        "end": 268,
+                                        "children": [
+                                          {
+                                            "type": "KtNameReferenceExpression",
+                                            "text": "MutableMap",
+                                            "start": 245,
+                                            "end": 255
+                                          },
+                                          {
+                                            "type": "KtTypeArgumentList",
+                                            "text": "\u003cString, Int\u003e",
+                                            "start": 255,
+                                            "end": 268,
+                                            "children": [
+                                              {
+                                                "type": "KtTypeProjection",
+                                                "text": "String",
+                                                "start": 256,
+                                                "end": 262,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeReference",
+                                                    "text": "String",
+                                                    "start": 256,
+                                                    "end": 262,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtUserType",
+                                                        "text": "String",
+                                                        "start": 256,
+                                                        "end": 262,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "String",
+                                                            "start": 256,
+                                                            "end": 262
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtTypeProjection",
+                                                "text": "Int",
+                                                "start": 264,
+                                                "end": 267,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeReference",
+                                                    "text": "Int",
+                                                    "start": 264,
+                                                    "end": 267,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtUserType",
+                                                        "text": "Int",
+                                                        "start": 264,
+                                                        "end": 267,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "Int",
+                                                            "start": 264,
+                                                            "end": 267
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "KtCallExpression",
+                    "start": 272,
+                    "end": 471,
+                    "children": [
+                      {
+                        "type": "KtNameReferenceExpression",
+                        "text": "mutableListOf",
+                        "start": 272,
+                        "end": 285
+                      },
+                      {
+                        "type": "KtValueArgumentList",
+                        "start": 285,
+                        "end": 471,
+                        "children": [
+                          {
+                            "type": "KtValueArgument",
+                            "start": 286,
+                            "end": 346,
+                            "children": [
+                              {
+                                "type": "KtCallExpression",
+                                "start": 286,
+                                "end": 346,
+                                "children": [
+                                  {
+                                    "type": "KtNameReferenceExpression",
+                                    "text": "mutableMapOf",
+                                    "start": 286,
+                                    "end": 298
+                                  },
+                                  {
+                                    "type": "KtValueArgumentList",
+                                    "start": 298,
+                                    "end": 346,
+                                    "children": [
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"id\" to 100",
+                                        "start": 299,
+                                        "end": 310,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"id\" to 100",
+                                            "start": 299,
+                                            "end": 310,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"id\"",
+                                                "start": 299,
+                                                "end": 303,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "id",
+                                                    "start": 300,
+                                                    "end": 302
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 304,
+                                                "end": 306
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "100",
+                                                "start": 307,
+                                                "end": 310
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"customerId\" to 1",
+                                        "start": 312,
+                                        "end": 329,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"customerId\" to 1",
+                                            "start": 312,
+                                            "end": 329,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"customerId\"",
+                                                "start": 312,
+                                                "end": 324,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "customerId",
+                                                    "start": 313,
+                                                    "end": 323
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 325,
+                                                "end": 327
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "1",
+                                                "start": 328,
+                                                "end": 329
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"total\" to 250",
+                                        "start": 331,
+                                        "end": 345,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"total\" to 250",
+                                            "start": 331,
+                                            "end": 345,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"total\"",
+                                                "start": 331,
+                                                "end": 338,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "total",
+                                                    "start": 332,
+                                                    "end": 337
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 339,
+                                                "end": 341
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "250",
+                                                "start": 342,
+                                                "end": 345
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "KtValueArgument",
+                            "start": 348,
+                            "end": 408,
+                            "children": [
+                              {
+                                "type": "KtCallExpression",
+                                "start": 348,
+                                "end": 408,
+                                "children": [
+                                  {
+                                    "type": "KtNameReferenceExpression",
+                                    "text": "mutableMapOf",
+                                    "start": 348,
+                                    "end": 360
+                                  },
+                                  {
+                                    "type": "KtValueArgumentList",
+                                    "start": 360,
+                                    "end": 408,
+                                    "children": [
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"id\" to 101",
+                                        "start": 361,
+                                        "end": 372,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"id\" to 101",
+                                            "start": 361,
+                                            "end": 372,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"id\"",
+                                                "start": 361,
+                                                "end": 365,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "id",
+                                                    "start": 362,
+                                                    "end": 364
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 366,
+                                                "end": 368
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "101",
+                                                "start": 369,
+                                                "end": 372
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"customerId\" to 2",
+                                        "start": 374,
+                                        "end": 391,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"customerId\" to 2",
+                                            "start": 374,
+                                            "end": 391,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"customerId\"",
+                                                "start": 374,
+                                                "end": 386,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "customerId",
+                                                    "start": 375,
+                                                    "end": 385
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 387,
+                                                "end": 389
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "2",
+                                                "start": 390,
+                                                "end": 391
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"total\" to 125",
+                                        "start": 393,
+                                        "end": 407,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"total\" to 125",
+                                            "start": 393,
+                                            "end": 407,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"total\"",
+                                                "start": 393,
+                                                "end": 400,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "total",
+                                                    "start": 394,
+                                                    "end": 399
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 401,
+                                                "end": 403
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "125",
+                                                "start": 404,
+                                                "end": 407
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "KtValueArgument",
+                            "start": 410,
+                            "end": 470,
+                            "children": [
+                              {
+                                "type": "KtCallExpression",
+                                "start": 410,
+                                "end": 470,
+                                "children": [
+                                  {
+                                    "type": "KtNameReferenceExpression",
+                                    "text": "mutableMapOf",
+                                    "start": 410,
+                                    "end": 422
+                                  },
+                                  {
+                                    "type": "KtValueArgumentList",
+                                    "start": 422,
+                                    "end": 470,
+                                    "children": [
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"id\" to 102",
+                                        "start": 423,
+                                        "end": 434,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"id\" to 102",
+                                            "start": 423,
+                                            "end": 434,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"id\"",
+                                                "start": 423,
+                                                "end": 427,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "id",
+                                                    "start": 424,
+                                                    "end": 426
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 428,
+                                                "end": 430
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "102",
+                                                "start": 431,
+                                                "end": 434
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"customerId\" to 1",
+                                        "start": 436,
+                                        "end": 453,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"customerId\" to 1",
+                                            "start": 436,
+                                            "end": 453,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"customerId\"",
+                                                "start": 436,
+                                                "end": 448,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "customerId",
+                                                    "start": 437,
+                                                    "end": 447
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 449,
+                                                "end": 451
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "1",
+                                                "start": 452,
+                                                "end": 453
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtValueArgument",
+                                        "text": "\"total\" to 300",
+                                        "start": 455,
+                                        "end": 469,
+                                        "children": [
+                                          {
+                                            "type": "KtBinaryExpression",
+                                            "text": "\"total\" to 300",
+                                            "start": 455,
+                                            "end": 469,
+                                            "children": [
+                                              {
+                                                "type": "KtStringTemplateExpression",
+                                                "text": "\"total\"",
+                                                "start": 455,
+                                                "end": 462,
+                                                "children": [
+                                                  {
+                                                    "type": "KtLiteralStringTemplateEntry",
+                                                    "text": "total",
+                                                    "start": 456,
+                                                    "end": 461
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtOperationReferenceExpression",
+                                                "text": "to",
+                                                "start": 463,
+                                                "end": 465
+                                              },
+                                              {
+                                                "type": "KtConstantExpression",
+                                                "text": "300",
+                                                "start": 466,
+                                                "end": 469
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "KtProperty",
+                "start": 476,
+                "end": 828,
+                "children": [
+                  {
+                    "type": "KtTypeReference",
+                    "start": 488,
+                    "end": 524,
+                    "children": [
+                      {
+                        "type": "KtUserType",
+                        "start": 488,
+                        "end": 524,
+                        "children": [
+                          {
+                            "type": "KtNameReferenceExpression",
+                            "text": "MutableList",
+                            "start": 488,
+                            "end": 499
+                          },
+                          {
+                            "type": "KtTypeArgumentList",
+                            "start": 499,
+                            "end": 524,
+                            "children": [
+                              {
+                                "type": "KtTypeProjection",
+                                "start": 500,
+                                "end": 523,
+                                "children": [
+                                  {
+                                    "type": "KtTypeReference",
+                                    "start": 500,
+                                    "end": 523,
+                                    "children": [
+                                      {
+                                        "type": "KtUserType",
+                                        "start": 500,
+                                        "end": 523,
+                                        "children": [
+                                          {
+                                            "type": "KtNameReferenceExpression",
+                                            "text": "MutableMap",
+                                            "start": 500,
+                                            "end": 510
+                                          },
+                                          {
+                                            "type": "KtTypeArgumentList",
+                                            "text": "\u003cString, Int\u003e",
+                                            "start": 510,
+                                            "end": 523,
+                                            "children": [
+                                              {
+                                                "type": "KtTypeProjection",
+                                                "text": "String",
+                                                "start": 511,
+                                                "end": 517,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeReference",
+                                                    "text": "String",
+                                                    "start": 511,
+                                                    "end": 517,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtUserType",
+                                                        "text": "String",
+                                                        "start": 511,
+                                                        "end": 517,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "String",
+                                                            "start": 511,
+                                                            "end": 517
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtTypeProjection",
+                                                "text": "Int",
+                                                "start": 519,
+                                                "end": 522,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeReference",
+                                                    "text": "Int",
+                                                    "start": 519,
+                                                    "end": 522,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtUserType",
+                                                        "text": "Int",
+                                                        "start": 519,
+                                                        "end": 522,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "Int",
+                                                            "start": 519,
+                                                            "end": 522
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "KtCallExpression",
+                    "start": 527,
+                    "end": 828,
+                    "children": [
+                      {
+                        "type": "KtNameReferenceExpression",
+                        "text": "run",
+                        "start": 527,
+                        "end": 530
+                      },
+                      {
+                        "type": "KtLambdaArgument",
+                        "start": 531,
+                        "end": 828,
+                        "children": [
+                          {
+                            "type": "KtLambdaExpression",
+                            "start": 531,
+                            "end": 828,
+                            "children": [
+                              {
+                                "type": "KtFunctionLiteral",
+                                "start": 531,
+                                "end": 828,
+                                "children": [
+                                  {
+                                    "type": "KtBlockExpression",
+                                    "start": 537,
+                                    "end": 826,
+                                    "children": [
+                                      {
+                                        "type": "KtProperty",
+                                        "start": 537,
+                                        "end": 588,
+                                        "children": [
+                                          {
+                                            "type": "KtCallExpression",
+                                            "start": 548,
+                                            "end": 588,
+                                            "children": [
+                                              {
+                                                "type": "KtNameReferenceExpression",
+                                                "text": "mutableListOf",
+                                                "start": 548,
+                                                "end": 561
+                                              },
+                                              {
+                                                "type": "KtTypeArgumentList",
+                                                "start": 561,
+                                                "end": 586,
+                                                "children": [
+                                                  {
+                                                    "type": "KtTypeProjection",
+                                                    "start": 562,
+                                                    "end": 585,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtTypeReference",
+                                                        "start": 562,
+                                                        "end": 585,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtUserType",
+                                                            "start": 562,
+                                                            "end": 585,
+                                                            "children": [
+                                                              {
+                                                                "type": "KtNameReferenceExpression",
+                                                                "text": "MutableMap",
+                                                                "start": 562,
+                                                                "end": 572
+                                                              },
+                                                              {
+                                                                "type": "KtTypeArgumentList",
+                                                                "text": "\u003cString, Any\u003e",
+                                                                "start": 572,
+                                                                "end": 585,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "KtTypeProjection",
+                                                                    "text": "String",
+                                                                    "start": 573,
+                                                                    "end": 579,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "KtTypeReference",
+                                                                        "text": "String",
+                                                                        "start": 573,
+                                                                        "end": 579,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "KtUserType",
+                                                                            "text": "String",
+                                                                            "start": 573,
+                                                                            "end": 579,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "KtNameReferenceExpression",
+                                                                                "text": "String",
+                                                                                "start": 573,
+                                                                                "end": 579
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "KtTypeProjection",
+                                                                    "text": "Any",
+                                                                    "start": 581,
+                                                                    "end": 584,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "KtTypeReference",
+                                                                        "text": "Any",
+                                                                        "start": 581,
+                                                                        "end": 584,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "KtUserType",
+                                                                            "text": "Any",
+                                                                            "start": 581,
+                                                                            "end": 584,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "KtNameReferenceExpression",
+                                                                                "text": "Any",
+                                                                                "start": 581,
+                                                                                "end": 584
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "KtValueArgumentList",
+                                                "text": "()",
+                                                "start": 586,
+                                                "end": 588
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtForExpression",
+                                        "start": 593,
+                                        "end": 817,
+                                        "children": [
+                                          {
+                                            "type": "KtParameter",
+                                            "text": "o",
+                                            "start": 598,
+                                            "end": 599
+                                          },
+                                          {
+                                            "type": "KtContainerNode",
+                                            "text": "orders",
+                                            "start": 603,
+                                            "end": 609,
+                                            "children": [
+                                              {
+                                                "type": "KtNameReferenceExpression",
+                                                "text": "orders",
+                                                "start": 603,
+                                                "end": 609
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "KtContainerNodeForControlStructureBody",
+                                            "start": 611,
+                                            "end": 817,
+                                            "children": [
+                                              {
+                                                "type": "KtBlockExpression",
+                                                "start": 611,
+                                                "end": 817,
+                                                "children": [
+                                                  {
+                                                    "type": "KtForExpression",
+                                                    "start": 621,
+                                                    "end": 811,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtParameter",
+                                                        "text": "c",
+                                                        "start": 626,
+                                                        "end": 627
+                                                      },
+                                                      {
+                                                        "type": "KtContainerNode",
+                                                        "text": "customers",
+                                                        "start": 631,
+                                                        "end": 640,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "customers",
+                                                            "start": 631,
+                                                            "end": 640
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "KtContainerNodeForControlStructureBody",
+                                                        "start": 642,
+                                                        "end": 811,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtBlockExpression",
+                                                            "start": 642,
+                                                            "end": 811,
+                                                            "children": [
+                                                              {
+                                                                "type": "KtDotQualifiedExpression",
+                                                                "start": 656,
+                                                                "end": 801,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "KtNameReferenceExpression",
+                                                                    "text": "_res",
+                                                                    "start": 656,
+                                                                    "end": 660
+                                                                  },
+                                                                  {
+                                                                    "type": "KtCallExpression",
+                                                                    "start": 661,
+                                                                    "end": 801,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "KtNameReferenceExpression",
+                                                                        "text": "add",
+                                                                        "start": 661,
+                                                                        "end": 664
+                                                                      },
+                                                                      {
+                                                                        "type": "KtValueArgumentList",
+                                                                        "start": 664,
+                                                                        "end": 801,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "KtValueArgument",
+                                                                            "start": 665,
+                                                                            "end": 800,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "KtCallExpression",
+                                                                                "start": 665,
+                                                                                "end": 800,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "type": "KtNameReferenceExpression",
+                                                                                    "text": "mutableMapOf",
+                                                                                    "start": 665,
+                                                                                    "end": 677
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "KtValueArgumentList",
+                                                                                    "start": 677,
+                                                                                    "end": 800,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "KtValueArgument",
+                                                                                        "text": "\"orderId\" to o[\"id\"]",
+                                                                                        "start": 678,
+                                                                                        "end": 698,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "KtBinaryExpression",
+                                                                                            "text": "\"orderId\" to o[\"id\"]",
+                                                                                            "start": 678,
+                                                                                            "end": 698,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "KtStringTemplateExpression",
+                                                                                                "text": "\"orderId\"",
+                                                                                                "start": 678,
+                                                                                                "end": 687,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                                                    "text": "orderId",
+                                                                                                    "start": 679,
+                                                                                                    "end": 686
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtOperationReferenceExpression",
+                                                                                                "text": "to",
+                                                                                                "start": 688,
+                                                                                                "end": 690
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtArrayAccessExpression",
+                                                                                                "text": "o[\"id\"]",
+                                                                                                "start": 691,
+                                                                                                "end": 698,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtNameReferenceExpression",
+                                                                                                    "text": "o",
+                                                                                                    "start": 691,
+                                                                                                    "end": 692
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "KtContainerNode",
+                                                                                                    "text": "[\"id\"]",
+                                                                                                    "start": 692,
+                                                                                                    "end": 698,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "KtStringTemplateExpression",
+                                                                                                        "text": "\"id\"",
+                                                                                                        "start": 693,
+                                                                                                        "end": 697,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "type": "KtLiteralStringTemplateEntry",
+                                                                                                            "text": "id",
+                                                                                                            "start": 694,
+                                                                                                            "end": 696
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "KtValueArgument",
+                                                                                        "start": 700,
+                                                                                        "end": 736,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "KtBinaryExpression",
+                                                                                            "start": 700,
+                                                                                            "end": 736,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "KtStringTemplateExpression",
+                                                                                                "text": "\"orderCustomerId\"",
+                                                                                                "start": 700,
+                                                                                                "end": 717,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                                                    "text": "orderCustomerId",
+                                                                                                    "start": 701,
+                                                                                                    "end": 716
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtOperationReferenceExpression",
+                                                                                                "text": "to",
+                                                                                                "start": 718,
+                                                                                                "end": 720
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtArrayAccessExpression",
+                                                                                                "text": "o[\"customerId\"]",
+                                                                                                "start": 721,
+                                                                                                "end": 736,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtNameReferenceExpression",
+                                                                                                    "text": "o",
+                                                                                                    "start": 721,
+                                                                                                    "end": 722
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "KtContainerNode",
+                                                                                                    "text": "[\"customerId\"]",
+                                                                                                    "start": 722,
+                                                                                                    "end": 736,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "KtStringTemplateExpression",
+                                                                                                        "text": "\"customerId\"",
+                                                                                                        "start": 723,
+                                                                                                        "end": 735,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "type": "KtLiteralStringTemplateEntry",
+                                                                                                            "text": "customerId",
+                                                                                                            "start": 724,
+                                                                                                            "end": 734
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "KtValueArgument",
+                                                                                        "start": 738,
+                                                                                        "end": 771,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "KtBinaryExpression",
+                                                                                            "start": 738,
+                                                                                            "end": 771,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "KtStringTemplateExpression",
+                                                                                                "text": "\"pairedCustomerName\"",
+                                                                                                "start": 738,
+                                                                                                "end": 758,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                                                    "text": "pairedCustomerName",
+                                                                                                    "start": 739,
+                                                                                                    "end": 757
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtOperationReferenceExpression",
+                                                                                                "text": "to",
+                                                                                                "start": 759,
+                                                                                                "end": 761
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtArrayAccessExpression",
+                                                                                                "text": "c[\"name\"]",
+                                                                                                "start": 762,
+                                                                                                "end": 771,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtNameReferenceExpression",
+                                                                                                    "text": "c",
+                                                                                                    "start": 762,
+                                                                                                    "end": 763
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "KtContainerNode",
+                                                                                                    "text": "[\"name\"]",
+                                                                                                    "start": 763,
+                                                                                                    "end": 771,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "KtStringTemplateExpression",
+                                                                                                        "text": "\"name\"",
+                                                                                                        "start": 764,
+                                                                                                        "end": 770,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "type": "KtLiteralStringTemplateEntry",
+                                                                                                            "text": "name",
+                                                                                                            "start": 765,
+                                                                                                            "end": 769
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "KtValueArgument",
+                                                                                        "start": 773,
+                                                                                        "end": 799,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "KtBinaryExpression",
+                                                                                            "start": 773,
+                                                                                            "end": 799,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "KtStringTemplateExpression",
+                                                                                                "text": "\"orderTotal\"",
+                                                                                                "start": 773,
+                                                                                                "end": 785,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                                                    "text": "orderTotal",
+                                                                                                    "start": 774,
+                                                                                                    "end": 784
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtOperationReferenceExpression",
+                                                                                                "text": "to",
+                                                                                                "start": 786,
+                                                                                                "end": 788
+                                                                                              },
+                                                                                              {
+                                                                                                "type": "KtArrayAccessExpression",
+                                                                                                "text": "o[\"total\"]",
+                                                                                                "start": 789,
+                                                                                                "end": 799,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "KtNameReferenceExpression",
+                                                                                                    "text": "o",
+                                                                                                    "start": 789,
+                                                                                                    "end": 790
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "KtContainerNode",
+                                                                                                    "text": "[\"total\"]",
+                                                                                                    "start": 790,
+                                                                                                    "end": 799,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "KtStringTemplateExpression",
+                                                                                                        "text": "\"total\"",
+                                                                                                        "start": 791,
+                                                                                                        "end": 798,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "type": "KtLiteralStringTemplateEntry",
+                                                                                                            "text": "total",
+                                                                                                            "start": 792,
+                                                                                                            "end": 797
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "KtNameReferenceExpression",
+                                        "text": "_res",
+                                        "start": 822,
+                                        "end": 826
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "KtCallExpression",
+                "start": 833,
+                "end": 888,
+                "children": [
+                  {
+                    "type": "KtNameReferenceExpression",
+                    "text": "println",
+                    "start": 833,
+                    "end": 840
+                  },
+                  {
+                    "type": "KtValueArgumentList",
+                    "start": 840,
+                    "end": 888,
+                    "children": [
+                      {
+                        "type": "KtValueArgument",
+                        "start": 841,
+                        "end": 887,
+                        "children": [
+                          {
+                            "type": "KtStringTemplateExpression",
+                            "start": 841,
+                            "end": 887,
+                            "children": [
+                              {
+                                "type": "KtLiteralStringTemplateEntry",
+                                "start": 842,
+                                "end": 886
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "KtForExpression",
+                "start": 893,
+                "end": 1114,
+                "children": [
+                  {
+                    "type": "KtParameter",
+                    "text": "entry",
+                    "start": 898,
+                    "end": 903
+                  },
+                  {
+                    "type": "KtContainerNode",
+                    "text": "result",
+                    "start": 907,
+                    "end": 913,
+                    "children": [
+                      {
+                        "type": "KtNameReferenceExpression",
+                        "text": "result",
+                        "start": 907,
+                        "end": 913
+                      }
+                    ]
+                  },
+                  {
+                    "type": "KtContainerNodeForControlStructureBody",
+                    "start": 915,
+                    "end": 1114,
+                    "children": [
+                      {
+                        "type": "KtBlockExpression",
+                        "start": 915,
+                        "end": 1114,
+                        "children": [
+                          {
+                            "type": "KtCallExpression",
+                            "start": 925,
+                            "end": 1108,
+                            "children": [
+                              {
+                                "type": "KtNameReferenceExpression",
+                                "text": "println",
+                                "start": 925,
+                                "end": 932
+                              },
+                              {
+                                "type": "KtValueArgumentList",
+                                "start": 932,
+                                "end": 1108,
+                                "children": [
+                                  {
+                                    "type": "KtValueArgument",
+                                    "start": 933,
+                                    "end": 1107,
+                                    "children": [
+                                      {
+                                        "type": "KtDotQualifiedExpression",
+                                        "start": 933,
+                                        "end": 1107,
+                                        "children": [
+                                          {
+                                            "type": "KtCallExpression",
+                                            "start": 933,
+                                            "end": 1089,
+                                            "children": [
+                                              {
+                                                "type": "KtNameReferenceExpression",
+                                                "text": "listOf",
+                                                "start": 933,
+                                                "end": 939
+                                              },
+                                              {
+                                                "type": "KtValueArgumentList",
+                                                "start": 939,
+                                                "end": 1089,
+                                                "children": [
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "\"Order\"",
+                                                    "start": 940,
+                                                    "end": 947,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtStringTemplateExpression",
+                                                        "text": "\"Order\"",
+                                                        "start": 940,
+                                                        "end": 947,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtLiteralStringTemplateEntry",
+                                                            "text": "Order",
+                                                            "start": 941,
+                                                            "end": 946
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "entry[\"orderId\"]",
+                                                    "start": 949,
+                                                    "end": 965,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtArrayAccessExpression",
+                                                        "text": "entry[\"orderId\"]",
+                                                        "start": 949,
+                                                        "end": 965,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "entry",
+                                                            "start": 949,
+                                                            "end": 954
+                                                          },
+                                                          {
+                                                            "type": "KtContainerNode",
+                                                            "text": "[\"orderId\"]",
+                                                            "start": 954,
+                                                            "end": 965,
+                                                            "children": [
+                                                              {
+                                                                "type": "KtStringTemplateExpression",
+                                                                "text": "\"orderId\"",
+                                                                "start": 955,
+                                                                "end": 964,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                    "text": "orderId",
+                                                                    "start": 956,
+                                                                    "end": 963
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "\"(customerId:\"",
+                                                    "start": 967,
+                                                    "end": 981,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtStringTemplateExpression",
+                                                        "text": "\"(customerId:\"",
+                                                        "start": 967,
+                                                        "end": 981,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtLiteralStringTemplateEntry",
+                                                            "text": "(customerId:",
+                                                            "start": 968,
+                                                            "end": 980
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "start": 983,
+                                                    "end": 1007,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtArrayAccessExpression",
+                                                        "start": 983,
+                                                        "end": 1007,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "entry",
+                                                            "start": 983,
+                                                            "end": 988
+                                                          },
+                                                          {
+                                                            "type": "KtContainerNode",
+                                                            "text": "[\"orderCustomerId\"]",
+                                                            "start": 988,
+                                                            "end": 1007,
+                                                            "children": [
+                                                              {
+                                                                "type": "KtStringTemplateExpression",
+                                                                "text": "\"orderCustomerId\"",
+                                                                "start": 989,
+                                                                "end": 1006,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                    "text": "orderCustomerId",
+                                                                    "start": 990,
+                                                                    "end": 1005
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "\", total: $\"",
+                                                    "start": 1009,
+                                                    "end": 1021,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtStringTemplateExpression",
+                                                        "text": "\", total: $\"",
+                                                        "start": 1009,
+                                                        "end": 1021,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtLiteralStringTemplateEntry",
+                                                            "text": ", total: ",
+                                                            "start": 1010,
+                                                            "end": 1019
+                                                          },
+                                                          {
+                                                            "type": "KtLiteralStringTemplateEntry",
+                                                            "text": "$",
+                                                            "start": 1019,
+                                                            "end": 1020
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "entry[\"orderTotal\"]",
+                                                    "start": 1023,
+                                                    "end": 1042,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtArrayAccessExpression",
+                                                        "text": "entry[\"orderTotal\"]",
+                                                        "start": 1023,
+                                                        "end": 1042,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "entry",
+                                                            "start": 1023,
+                                                            "end": 1028
+                                                          },
+                                                          {
+                                                            "type": "KtContainerNode",
+                                                            "text": "[\"orderTotal\"]",
+                                                            "start": 1028,
+                                                            "end": 1042,
+                                                            "children": [
+                                                              {
+                                                                "type": "KtStringTemplateExpression",
+                                                                "text": "\"orderTotal\"",
+                                                                "start": 1029,
+                                                                "end": 1041,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                    "text": "orderTotal",
+                                                                    "start": 1030,
+                                                                    "end": 1040
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "\") paired with\"",
+                                                    "start": 1044,
+                                                    "end": 1059,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtStringTemplateExpression",
+                                                        "text": "\") paired with\"",
+                                                        "start": 1044,
+                                                        "end": 1059,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtLiteralStringTemplateEntry",
+                                                            "text": ") paired with",
+                                                            "start": 1045,
+                                                            "end": 1058
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "start": 1061,
+                                                    "end": 1088,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtArrayAccessExpression",
+                                                        "start": 1061,
+                                                        "end": 1088,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtNameReferenceExpression",
+                                                            "text": "entry",
+                                                            "start": 1061,
+                                                            "end": 1066
+                                                          },
+                                                          {
+                                                            "type": "KtContainerNode",
+                                                            "start": 1066,
+                                                            "end": 1088,
+                                                            "children": [
+                                                              {
+                                                                "type": "KtStringTemplateExpression",
+                                                                "text": "\"pairedCustomerName\"",
+                                                                "start": 1067,
+                                                                "end": 1087,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "KtLiteralStringTemplateEntry",
+                                                                    "text": "pairedCustomerName",
+                                                                    "start": 1068,
+                                                                    "end": 1086
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "KtCallExpression",
+                                            "text": "joinToString(\" \")",
+                                            "start": 1090,
+                                            "end": 1107,
+                                            "children": [
+                                              {
+                                                "type": "KtNameReferenceExpression",
+                                                "text": "joinToString",
+                                                "start": 1090,
+                                                "end": 1102
+                                              },
+                                              {
+                                                "type": "KtValueArgumentList",
+                                                "text": "(\" \")",
+                                                "start": 1102,
+                                                "end": 1107,
+                                                "children": [
+                                                  {
+                                                    "type": "KtValueArgument",
+                                                    "text": "\" \"",
+                                                    "start": 1103,
+                                                    "end": 1106,
+                                                    "children": [
+                                                      {
+                                                        "type": "KtStringTemplateExpression",
+                                                        "text": "\" \"",
+                                                        "start": 1103,
+                                                        "end": 1106,
+                                                        "children": [
+                                                          {
+                                                            "type": "KtLiteralStringTemplateEntry",
+                                                            "text": " ",
+                                                            "start": 1104,
+                                                            "end": 1105
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tools/json-ast/x/kotlin/inspect.go
+++ b/tools/json-ast/x/kotlin/inspect.go
@@ -1,0 +1,242 @@
+package kotlin
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Program represents a parsed Kotlin source file.
+type Program struct {
+	File any `json:"file"`
+}
+
+var (
+	parserOnce sync.Once
+	parserJar  string
+	parserCP   string
+	parserErr  error
+)
+
+// Inspect parses Kotlin source code using kotlinc and returns its AST.
+func Inspect(src string) (*Program, error) {
+	if err := ensureParser(); err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("java", "-cp", parserJar+string(os.PathListSeparator)+parserCP, "ParseKt")
+	cmd.Stdin = strings.NewReader(src)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(errBuf.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%v: %s", err, msg)
+		}
+		return nil, err
+	}
+	var prog Program
+	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
+}
+
+func ensureParser() error {
+	parserOnce.Do(func() {
+		kpath, err := ensureKotlinc()
+		if err != nil {
+			parserErr = err
+			return
+		}
+		os.Setenv("PATH", filepath.Dir(kpath)+string(os.PathListSeparator)+os.Getenv("PATH"))
+		cp, err := kotlinClasspath()
+		if err != nil {
+			parserErr = err
+			return
+		}
+		jars, err := ensureKastree()
+		if err != nil {
+			parserErr = err
+			return
+		}
+		parserCP = strings.Join(append(jars, cp), string(os.PathListSeparator))
+		root, err := repoRoot()
+		if err != nil {
+			parserErr = err
+			return
+		}
+		srcPath := filepath.Join(root, "tools", "json-ast", "x", "kotlin", "parse.kt")
+		tmpDir, err := os.MkdirTemp("", "kt-parser")
+		if err != nil {
+			parserErr = err
+			return
+		}
+		jar := filepath.Join(tmpDir, "parser.jar")
+		cmd := exec.Command(kpath, srcPath, "-cp", parserCP, "-d", jar)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			parserErr = fmt.Errorf("kotlinc: %v: %s", err, out.String())
+			return
+		}
+		parserJar = jar
+	})
+	return parserErr
+}
+
+func ensureKastree() ([]string, error) {
+	version := "0.4.0"
+	kotlinVer := "1.3.21"
+	libs := []struct{ g, a, v string }{
+		{"com.github.cretz.kastree", "kastree-ast-common", version},
+		{"com.github.cretz.kastree", "kastree-ast-jvm", version},
+		{"com.github.cretz.kastree", "kastree-ast-psi", version},
+		{"org.jetbrains.kotlin", "kotlin-compiler-embeddable", kotlinVer},
+		{"org.jetbrains.kotlin", "kotlin-stdlib-jdk8", kotlinVer},
+		{"org.jetbrains.kotlin", "kotlin-stdlib", kotlinVer},
+		{"org.jetbrains.kotlin", "kotlin-reflect", kotlinVer},
+		{"org.jetbrains.kotlin", "kotlin-script-runtime", kotlinVer},
+		{"org.jetbrains.intellij.deps", "trove4j", "1.0.20181211"},
+	}
+	dir := filepath.Join(os.TempDir(), "kastree")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	var jars []string
+	for _, dep := range libs {
+		path := filepath.Join(dir, dep.a+"-"+dep.v+".jar")
+		if _, err := os.Stat(path); err != nil {
+			groupPath := strings.ReplaceAll(dep.g, ".", "/")
+			url := fmt.Sprintf("https://repo1.maven.org/maven2/%s/%s/%s/%s-%s.jar", groupPath, dep.a, dep.v, dep.a, dep.v)
+			if err := downloadFile(url, path); err != nil {
+				return nil, err
+			}
+		}
+		jars = append(jars, path)
+	}
+	return jars, nil
+}
+
+func downloadFile(url, path string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: %s", url, resp.Status)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func ensureKotlinc() (string, error) {
+	if path, err := exec.LookPath("kotlinc"); err == nil {
+		return path, nil
+	}
+	dir := filepath.Join(os.TempDir(), "kotlinc")
+	bin := filepath.Join(dir, "bin", "kotlinc")
+	if _, err := os.Stat(bin); err == nil {
+		return bin, nil
+	}
+	url := "https://github.com/JetBrains/kotlin/releases/download/v1.3.21/kotlin-compiler-1.3.21.zip"
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("download kotlin: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download kotlin: %s", resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", err
+	}
+	for _, f := range zr.File {
+		name := strings.TrimPrefix(f.Name, "kotlinc/")
+		if name == "" {
+			continue
+		}
+		dest := filepath.Join(dir, name)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(dest, f.Mode())
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return "", err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", err
+		}
+		out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+		if err != nil {
+			rc.Close()
+			return "", err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return "", err
+		}
+		out.Close()
+		rc.Close()
+	}
+	return bin, nil
+}
+
+func kotlinClasspath() (string, error) {
+	kpath, err := exec.LookPath("kotlinc")
+	if err != nil {
+		return "", err
+	}
+	kpath, _ = filepath.EvalSymlinks(kpath)
+	home := filepath.Join(filepath.Dir(kpath), "..")
+	pattern := filepath.Join(home, "lib", "*.jar")
+	jars, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+	if len(jars) == 0 {
+		return "", fmt.Errorf("no kotlin libs found")
+	}
+	return strings.Join(jars, string(os.PathListSeparator)), nil
+}
+
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found")
+}

--- a/tools/json-ast/x/kotlin/inspect_test.go
+++ b/tools/json-ast/x/kotlin/inspect_test.go
@@ -1,0 +1,92 @@
+//go:build slow
+
+package kotlin_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	kotlin "mochi/tools/json-ast/x/kotlin"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureKotlinc(t *testing.T) {
+	if _, err := exec.LookPath("kotlinc"); err != nil {
+		t.Skip("kotlinc not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureKotlinc(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "kt")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "kotlin")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.kt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".kt")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := kotlin.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			golden := filepath.Join(outDir, name+".kt.json")
+			if *update {
+				if err := os.WriteFile(golden, out, 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+			want, err := os.ReadFile(golden)
+			if err != nil {
+				t.Skip("missing golden")
+				return
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}

--- a/tools/json-ast/x/kotlin/parse.kt
+++ b/tools/json-ast/x/kotlin/parse.kt
@@ -1,0 +1,45 @@
+import kastree.ast.psi.Parser
+import kotlin.reflect.full.memberProperties
+
+fun escape(s: String): String =
+    s.replace("\\", "\\\\")
+     .replace("\"", "\\\"")
+     .replace("\n", "\\n")
+     .replace("\r", "\\r")
+
+fun dumpValue(v: Any?, sb: StringBuilder) {
+    when (v) {
+        null -> sb.append("null")
+        is String -> sb.append('"').append(escape(v)).append('"')
+        is Boolean, is Number -> sb.append(v.toString())
+        is List<*> -> {
+            sb.append('[')
+            for (i in v.indices) {
+                if (i > 0) sb.append(',')
+                dumpValue(v[i], sb)
+            }
+            sb.append(']')
+        }
+        else -> dumpNode(v, sb)
+    }
+}
+
+fun dumpNode(v: Any, sb: StringBuilder) {
+    val cls = v.javaClass
+    sb.append("{\"type\":\"").append(cls.simpleName).append("\"")
+    for (prop in cls.kotlin.memberProperties) {
+        val value = prop.getter.call(v)
+        if (value == null) continue
+        sb.append(",\"").append(prop.name).append("\":")
+        dumpValue(value, sb)
+    }
+    sb.append('}')
+}
+
+fun main() {
+    val src = generateSequence(::readLine).joinToString("\n")
+    val file = Parser.parseFile(src)
+    val sb = StringBuilder()
+    dumpNode(file, sb)
+    println("{\"file\":" + sb.toString() + "}")
+}


### PR DESCRIPTION
## Summary
- rewrite Kotlin AST parser to use Kastree and output JSON recursively
- download Kotlin compiler and Kastree jars on demand
- update inspector to compile the parser and invoke it

## Testing
- `go test ./tools/json-ast/x/kotlin -run TestInspect_Golden/cross_join -tags slow -count=1 -update` *(fails: missing Kotlin classes)*

------
https://chatgpt.com/codex/tasks/task_e_688986a32c5c832099206f4ed3f7024d