### PR TITLE
Improve F# json-ast inspector

### DIFF
--- a/tools/json-ast/x/fs/parse.fsx
+++ b/tools/json-ast/x/fs/parse.fsx
@@ -1,0 +1,84 @@
+#r "nuget: FSharp.Compiler.Service, 41.0.1"
+open System
+open System.Text
+open System.Text.Json
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Text
+open FSharp.Compiler.Syntax
+
+let input = Console.In.ReadToEnd()
+let checker = FSharpChecker.Create()
+let opts =
+    { FSharpParsingOptions.Default with
+        SourceFiles = [| "stdin.fs" |]
+        IsInteractive = true }
+let res =
+    checker.ParseFile("stdin.fs", SourceText.ofString input, opts)
+    |> Async.RunSynchronously
+
+let lines = input.Split([|"\n"|], StringSplitOptions.None)
+let slice (r: range) =
+    let sb = StringBuilder()
+    for i in r.StartLine .. r.EndLine do
+        let line = lines.[i - 1]
+        if i = r.StartLine && i = r.EndLine then
+            sb.Append(line.Substring(r.StartColumn, r.EndColumn - r.StartColumn)) |> ignore
+        elif i = r.StartLine then
+            sb.Append(line.Substring(r.StartColumn)) |> ignore
+        elif i = r.EndLine then
+            sb.Append(line.Substring(0, r.EndColumn)) |> ignore
+        else
+            sb.AppendLine(line) |> ignore
+    sb.ToString()
+
+let vars = ResizeArray<_>()
+let prints = ResizeArray<_>()
+let stmts = ResizeArray<_>()
+
+let rec visitExpr expr =
+    match expr with
+    | SynExpr.App(_,_,SynExpr.Ident id, arg, _) when id.idText = "printfn" ->
+        prints.Add(slice arg.Range)
+    | SynExpr.ForEach(_,_,_, pat, seqExpr, body, _) ->
+        let varName =
+            match pat with
+            | SynPat.Named(si, _, _, _) ->
+                match si with
+                | SynIdent(id, _) -> id.idText
+                | _ -> "_"
+            | _ -> "_"
+        let bodyStmtsBefore = stmts.Count
+        visitExpr body
+        let bodyStmts = [ for i in bodyStmtsBefore .. stmts.Count - 1 -> stmts.[i] ]
+        while stmts.Count > bodyStmtsBefore do stmts.RemoveAt(stmts.Count-1)
+        stmts.Add(box {| var = varName; expr = slice seqExpr.Range; body = bodyStmts; line = 0; raw = "" |})
+    | SynExpr.Sequential(_,_,e1,e2,_) ->
+        visitExpr e1
+        visitExpr e2
+    | _ -> ()
+
+let rec visitDecl decl =
+    match decl with
+    | SynModuleDecl.Let(_,bindings,_) ->
+        for b in bindings do
+            match b.HeadPattern with
+            | SynPat.Named(si, _, _, _, _) ->
+                let name =
+                    match si with
+                    | SynIdent(id, _) -> id.idText
+                    | _ -> "_"
+                vars.Add({| name = name; expr = slice b.Expr.Range; ``mutable`` = b.IsMutable; ``type`` = None; line = b.RangeOfBindingSansRhs.StartLine; raw = "" |})
+            | _ -> ()
+    | SynModuleDecl.DoExpr(_,expr,_) -> visitExpr expr
+    | _ -> ()
+
+match res.ParseTree with
+| Some (ParsedInput.ImplFile(impl)) ->
+    for d in impl.Contents do
+        visitDecl d
+    let obj = {| vars = vars; prints = prints; stmts = stmts |}
+    let json = JsonSerializer.Serialize(obj)
+    printfn "%s" json
+| _ ->
+    eprintfn "parse failed"
+    Environment.ExitCode <- 1

--- a/tools/json-ast/x/fs/types.go
+++ b/tools/json-ast/x/fs/types.go
@@ -1,0 +1,34 @@
+package fs
+
+type Var struct {
+	Name    string `json:"name"`
+	Expr    string `json:"expr"`
+	Mutable bool   `json:"mutable"`
+	Type    string `json:"type"`
+	Line    int    `json:"line"`
+	Raw     string `json:"raw"`
+}
+
+type Assign struct {
+	Name  string `json:"name"`
+	Index string `json:"index"`
+	Expr  string `json:"expr"`
+	Line  int    `json:"line"`
+	Raw   string `json:"raw"`
+}
+
+type ForIn struct {
+	Var  string `json:"var"`
+	Expr string `json:"expr"`
+	Body []Stmt `json:"body"`
+	Line int    `json:"line"`
+	Raw  string `json:"raw"`
+}
+
+type PrintStmt struct {
+	Expr string `json:"expr"`
+	Line int    `json:"line"`
+	Raw  string `json:"raw"`
+}
+
+type Stmt interface{}


### PR DESCRIPTION
## Summary
- define dedicated AST node structs for the F# inspector
- drop `Source` from `Program`
- introduce a helper `parse.fsx` script that uses `FSharp.Compiler.Service`
- tweak inspector to use `dotnet fsi`

## Testing
- `go test -tags slow ./tools/json-ast/x/fs -run TestInspect_Golden -count=1` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68898699fb40832093895bd21a526411