### PR TITLE
Use structured Java NEW nodes

### DIFF
--- a/tests/json-ast/x/java/append_builtin.java.json
+++ b/tests/json-ast/x/java/append_builtin.java.json
@@ -5,7 +5,7 @@
       "name": "a",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/avg_builtin.java.json
+++ b/tests/json-ast/x/java/avg_builtin.java.json
@@ -8,7 +8,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {
@@ -103,7 +103,7 @@
                 },
                 "args": [
                   {
-                    "kind": "Array",
+                    "kind": "NEW_ARRAY",
                     "elems": [
                       {
                         "kind": "Literal",

--- a/tests/json-ast/x/java/bench_block.java.json
+++ b/tests/json-ast/x/java/bench_block.java.json
@@ -63,7 +63,7 @@
                     "name": "s"
                   },
                   "right": {
-                    "kind": "UnknownExpr"
+                    "kind": "NULL_LITERAL"
                   },
                   "op": "NOT_EQUAL_TO"
                 },
@@ -86,8 +86,7 @@
               },
               "then": [
                 {
-                  "kind": "Unknown",
-                  "type": "TRY"
+                  "kind": "TRY"
                 }
               ]
             }
@@ -226,8 +225,7 @@
       ]
     },
     {
-      "kind": "Unknown",
-      "type": "BLOCK"
+      "kind": "BLOCK"
     }
   ]
 }

--- a/tests/json-ast/x/java/break_continue.java.json
+++ b/tests/json-ast/x/java/break_continue.java.json
@@ -5,7 +5,7 @@
       "name": "numbers",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/cast_struct.java.json
+++ b/tests/json-ast/x/java/cast_struct.java.json
@@ -5,7 +5,13 @@
       "name": "todo",
       "type": "Todo",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "String",
+            "value": "hi"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/count_builtin.java.json
+++ b/tests/json-ast/x/java/count_builtin.java.json
@@ -6,7 +6,7 @@
         "kind": "Member",
         "name": "length",
         "expr": {
-          "kind": "Array",
+          "kind": "NEW_ARRAY",
           "elems": [
             {
               "kind": "Literal",

--- a/tests/json-ast/x/java/cross_join.java.json
+++ b/tests/json-ast/x/java/cross_join.java.json
@@ -5,16 +5,46 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "3"
+              },
+              {
+                "kind": "String",
+                "value": "Charlie"
+              }
+            ]
           }
         ]
       }
@@ -24,16 +54,58 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "250"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "125"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "102"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "300"
+              }
+            ]
           }
         ]
       }
@@ -43,7 +115,158 @@
       "name": "result",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/cross_join_filter.java.json
+++ b/tests/json-ast/x/java/cross_join_filter.java.json
@@ -5,7 +5,7 @@
       "name": "nums",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",
@@ -27,7 +27,7 @@
       "name": "letters",
       "type": "String[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "String",
@@ -45,7 +45,183 @@
       "name": "pairs",
       "type": "java.util.List\u003cResult2\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "n",
+            "expr": {
+              "kind": "Ident",
+              "name": "nums"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "l",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "letters"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Binary",
+                        "left": {
+                          "kind": "Ident",
+                          "name": "n"
+                        },
+                        "right": {
+                          "kind": "Literal",
+                          "value": "2"
+                        },
+                        "op": "REMAINDER"
+                      },
+                      "right": {
+                        "kind": "Literal",
+                        "value": "0"
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/cross_join_triple.java.json
+++ b/tests/json-ast/x/java/cross_join_triple.java.json
@@ -5,7 +5,7 @@
       "name": "nums",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",
@@ -23,7 +23,7 @@
       "name": "letters",
       "type": "String[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "String",
@@ -41,7 +41,7 @@
       "name": "bools",
       "type": "boolean[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",
@@ -59,7 +59,176 @@
       "name": "combos",
       "type": "java.util.List\u003cResult2\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "n",
+            "expr": {
+              "kind": "Ident",
+              "name": "nums"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "l",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "letters"
+                },
+                "body": [
+                  {
+                    "kind": "ForEach",
+                    "name": "b",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "bools"
+                    },
+                    "body": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -70,7 +239,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {
@@ -141,7 +310,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {

--- a/tests/json-ast/x/java/dataset_sort_take_limit.java.json
+++ b/tests/json-ast/x/java/dataset_sort_take_limit.java.json
@@ -5,28 +5,98 @@
       "name": "products",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Laptop"
+              },
+              {
+                "kind": "Literal",
+                "value": "1500"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Smartphone"
+              },
+              {
+                "kind": "Literal",
+                "value": "900"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Tablet"
+              },
+              {
+                "kind": "Literal",
+                "value": "600"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Monitor"
+              },
+              {
+                "kind": "Literal",
+                "value": "300"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Keyboard"
+              },
+              {
+                "kind": "Literal",
+                "value": "100"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Mouse"
+              },
+              {
+                "kind": "Literal",
+                "value": "50"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Headphones"
+              },
+              {
+                "kind": "Literal",
+                "value": "200"
+              }
+            ]
           }
         ]
       }
@@ -36,7 +106,151 @@
       "name": "expensive",
       "type": "java.util.List\u003cData1\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cData1\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "p",
+            "expr": {
+              "kind": "Ident",
+              "name": "products"
+            },
+            "body": [
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cData1\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "1"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "3"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/dataset_where_filter.java.json
+++ b/tests/json-ast/x/java/dataset_where_filter.java.json
@@ -5,19 +5,59 @@
       "name": "people",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "30"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "15"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Charlie"
+              },
+              {
+                "kind": "Literal",
+                "value": "65"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Diana"
+              },
+              {
+                "kind": "Literal",
+                "value": "45"
+              }
+            ]
           }
         ]
       }
@@ -27,7 +67,177 @@
       "name": "adults",
       "type": "java.util.List\u003cResult3\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "person",
+            "expr": {
+              "kind": "Ident",
+              "name": "people"
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Member",
+                    "name": "age",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "person"
+                    }
+                  },
+                  "right": {
+                    "kind": "Literal",
+                    "value": "18"
+                  },
+                  "op": "GREATER_THAN_EQUAL"
+                },
+                "then": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult3\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -38,7 +248,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {

--- a/tests/json-ast/x/java/exists_builtin.java.json
+++ b/tests/json-ast/x/java/exists_builtin.java.json
@@ -5,7 +5,7 @@
       "name": "data",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",
@@ -30,7 +30,165 @@
         },
         "args": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_tmp",
+                "type": "java.util.ArrayList\u003cInteger\u003e",
+                "expr": {
+                  "kind": "NEW_CLASS"
+                }
+              },
+              {
+                "kind": "ForEach",
+                "name": "x",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "data"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "x"
+                      },
+                      "right": {
+                        "kind": "Literal",
+                        "value": "1"
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "list",
+                "type": "java.util.ArrayList\u003cInteger\u003e",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "_tmp"
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "skip",
+                "type": "int",
+                "expr": {
+                  "kind": "Literal",
+                  "value": "0"
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "take",
+                "type": "int",
+                "expr": {
+                  "kind": "Literal",
+                  "value": "-1"
+                }
+              },
+              {
+                "kind": "ForRange",
+                "name": "i",
+                "start": {
+                  "kind": "Literal",
+                  "value": "0"
+                },
+                "end": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "size",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "list"
+                    }
+                  }
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "i"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "op": "LESS_THAN"
+                    },
+                    "then": [
+                      {
+                        "kind": "Continue"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Binary",
+                        "left": {
+                          "kind": "Ident",
+                          "name": "take"
+                        },
+                        "right": {
+                          "kind": "Literal",
+                          "value": "0"
+                        },
+                        "op": "GREATER_THAN_EQUAL"
+                      },
+                      "right": {
+                        "kind": "Binary",
+                        "left": {
+                          "kind": "Ident",
+                          "name": "i"
+                        },
+                        "right": {
+                          "kind": "Binary",
+                          "left": {
+                            "kind": "Ident",
+                            "name": "skip"
+                          },
+                          "right": {
+                            "kind": "Ident",
+                            "name": "take"
+                          },
+                          "op": "PLUS"
+                        },
+                        "op": "GREATER_THAN_EQUAL"
+                      },
+                      "op": "CONDITIONAL_AND"
+                    },
+                    "then": [
+                      {
+                        "kind": "Break"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
           }
         ]
       }

--- a/tests/json-ast/x/java/for_list_collection.java.json
+++ b/tests/json-ast/x/java/for_list_collection.java.json
@@ -4,7 +4,7 @@
       "kind": "ForEach",
       "name": "n",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/for_map_collection.java.json
+++ b/tests/json-ast/x/java/for_map_collection.java.json
@@ -5,7 +5,17 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          },
+          {
+            "kind": "Literal",
+            "value": "2"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/group_by.java.json
+++ b/tests/json-ast/x/java/group_by.java.json
@@ -5,25 +5,109 @@
       "name": "people",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "30"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "15"
+              },
+              {
+                "kind": "String",
+                "value": "Hanoi"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Charlie"
+              },
+              {
+                "kind": "Literal",
+                "value": "65"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Diana"
+              },
+              {
+                "kind": "Literal",
+                "value": "45"
+              },
+              {
+                "kind": "String",
+                "value": "Hanoi"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Eve"
+              },
+              {
+                "kind": "Literal",
+                "value": "70"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Frank"
+              },
+              {
+                "kind": "Literal",
+                "value": "22"
+              },
+              {
+                "kind": "String",
+                "value": "Hanoi"
+              }
+            ]
           }
         ]
       }
@@ -33,7 +117,301 @@
       "name": "stats",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "person",
+            "expr": {
+              "kind": "Ident",
+              "name": "people"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Integer",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "person"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "String",
+                        "value": "city"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group2",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group2",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/group_by_conditional_sum.java.json
+++ b/tests/json-ast/x/java/group_by_conditional_sum.java.json
@@ -5,16 +5,58 @@
       "name": "items",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "a"
+              },
+              {
+                "kind": "Literal",
+                "value": "10"
+              },
+              {
+                "kind": "Literal",
+                "value": "true"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "a"
+              },
+              {
+                "kind": "Literal",
+                "value": "5"
+              },
+              {
+                "kind": "Literal",
+                "value": "false"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "b"
+              },
+              {
+                "kind": "Literal",
+                "value": "20"
+              },
+              {
+                "kind": "Literal",
+                "value": "true"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +66,304 @@
       "name": "result",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "i",
+            "expr": {
+              "kind": "Ident",
+              "name": "items"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Integer",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "String",
+                        "value": "cat"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group2",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group2",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -57,7 +396,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/group_by_having.java.json
+++ b/tests/json-ast/x/java/group_by_having.java.json
@@ -5,28 +5,98 @@
       "name": "people",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "String",
+                "value": "Hanoi"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Charlie"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Diana"
+              },
+              {
+                "kind": "String",
+                "value": "Hanoi"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Eve"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Frank"
+              },
+              {
+                "kind": "String",
+                "value": "Hanoi"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "George"
+              },
+              {
+                "kind": "String",
+                "value": "Paris"
+              }
+            ]
           }
         ]
       }
@@ -36,7 +106,329 @@
       "name": "big",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "p",
+            "expr": {
+              "kind": "Ident",
+              "name": "people"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Integer",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "p"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "String",
+                        "value": "city"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group2",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group2",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "size",
+                      "expr": {
+                        "kind": "Member",
+                        "name": "items",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "g"
+                        }
+                      }
+                    }
+                  },
+                  "right": {
+                    "kind": "Literal",
+                    "value": "4"
+                  },
+                  "op": "GREATER_THAN_EQUAL"
+                },
+                "then": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/group_by_join.java.json
+++ b/tests/json-ast/x/java/group_by_join.java.json
@@ -5,13 +5,33 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           }
         ]
       }
@@ -21,16 +41,46 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "102"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           }
         ]
       }
@@ -40,7 +90,336 @@
       "name": "stats",
       "type": "java.util.List\u003cResult5\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "o"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "customerId"
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "VarDecl",
+                        "name": "_k",
+                        "expr": {
+                          "kind": "Member",
+                          "name": "name",
+                          "expr": {
+                            "kind": "Ident",
+                            "name": "c"
+                          }
+                        }
+                      },
+                      {
+                        "kind": "VarDecl",
+                        "name": "_ks",
+                        "type": "String",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "valueOf",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "String"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "Ident",
+                              "name": "_k"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "kind": "VarDecl",
+                        "name": "g",
+                        "type": "Group3",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "_groups"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "Ident",
+                              "name": "_ks"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "kind": "If",
+                        "cond": {
+                          "kind": "Binary",
+                          "left": {
+                            "kind": "Ident",
+                            "name": "g"
+                          },
+                          "right": {
+                            "kind": "NULL_LITERAL"
+                          },
+                          "op": "EQUAL_TO"
+                        },
+                        "then": [
+                          {
+                            "kind": "Assign",
+                            "name": "g",
+                            "target": {
+                              "kind": "Ident",
+                              "name": "g"
+                            },
+                            "expr": {
+                              "kind": "NEW_CLASS",
+                              "args": [
+                                {
+                                  "kind": "Ident",
+                                  "name": "_k"
+                                },
+                                {
+                                  "kind": "NEW_CLASS"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "kind": "Expr"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group3",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/group_by_left_join.java.json
+++ b/tests/json-ast/x/java/group_by_left_join.java.json
@@ -5,16 +5,46 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "3"
+              },
+              {
+                "kind": "String",
+                "value": "Charlie"
+              }
+            ]
           }
         ]
       }
@@ -24,16 +54,46 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "102"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           }
         ]
       }
@@ -43,7 +103,349 @@
       "name": "stats",
       "type": "java.util.List\u003cResult5\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "c",
+            "expr": {
+              "kind": "Ident",
+              "name": "customers"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "o",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "orders"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Member",
+                        "name": "customerId",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "o"
+                        }
+                      },
+                      "right": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "c"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "id"
+                            }
+                          ]
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "VarDecl",
+                        "name": "_k",
+                        "expr": {
+                          "kind": "Cast",
+                          "value": "Integer",
+                          "expr": {
+                            "kind": "Call",
+                            "target": {
+                              "kind": "Member",
+                              "name": "get",
+                              "expr": {
+                                "kind": "Ident",
+                                "name": "c"
+                              }
+                            },
+                            "args": [
+                              {
+                                "kind": "String",
+                                "value": "name"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "kind": "VarDecl",
+                        "name": "_ks",
+                        "type": "String",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "valueOf",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "String"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "Ident",
+                              "name": "_k"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "kind": "VarDecl",
+                        "name": "g",
+                        "type": "Group3",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "_groups"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "Ident",
+                              "name": "_ks"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "kind": "If",
+                        "cond": {
+                          "kind": "Binary",
+                          "left": {
+                            "kind": "Ident",
+                            "name": "g"
+                          },
+                          "right": {
+                            "kind": "NULL_LITERAL"
+                          },
+                          "op": "EQUAL_TO"
+                        },
+                        "then": [
+                          {
+                            "kind": "Assign",
+                            "name": "g",
+                            "target": {
+                              "kind": "Ident",
+                              "name": "g"
+                            },
+                            "expr": {
+                              "kind": "NEW_CLASS",
+                              "args": [
+                                {
+                                  "kind": "Ident",
+                                  "name": "_k"
+                                },
+                                {
+                                  "kind": "NEW_CLASS"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "kind": "Expr"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group3",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/group_by_multi_join.java.json
+++ b/tests/json-ast/x/java/group_by_multi_join.java.json
@@ -5,13 +5,33 @@
       "name": "nations",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "A"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "B"
+              }
+            ]
           }
         ]
       }
@@ -21,13 +41,33 @@
       "name": "suppliers",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           }
         ]
       }
@@ -37,16 +77,70 @@
       "name": "partsupp",
       "type": "Data3[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "10.0"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "20.0"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "200"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "5.0"
+              },
+              {
+                "kind": "Literal",
+                "value": "3"
+              }
+            ]
           }
         ]
       }
@@ -56,7 +150,252 @@
       "name": "filtered",
       "type": "java.util.List\u003cResult5\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "ps",
+            "expr": {
+              "kind": "Ident",
+              "name": "partsupp"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "s",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "suppliers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "s"
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "supplier",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "ps"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "ForEach",
+                        "name": "n",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "nations"
+                        },
+                        "body": [
+                          {
+                            "kind": "If",
+                            "cond": {
+                              "kind": "Binary",
+                              "left": {
+                                "kind": "Member",
+                                "name": "id",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "n"
+                                }
+                              },
+                              "right": {
+                                "kind": "Member",
+                                "name": "nation",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "s"
+                                }
+                              },
+                              "op": "EQUAL_TO"
+                            },
+                            "then": [
+                              {
+                                "kind": "If",
+                                "cond": {
+                                  "kind": "Call",
+                                  "target": {
+                                    "kind": "Member",
+                                    "name": "equals",
+                                    "expr": {
+                                      "kind": "Member",
+                                      "name": "name",
+                                      "expr": {
+                                        "kind": "Ident",
+                                        "name": "n"
+                                      }
+                                    }
+                                  },
+                                  "args": [
+                                    {
+                                      "kind": "String",
+                                      "value": "A"
+                                    }
+                                  ]
+                                },
+                                "then": [
+                                  {
+                                    "kind": "Expr"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -64,7 +403,296 @@
       "name": "grouped",
       "type": "java.util.List\u003cResult8\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group6\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult8\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "x",
+            "expr": {
+              "kind": "Ident",
+              "name": "filtered"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "Member",
+                  "name": "part",
+                  "expr": {
+                    "kind": "Ident",
+                    "name": "x"
+                  }
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group6",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup6\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult8\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group6",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -105,7 +733,7 @@
                 },
                 "args": [
                   {
-                    "kind": "UnknownExpr"
+                    "kind": "MEMBER_REFERENCE"
                   }
                 ]
               }

--- a/tests/json-ast/x/java/group_by_multi_join_sort.java.json
+++ b/tests/json-ast/x/java/group_by_multi_join_sort.java.json
@@ -5,10 +5,20 @@
       "name": "nation",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "BRAZIL"
+              }
+            ]
           }
         ]
       }
@@ -18,10 +28,40 @@
       "name": "customer",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "100.0"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "123 St"
+              },
+              {
+                "kind": "String",
+                "value": "123-456"
+              },
+              {
+                "kind": "String",
+                "value": "Loyal"
+              }
+            ]
           }
         ]
       }
@@ -31,13 +71,41 @@
       "name": "orders",
       "type": "Data3[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1000"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "1993-10-15"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2000"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "1994-01-02"
+              }
+            ]
           }
         ]
       }
@@ -47,13 +115,49 @@
       "name": "lineitem",
       "type": "Data4[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1000"
+              },
+              {
+                "kind": "String",
+                "value": "R"
+              },
+              {
+                "kind": "Literal",
+                "value": "1000.0"
+              },
+              {
+                "kind": "Literal",
+                "value": "0.1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2000"
+              },
+              {
+                "kind": "String",
+                "value": "N"
+              },
+              {
+                "kind": "Literal",
+                "value": "500.0"
+              },
+              {
+                "kind": "Literal",
+                "value": "0.0"
+              }
+            ]
           }
         ]
       }
@@ -81,7 +185,523 @@
       "name": "result",
       "type": "java.util.List\u003cResult8\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group6\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult8\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "c",
+            "expr": {
+              "kind": "Ident",
+              "name": "customer"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "o",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "orders"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Member",
+                        "name": "o_custkey",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "o"
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "c_custkey",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "ForEach",
+                        "name": "l",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "lineitem"
+                        },
+                        "body": [
+                          {
+                            "kind": "If",
+                            "cond": {
+                              "kind": "Binary",
+                              "left": {
+                                "kind": "Member",
+                                "name": "l_orderkey",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "l"
+                                }
+                              },
+                              "right": {
+                                "kind": "Member",
+                                "name": "o_orderkey",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "o"
+                                }
+                              },
+                              "op": "EQUAL_TO"
+                            },
+                            "then": [
+                              {
+                                "kind": "ForEach",
+                                "name": "n",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "nation"
+                                },
+                                "body": [
+                                  {
+                                    "kind": "If",
+                                    "cond": {
+                                      "kind": "Binary",
+                                      "left": {
+                                        "kind": "Member",
+                                        "name": "n_nationkey",
+                                        "expr": {
+                                          "kind": "Ident",
+                                          "name": "n"
+                                        }
+                                      },
+                                      "right": {
+                                        "kind": "Member",
+                                        "name": "c_nationkey",
+                                        "expr": {
+                                          "kind": "Ident",
+                                          "name": "c"
+                                        }
+                                      },
+                                      "op": "EQUAL_TO"
+                                    },
+                                    "then": [
+                                      {
+                                        "kind": "If",
+                                        "cond": {
+                                          "kind": "Binary",
+                                          "left": {
+                                            "kind": "Binary",
+                                            "left": {
+                                              "kind": "Binary",
+                                              "left": {
+                                                "kind": "Call",
+                                                "target": {
+                                                  "kind": "Member",
+                                                  "name": "compareTo",
+                                                  "expr": {
+                                                    "kind": "Member",
+                                                    "name": "o_orderdate",
+                                                    "expr": {
+                                                      "kind": "Ident",
+                                                      "name": "o"
+                                                    }
+                                                  }
+                                                },
+                                                "args": [
+                                                  {
+                                                    "kind": "Ident",
+                                                    "name": "start_date"
+                                                  }
+                                                ]
+                                              },
+                                              "right": {
+                                                "kind": "Literal",
+                                                "value": "0"
+                                              },
+                                              "op": "GREATER_THAN_EQUAL"
+                                            },
+                                            "right": {
+                                              "kind": "Binary",
+                                              "left": {
+                                                "kind": "Member",
+                                                "name": "o_orderdate",
+                                                "expr": {
+                                                  "kind": "Ident",
+                                                  "name": "o"
+                                                }
+                                              },
+                                              "right": {
+                                                "kind": "Ident",
+                                                "name": "end_date"
+                                              },
+                                              "op": "LESS_THAN"
+                                            },
+                                            "op": "CONDITIONAL_AND"
+                                          },
+                                          "right": {
+                                            "kind": "Binary",
+                                            "left": {
+                                              "kind": "Member",
+                                              "name": "l_returnflag",
+                                              "expr": {
+                                                "kind": "Ident",
+                                                "name": "l"
+                                              }
+                                            },
+                                            "right": {
+                                              "kind": "String",
+                                              "value": "R"
+                                            },
+                                            "op": "EQUAL_TO"
+                                          },
+                                          "op": "CONDITIONAL_AND"
+                                        },
+                                        "then": [
+                                          {
+                                            "kind": "VarDecl",
+                                            "name": "_k",
+                                            "expr": {
+                                              "kind": "NEW_CLASS",
+                                              "args": [
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "c_custkey",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "c"
+                                                  }
+                                                },
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "c_name",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "c"
+                                                  }
+                                                },
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "c_acctbal",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "c"
+                                                  }
+                                                },
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "c_address",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "c"
+                                                  }
+                                                },
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "c_phone",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "c"
+                                                  }
+                                                },
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "c_comment",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "c"
+                                                  }
+                                                },
+                                                {
+                                                  "kind": "Member",
+                                                  "name": "n_name",
+                                                  "expr": {
+                                                    "kind": "Ident",
+                                                    "name": "n"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "kind": "VarDecl",
+                                            "name": "_ks",
+                                            "type": "String",
+                                            "expr": {
+                                              "kind": "Call",
+                                              "target": {
+                                                "kind": "Member",
+                                                "name": "valueOf",
+                                                "expr": {
+                                                  "kind": "Ident",
+                                                  "name": "String"
+                                                }
+                                              },
+                                              "args": [
+                                                {
+                                                  "kind": "Ident",
+                                                  "name": "_k"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "kind": "VarDecl",
+                                            "name": "g",
+                                            "type": "Group6",
+                                            "expr": {
+                                              "kind": "Call",
+                                              "target": {
+                                                "kind": "Member",
+                                                "name": "get",
+                                                "expr": {
+                                                  "kind": "Ident",
+                                                  "name": "_groups"
+                                                }
+                                              },
+                                              "args": [
+                                                {
+                                                  "kind": "Ident",
+                                                  "name": "_ks"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "kind": "If",
+                                            "cond": {
+                                              "kind": "Binary",
+                                              "left": {
+                                                "kind": "Ident",
+                                                "name": "g"
+                                              },
+                                              "right": {
+                                                "kind": "NULL_LITERAL"
+                                              },
+                                              "op": "EQUAL_TO"
+                                            },
+                                            "then": [
+                                              {
+                                                "kind": "Assign",
+                                                "name": "g",
+                                                "target": {
+                                                  "kind": "Ident",
+                                                  "name": "g"
+                                                },
+                                                "expr": {
+                                                  "kind": "NEW_CLASS",
+                                                  "args": [
+                                                    {
+                                                      "kind": "Ident",
+                                                      "name": "_k"
+                                                    },
+                                                    {
+                                                      "kind": "NEW_CLASS"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "kind": "Expr"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "Expr"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup6\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group6",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -114,7 +734,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/group_by_multi_sort.java.json
+++ b/tests/json-ast/x/java/group_by_multi_sort.java.json
@@ -5,19 +5,75 @@
       "name": "items",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "x"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "x"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "3"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "y"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "4"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "y"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           }
         ]
       }
@@ -27,7 +83,312 @@
       "name": "grouped",
       "type": "java.util.List\u003cResult5\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "i",
+            "expr": {
+              "kind": "Ident",
+              "name": "items"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "NEW_CLASS",
+                  "args": [
+                    {
+                      "kind": "Member",
+                      "name": "a",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    },
+                    {
+                      "kind": "Member",
+                      "name": "b",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group3",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup3\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group3",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -38,7 +399,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {
@@ -139,7 +500,7 @@
                 },
                 "args": [
                   {
-                    "kind": "UnknownExpr"
+                    "kind": "MEMBER_REFERENCE"
                   }
                 ]
               }

--- a/tests/json-ast/x/java/group_by_sort.java.json
+++ b/tests/json-ast/x/java/group_by_sort.java.json
@@ -5,19 +5,59 @@
       "name": "items",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "a"
+              },
+              {
+                "kind": "Literal",
+                "value": "3"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "a"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "b"
+              },
+              {
+                "kind": "Literal",
+                "value": "5"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "b"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           }
         ]
       }
@@ -27,7 +67,304 @@
       "name": "grouped",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "i",
+            "expr": {
+              "kind": "Ident",
+              "name": "items"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Integer",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "String",
+                        "value": "cat"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group2",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group2",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -60,7 +397,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/group_items_iteration.java.json
+++ b/tests/json-ast/x/java/group_items_iteration.java.json
@@ -5,16 +5,46 @@
       "name": "data",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "a"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "a"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "b"
+              },
+              {
+                "kind": "Literal",
+                "value": "3"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +54,301 @@
       "name": "groups",
       "type": "java.util.List\u003cData1\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_groups",
+            "type": "java.util.LinkedHashMap\u003cString, Group2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cData1\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "d",
+            "expr": {
+              "kind": "Ident",
+              "name": "data"
+            },
+            "body": [
+              {
+                "kind": "VarDecl",
+                "name": "_k",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Integer",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "d"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "String",
+                        "value": "tag"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "_ks",
+                "type": "String",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "valueOf",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "String"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_k"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "type": "Group2",
+                "expr": {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "get",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  },
+                  "args": [
+                    {
+                      "kind": "Ident",
+                      "name": "_ks"
+                    }
+                  ]
+                }
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "g"
+                  },
+                  "right": {
+                    "kind": "NULL_LITERAL"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Assign",
+                    "name": "g",
+                    "target": {
+                      "kind": "Ident",
+                      "name": "g"
+                    },
+                    "expr": {
+                      "kind": "NEW_CLASS",
+                      "args": [
+                        {
+                          "kind": "Ident",
+                          "name": "_k"
+                        },
+                        {
+                          "kind": "NEW_CLASS"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cGroup2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS",
+              "args": [
+                {
+                  "kind": "Call",
+                  "target": {
+                    "kind": "Member",
+                    "name": "values",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "_groups"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "VarDecl",
+                "name": "g",
+                "expr": {
+                  "kind": "Cast",
+                  "value": "Group2",
+                  "expr": {
+                    "kind": "Call",
+                    "target": {
+                      "kind": "Member",
+                      "name": "get",
+                      "expr": {
+                        "kind": "Ident",
+                        "name": "list"
+                      }
+                    },
+                    "args": [
+                      {
+                        "kind": "Ident",
+                        "name": "i"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -32,7 +356,7 @@
       "name": "tmp",
       "type": "Object[]",
       "expr": {
-        "kind": "Array"
+        "kind": "NEW_ARRAY"
       }
     },
     {
@@ -40,7 +364,151 @@
       "name": "result",
       "type": "java.util.List\u003cObject\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cObject\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "r",
+            "expr": {
+              "kind": "Ident",
+              "name": "tmp"
+            },
+            "body": [
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cObject\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -182,7 +650,21 @@
                     },
                     "args": [
                       {
-                        "kind": "UnknownExpr"
+                        "kind": "NEW_CLASS",
+                        "args": [
+                          {
+                            "kind": "Member",
+                            "name": "key",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "g"
+                            }
+                          },
+                          {
+                            "kind": "Ident",
+                            "name": "total"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -191,7 +673,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }
@@ -228,7 +710,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/in_operator.java.json
+++ b/tests/json-ast/x/java/in_operator.java.json
@@ -5,7 +5,7 @@
       "name": "xs",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/in_operator_extended.java.json
+++ b/tests/json-ast/x/java/in_operator_extended.java.json
@@ -5,7 +5,7 @@
       "name": "xs",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",
@@ -27,7 +27,173 @@
       "name": "ys",
       "type": "java.util.List\u003cInteger\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cInteger\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "x",
+            "expr": {
+              "kind": "Ident",
+              "name": "xs"
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "x"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "2"
+                    },
+                    "op": "REMAINDER"
+                  },
+                  "right": {
+                    "kind": "Literal",
+                    "value": "1"
+                  },
+                  "op": "EQUAL_TO"
+                },
+                "then": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cInteger\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -35,7 +201,13 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/inner_join.java.json
+++ b/tests/json-ast/x/java/inner_join.java.json
@@ -5,16 +5,46 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "3"
+              },
+              {
+                "kind": "String",
+                "value": "Charlie"
+              }
+            ]
           }
         ]
       }
@@ -24,19 +54,75 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "250"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "125"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "102"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "300"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "103"
+              },
+              {
+                "kind": "Literal",
+                "value": "4"
+              },
+              {
+                "kind": "Literal",
+                "value": "80"
+              }
+            ]
           }
         ]
       }
@@ -46,7 +132,196 @@
       "name": "result",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "o"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "customerId"
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/join_multi.java.json
+++ b/tests/json-ast/x/java/join_multi.java.json
@@ -5,13 +5,33 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           }
         ]
       }
@@ -21,13 +41,33 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           }
         ]
       }
@@ -37,13 +77,33 @@
       "name": "items",
       "type": "Data3[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "String",
+                "value": "a"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "String",
+                "value": "b"
+              }
+            ]
           }
         ]
       }
@@ -53,7 +113,244 @@
       "name": "result",
       "type": "java.util.List\u003cResult5\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "o"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "customerId"
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "ForEach",
+                        "name": "i",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "items"
+                        },
+                        "body": [
+                          {
+                            "kind": "If",
+                            "cond": {
+                              "kind": "Binary",
+                              "left": {
+                                "kind": "Cast",
+                                "value": "Integer",
+                                "expr": {
+                                  "kind": "Call",
+                                  "target": {
+                                    "kind": "Member",
+                                    "name": "get",
+                                    "expr": {
+                                      "kind": "Ident",
+                                      "name": "o"
+                                    }
+                                  },
+                                  "args": [
+                                    {
+                                      "kind": "String",
+                                      "value": "id"
+                                    }
+                                  ]
+                                }
+                              },
+                              "right": {
+                                "kind": "Member",
+                                "name": "orderId",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "i"
+                                }
+                              },
+                              "op": "EQUAL_TO"
+                            },
+                            "then": [
+                              {
+                                "kind": "Expr"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/json_builtin.java.json
+++ b/tests/json-ast/x/java/json_builtin.java.json
@@ -5,7 +5,17 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          },
+          {
+            "kind": "Literal",
+            "value": "2"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/left_join.java.json
+++ b/tests/json-ast/x/java/left_join.java.json
@@ -5,13 +5,33 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           }
         ]
       }
@@ -21,13 +41,41 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "250"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "3"
+              },
+              {
+                "kind": "Literal",
+                "value": "80"
+              }
+            ]
           }
         ]
       }
@@ -37,7 +85,196 @@
       "name": "result",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "o"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "customerId"
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/left_join_multi.java.json
+++ b/tests/json-ast/x/java/left_join_multi.java.json
@@ -5,13 +5,33 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           }
         ]
       }
@@ -21,13 +41,33 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           }
         ]
       }
@@ -37,10 +77,20 @@
       "name": "items",
       "type": "Data3[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "String",
+                "value": "a"
+              }
+            ]
           }
         ]
       }
@@ -50,7 +100,244 @@
       "name": "result",
       "type": "java.util.List\u003cResult5\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "o"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "customerId"
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "ForEach",
+                        "name": "i",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "items"
+                        },
+                        "body": [
+                          {
+                            "kind": "If",
+                            "cond": {
+                              "kind": "Binary",
+                              "left": {
+                                "kind": "Cast",
+                                "value": "Integer",
+                                "expr": {
+                                  "kind": "Call",
+                                  "target": {
+                                    "kind": "Member",
+                                    "name": "get",
+                                    "expr": {
+                                      "kind": "Ident",
+                                      "name": "o"
+                                    }
+                                  },
+                                  "args": [
+                                    {
+                                      "kind": "String",
+                                      "value": "id"
+                                    }
+                                  ]
+                                }
+                              },
+                              "right": {
+                                "kind": "Member",
+                                "name": "orderId",
+                                "expr": {
+                                  "kind": "Ident",
+                                  "name": "i"
+                                }
+                              },
+                              "op": "EQUAL_TO"
+                            },
+                            "then": [
+                              {
+                                "kind": "Expr"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult5\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/len_builtin.java.json
+++ b/tests/json-ast/x/java/len_builtin.java.json
@@ -6,7 +6,7 @@
         "kind": "Member",
         "name": "length",
         "expr": {
-          "kind": "Array",
+          "kind": "NEW_ARRAY",
           "elems": [
             {
               "kind": "Literal",

--- a/tests/json-ast/x/java/len_map.java.json
+++ b/tests/json-ast/x/java/len_map.java.json
@@ -8,7 +8,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {
@@ -79,7 +79,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {
@@ -145,7 +145,15 @@
               "kind": "Member",
               "name": "size",
               "expr": {
-                "kind": "UnknownExpr"
+                "kind": "NEW_CLASS",
+                "body": [
+                  {
+                    "kind": "Expr"
+                  },
+                  {
+                    "kind": "Expr"
+                  }
+                ]
               }
             }
           }

--- a/tests/json-ast/x/java/list_assign.java.json
+++ b/tests/json-ast/x/java/list_assign.java.json
@@ -5,7 +5,7 @@
       "name": "nums",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/list_index.java.json
+++ b/tests/json-ast/x/java/list_index.java.json
@@ -5,7 +5,7 @@
       "name": "xs",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/list_nested_assign.java.json
+++ b/tests/json-ast/x/java/list_nested_assign.java.json
@@ -5,10 +5,10 @@
       "name": "matrix",
       "type": "int[][]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "Array",
+            "kind": "NEW_ARRAY",
             "elems": [
               {
                 "kind": "Literal",
@@ -21,7 +21,7 @@
             ]
           },
           {
-            "kind": "Array",
+            "kind": "NEW_ARRAY",
             "elems": [
               {
                 "kind": "Literal",

--- a/tests/json-ast/x/java/list_set_ops.java.json
+++ b/tests/json-ast/x/java/list_set_ops.java.json
@@ -74,7 +74,7 @@
                         },
                         "args": [
                           {
-                            "kind": "Array",
+                            "kind": "NEW_ARRAY",
                             "elems": [
                               {
                                 "kind": "Literal",
@@ -108,7 +108,7 @@
                         },
                         "args": [
                           {
-                            "kind": "Array",
+                            "kind": "NEW_ARRAY",
                             "elems": [
                               {
                                 "kind": "Literal",
@@ -182,7 +182,7 @@
                     },
                     "args": [
                       {
-                        "kind": "Array",
+                        "kind": "NEW_ARRAY",
                         "elems": [
                           {
                             "kind": "Literal",
@@ -229,7 +229,7 @@
                           },
                           "args": [
                             {
-                              "kind": "Array",
+                              "kind": "NEW_ARRAY",
                               "elems": [
                                 {
                                   "kind": "Literal",
@@ -327,7 +327,7 @@
                     },
                     "args": [
                       {
-                        "kind": "Array",
+                        "kind": "NEW_ARRAY",
                         "elems": [
                           {
                             "kind": "Literal",
@@ -374,7 +374,7 @@
                           },
                           "args": [
                             {
-                              "kind": "Array",
+                              "kind": "NEW_ARRAY",
                               "elems": [
                                 {
                                   "kind": "Literal",
@@ -478,7 +478,7 @@
                   },
                   "args": [
                     {
-                      "kind": "Array",
+                      "kind": "NEW_ARRAY",
                       "elems": [
                         {
                           "kind": "Literal",
@@ -512,7 +512,7 @@
                   },
                   "args": [
                     {
-                      "kind": "Array",
+                      "kind": "NEW_ARRAY",
                       "elems": [
                         {
                           "kind": "Literal",

--- a/tests/json-ast/x/java/load_jsonl.java.json
+++ b/tests/json-ast/x/java/load_jsonl.java.json
@@ -5,16 +5,58 @@
       "name": "people",
       "type": "Person[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "30"
+              },
+              {
+                "kind": "String",
+                "value": "alice@example.com"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "15"
+              },
+              {
+                "kind": "String",
+                "value": "bob@example.com"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Charlie"
+              },
+              {
+                "kind": "Literal",
+                "value": "20"
+              },
+              {
+                "kind": "String",
+                "value": "charlie@example.com"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +66,177 @@
       "name": "adults",
       "type": "java.util.List\u003cResult2\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "p",
+            "expr": {
+              "kind": "Ident",
+              "name": "people"
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Member",
+                    "name": "age",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "p"
+                    }
+                  },
+                  "right": {
+                    "kind": "Literal",
+                    "value": "18"
+                  },
+                  "op": "GREATER_THAN_EQUAL"
+                },
+                "then": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -35,7 +247,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {

--- a/tests/json-ast/x/java/load_yaml.java.json
+++ b/tests/json-ast/x/java/load_yaml.java.json
@@ -5,16 +5,58 @@
       "name": "people",
       "type": "Person[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "30"
+              },
+              {
+                "kind": "String",
+                "value": "alice@example.com"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "15"
+              },
+              {
+                "kind": "String",
+                "value": "bob@example.com"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Charlie"
+              },
+              {
+                "kind": "Literal",
+                "value": "20"
+              },
+              {
+                "kind": "String",
+                "value": "charlie@example.com"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +66,177 @@
       "name": "adults",
       "type": "java.util.List\u003cResult2\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "p",
+            "expr": {
+              "kind": "Ident",
+              "name": "people"
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Member",
+                    "name": "age",
+                    "expr": {
+                      "kind": "Ident",
+                      "name": "p"
+                    }
+                  },
+                  "right": {
+                    "kind": "Literal",
+                    "value": "18"
+                  },
+                  "op": "GREATER_THAN_EQUAL"
+                },
+                "then": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "_res",
+            "type": "java.util.ArrayList\u003cResult2\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/map_assign.java.json
+++ b/tests/json-ast/x/java/map_assign.java.json
@@ -5,7 +5,13 @@
       "name": "scores",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/map_in_operator.java.json
+++ b/tests/json-ast/x/java/map_in_operator.java.json
@@ -5,7 +5,15 @@
       "name": "m",
       "type": "java.util.Map",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/map_index.java.json
+++ b/tests/json-ast/x/java/map_index.java.json
@@ -5,7 +5,17 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          },
+          {
+            "kind": "Literal",
+            "value": "2"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/map_int_key.java.json
+++ b/tests/json-ast/x/java/map_int_key.java.json
@@ -5,7 +5,15 @@
       "name": "m",
       "type": "java.util.Map",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/map_literal_dynamic.java.json
+++ b/tests/json-ast/x/java/map_literal_dynamic.java.json
@@ -23,7 +23,17 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Ident",
+            "name": "x"
+          },
+          {
+            "kind": "Ident",
+            "name": "y"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/map_membership.java.json
+++ b/tests/json-ast/x/java/map_membership.java.json
@@ -5,7 +5,17 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          },
+          {
+            "kind": "Literal",
+            "value": "2"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/membership.java.json
+++ b/tests/json-ast/x/java/membership.java.json
@@ -5,7 +5,7 @@
       "name": "nums",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/min_max_builtin.java.json
+++ b/tests/json-ast/x/java/min_max_builtin.java.json
@@ -5,7 +5,7 @@
       "name": "nums",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",

--- a/tests/json-ast/x/java/order_by_map.java.json
+++ b/tests/json-ast/x/java/order_by_map.java.json
@@ -5,16 +5,46 @@
       "name": "data",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "0"
+              },
+              {
+                "kind": "Literal",
+                "value": "5"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +54,151 @@
       "name": "sorted",
       "type": "java.util.List\u003cData1\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cData1\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "x",
+            "expr": {
+              "kind": "Ident",
+              "name": "data"
+            },
+            "body": [
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cData1\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -57,7 +231,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/outer_join.java.json
+++ b/tests/json-ast/x/java/outer_join.java.json
@@ -5,19 +5,59 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "3"
+              },
+              {
+                "kind": "String",
+                "value": "Charlie"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "4"
+              },
+              {
+                "kind": "String",
+                "value": "Diana"
+              }
+            ]
           }
         ]
       }
@@ -27,19 +67,75 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "250"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "125"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "102"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "300"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "103"
+              },
+              {
+                "kind": "Literal",
+                "value": "5"
+              },
+              {
+                "kind": "Literal",
+                "value": "80"
+              }
+            ]
           }
         ]
       }
@@ -49,7 +145,196 @@
       "name": "result",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "o",
+            "expr": {
+              "kind": "Ident",
+              "name": "orders"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "c",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "customers"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "o"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "customerId"
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "kind": "Member",
+                        "name": "id",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "c"
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/query_sum_select.java.json
+++ b/tests/json-ast/x/java/query_sum_select.java.json
@@ -5,7 +5,7 @@
       "name": "nums",
       "type": "int[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
             "kind": "Literal",
@@ -27,7 +27,165 @@
       "name": "result",
       "type": "java.util.List\u003cint\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cint\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "n",
+            "expr": {
+              "kind": "Ident",
+              "name": "nums"
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "n"
+                  },
+                  "right": {
+                    "kind": "Literal",
+                    "value": "1"
+                  },
+                  "op": "GREATER_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Expr"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cint\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -60,7 +218,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/record_assign.java.json
+++ b/tests/json-ast/x/java/record_assign.java.json
@@ -5,7 +5,13 @@
       "name": "c",
       "type": "Counter",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "0"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/right_join.java.json
+++ b/tests/json-ast/x/java/right_join.java.json
@@ -5,19 +5,59 @@
       "name": "customers",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "Alice"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "Bob"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "3"
+              },
+              {
+                "kind": "String",
+                "value": "Charlie"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "4"
+              },
+              {
+                "kind": "String",
+                "value": "Diana"
+              }
+            ]
           }
         ]
       }
@@ -27,16 +67,58 @@
       "name": "orders",
       "type": "Data2[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "100"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "250"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "101"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Literal",
+                "value": "125"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "102"
+              },
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "Literal",
+                "value": "300"
+              }
+            ]
           }
         ]
       }
@@ -46,7 +128,196 @@
       "name": "result",
       "type": "java.util.List\u003cResult4\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "c",
+            "expr": {
+              "kind": "Ident",
+              "name": "customers"
+            },
+            "body": [
+              {
+                "kind": "ForEach",
+                "name": "o",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "orders"
+                },
+                "body": [
+                  {
+                    "kind": "If",
+                    "cond": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Member",
+                        "name": "customerId",
+                        "expr": {
+                          "kind": "Ident",
+                          "name": "o"
+                        }
+                      },
+                      "right": {
+                        "kind": "Cast",
+                        "value": "Integer",
+                        "expr": {
+                          "kind": "Call",
+                          "target": {
+                            "kind": "Member",
+                            "name": "get",
+                            "expr": {
+                              "kind": "Ident",
+                              "name": "c"
+                            }
+                          },
+                          "args": [
+                            {
+                              "kind": "String",
+                              "value": "id"
+                            }
+                          ]
+                        }
+                      },
+                      "op": "EQUAL_TO"
+                    },
+                    "then": [
+                      {
+                        "kind": "Expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cResult4\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/save_jsonl_stdout.java.json
+++ b/tests/json-ast/x/java/save_jsonl_stdout.java.json
@@ -5,13 +5,33 @@
       "name": "people",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "30"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "25"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +44,7 @@
         {
           "kind": "If",
           "cond": {
-            "kind": "UnknownExpr"
+            "kind": "INSTANCE_OF"
           },
           "then": [
             {
@@ -32,7 +52,7 @@
               "name": "m",
               "type": "java.util.LinkedHashMap\u003cString, Object\u003e",
               "expr": {
-                "kind": "UnknownExpr"
+                "kind": "NEW_CLASS"
               }
             },
             {
@@ -69,7 +89,7 @@
           "name": "m",
           "type": "java.util.LinkedHashMap\u003cString, Object\u003e",
           "expr": {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS"
           }
         },
         {
@@ -95,8 +115,7 @@
           },
           "body": [
             {
-              "kind": "Unknown",
-              "type": "TRY"
+              "kind": "TRY"
             }
           ]
         },
@@ -151,7 +170,7 @@
               "name": "parts",
               "type": "java.util.List\u003cString\u003e",
               "expr": {
-                "kind": "UnknownExpr"
+                "kind": "NEW_CLASS"
               }
             },
             {
@@ -188,7 +207,7 @@
                 {
                   "kind": "If",
                   "cond": {
-                    "kind": "UnknownExpr"
+                    "kind": "INSTANCE_OF"
                   },
                   "then": [
                     {

--- a/tests/json-ast/x/java/slice.java.json
+++ b/tests/json-ast/x/java/slice.java.json
@@ -41,7 +41,7 @@
             },
             "args": [
               {
-                "kind": "Array",
+                "kind": "NEW_ARRAY",
                 "elems": [
                   {
                     "kind": "Literal",
@@ -111,7 +111,7 @@
             },
             "args": [
               {
-                "kind": "Array",
+                "kind": "NEW_ARRAY",
                 "elems": [
                   {
                     "kind": "Literal",

--- a/tests/json-ast/x/java/sort_stable.java.json
+++ b/tests/json-ast/x/java/sort_stable.java.json
@@ -5,16 +5,46 @@
       "name": "items",
       "type": "Data1[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "a"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "1"
+              },
+              {
+                "kind": "String",
+                "value": "b"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "String",
+                "value": "c"
+              }
+            ]
           }
         ]
       }
@@ -24,7 +54,151 @@
       "name": "result",
       "type": "java.util.List\u003cString\u003e",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "body": [
+          {
+            "kind": "VarDecl",
+            "name": "_tmp",
+            "type": "java.util.ArrayList\u003cString\u003e",
+            "expr": {
+              "kind": "NEW_CLASS"
+            }
+          },
+          {
+            "kind": "ForEach",
+            "name": "i",
+            "expr": {
+              "kind": "Ident",
+              "name": "items"
+            },
+            "body": [
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "VarDecl",
+            "name": "list",
+            "type": "java.util.ArrayList\u003cString\u003e",
+            "expr": {
+              "kind": "Ident",
+              "name": "_tmp"
+            }
+          },
+          {
+            "kind": "Expr"
+          },
+          {
+            "kind": "VarDecl",
+            "name": "skip",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "0"
+            }
+          },
+          {
+            "kind": "VarDecl",
+            "name": "take",
+            "type": "int",
+            "expr": {
+              "kind": "Literal",
+              "value": "-1"
+            }
+          },
+          {
+            "kind": "ForRange",
+            "name": "i",
+            "start": {
+              "kind": "Literal",
+              "value": "0"
+            },
+            "end": {
+              "kind": "Call",
+              "target": {
+                "kind": "Member",
+                "name": "size",
+                "expr": {
+                  "kind": "Ident",
+                  "name": "list"
+                }
+              }
+            },
+            "body": [
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Ident",
+                    "name": "i"
+                  },
+                  "right": {
+                    "kind": "Ident",
+                    "name": "skip"
+                  },
+                  "op": "LESS_THAN"
+                },
+                "then": [
+                  {
+                    "kind": "Continue"
+                  }
+                ]
+              },
+              {
+                "kind": "If",
+                "cond": {
+                  "kind": "Binary",
+                  "left": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "take"
+                    },
+                    "right": {
+                      "kind": "Literal",
+                      "value": "0"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "right": {
+                    "kind": "Binary",
+                    "left": {
+                      "kind": "Ident",
+                      "name": "i"
+                    },
+                    "right": {
+                      "kind": "Binary",
+                      "left": {
+                        "kind": "Ident",
+                        "name": "skip"
+                      },
+                      "right": {
+                        "kind": "Ident",
+                        "name": "take"
+                      },
+                      "op": "PLUS"
+                    },
+                    "op": "GREATER_THAN_EQUAL"
+                  },
+                  "op": "CONDITIONAL_AND"
+                },
+                "then": [
+                  {
+                    "kind": "Break"
+                  }
+                ]
+              },
+              {
+                "kind": "Expr"
+              }
+            ]
+          },
+          {
+            "kind": "Expr"
+          }
+        ]
       }
     },
     {
@@ -57,7 +231,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tests/json-ast/x/java/sum_builtin.java.json
+++ b/tests/json-ast/x/java/sum_builtin.java.json
@@ -33,7 +33,7 @@
                   },
                   "args": [
                     {
-                      "kind": "Array",
+                      "kind": "NEW_ARRAY",
                       "elems": [
                         {
                           "kind": "Literal",
@@ -96,7 +96,7 @@
                   },
                   "args": [
                     {
-                      "kind": "Array",
+                      "kind": "NEW_ARRAY",
                       "elems": [
                         {
                           "kind": "Literal",
@@ -146,7 +146,7 @@
                 },
                 "args": [
                   {
-                    "kind": "Array",
+                    "kind": "NEW_ARRAY",
                     "elems": [
                       {
                         "kind": "Literal",

--- a/tests/json-ast/x/java/tree_sum.java.json
+++ b/tests/json-ast/x/java/tree_sum.java.json
@@ -5,7 +5,34 @@
       "name": "t",
       "type": "Node",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Ident",
+            "name": "Leaf"
+          },
+          {
+            "kind": "Literal",
+            "value": "1"
+          },
+          {
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "Ident",
+                "name": "Leaf"
+              },
+              {
+                "kind": "Literal",
+                "value": "2"
+              },
+              {
+                "kind": "Ident",
+                "name": "Leaf"
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/two-sum.java.json
+++ b/tests/json-ast/x/java/two-sum.java.json
@@ -12,7 +12,7 @@
         },
         "args": [
           {
-            "kind": "Array",
+            "kind": "NEW_ARRAY",
             "elems": [
               {
                 "kind": "Literal",
@@ -129,7 +129,7 @@
                     {
                       "kind": "Return",
                       "expr": {
-                        "kind": "Array",
+                        "kind": "NEW_ARRAY",
                         "elems": [
                           {
                             "kind": "Ident",
@@ -151,7 +151,7 @@
         {
           "kind": "Return",
           "expr": {
-            "kind": "Array",
+            "kind": "NEW_ARRAY",
             "elems": [
               {
                 "kind": "Literal",

--- a/tests/json-ast/x/java/update_stmt.java.json
+++ b/tests/json-ast/x/java/update_stmt.java.json
@@ -5,19 +5,75 @@
       "name": "people",
       "type": "Person[]",
       "expr": {
-        "kind": "Array",
+        "kind": "NEW_ARRAY",
         "elems": [
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Alice"
+              },
+              {
+                "kind": "Literal",
+                "value": "17"
+              },
+              {
+                "kind": "String",
+                "value": "minor"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "25"
+              },
+              {
+                "kind": "String",
+                "value": "unknown"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Charlie"
+              },
+              {
+                "kind": "Literal",
+                "value": "18"
+              },
+              {
+                "kind": "String",
+                "value": "unknown"
+              }
+            ]
           },
           {
-            "kind": "UnknownExpr"
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Diana"
+              },
+              {
+                "kind": "Literal",
+                "value": "16"
+              },
+              {
+                "kind": "String",
+                "value": "minor"
+              }
+            ]
           }
         ]
       }

--- a/tests/json-ast/x/java/user_type_literal.java.json
+++ b/tests/json-ast/x/java/user_type_literal.java.json
@@ -5,7 +5,26 @@
       "name": "book",
       "type": "Book",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "String",
+            "value": "Go"
+          },
+          {
+            "kind": "NEW_CLASS",
+            "args": [
+              {
+                "kind": "String",
+                "value": "Bob"
+              },
+              {
+                "kind": "Literal",
+                "value": "42"
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/tests/json-ast/x/java/values_builtin.java.json
+++ b/tests/json-ast/x/java/values_builtin.java.json
@@ -5,7 +5,21 @@
       "name": "m",
       "type": "Data1",
       "expr": {
-        "kind": "UnknownExpr"
+        "kind": "NEW_CLASS",
+        "args": [
+          {
+            "kind": "Literal",
+            "value": "1"
+          },
+          {
+            "kind": "Literal",
+            "value": "2"
+          },
+          {
+            "kind": "Literal",
+            "value": "3"
+          }
+        ]
       }
     },
     {
@@ -79,7 +93,7 @@
             },
             "args": [
               {
-                "kind": "UnknownExpr"
+                "kind": "MEMBER_REFERENCE"
               }
             ]
           }

--- a/tools/json-ast/x/java/inspect.go
+++ b/tools/json-ast/x/java/inspect.go
@@ -3,19 +3,125 @@
 package java
 
 import (
-	jparser "mochi/tools/a2mochi/x/java"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
 )
 
-// Program represents a parsed Java source file in simplified form.
+// Program represents the parsed structure of a Java source file.
 type Program struct {
-	Body []jparser.Stmt `json:"body"`
+	Body []Stmt `json:"body"`
 }
 
-// Inspect parses the given Java source code and returns its Program structure.
+// Stmt represents a statement node in the simplified AST.
+type Stmt struct {
+	Kind   string  `json:"kind"`
+	Name   string  `json:"name,omitempty"`
+	Type   string  `json:"type,omitempty"`
+	Target *Expr   `json:"target,omitempty"`
+	Expr   *Expr   `json:"expr,omitempty"`
+	Cond   *Expr   `json:"cond,omitempty"`
+	Start  *Expr   `json:"start,omitempty"`
+	End    *Expr   `json:"end,omitempty"`
+	Body   []Stmt  `json:"body,omitempty"`
+	Then   []Stmt  `json:"then,omitempty"`
+	Else   []Stmt  `json:"else,omitempty"`
+	Params []Param `json:"params,omitempty"`
+}
+
+// Param represents a function parameter.
+type Param struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// Expr represents an expression node in the simplified AST.
+type Expr struct {
+	Kind   string  `json:"kind"`
+	Value  string  `json:"value,omitempty"`
+	Name   string  `json:"name,omitempty"`
+	Left   *Expr   `json:"left,omitempty"`
+	Right  *Expr   `json:"right,omitempty"`
+	Target *Expr   `json:"target,omitempty"`
+	Args   []Expr  `json:"args,omitempty"`
+	Expr   *Expr   `json:"expr,omitempty"`
+	Index  *Expr   `json:"index,omitempty"`
+	Cond   *Expr   `json:"cond,omitempty"`
+	Then   *Expr   `json:"then,omitempty"`
+	Else   *Expr   `json:"else,omitempty"`
+	Elems  []Expr  `json:"elems,omitempty"`
+	Params []Param `json:"params,omitempty"`
+	Body   []Stmt  `json:"body,omitempty"`
+	Op     string  `json:"op,omitempty"`
+}
+
+//go:embed internal/AstJson.java
+var astSource []byte
+
+var (
+	compileOnce sync.Once
+	compileErr  error
+	classDir    string
+)
+
+// ensureCompiled compiles the helper Java parser once.
+func ensureCompiled() error {
+	compileOnce.Do(func() {
+		tmp, err := os.MkdirTemp("", "jsonast-java-*")
+		if err != nil {
+			compileErr = err
+			return
+		}
+		src := filepath.Join(tmp, "AstJson.java")
+		if err := os.WriteFile(src, astSource, 0o644); err != nil {
+			compileErr = err
+			return
+		}
+		classDir = filepath.Join(tmp, "bin")
+		os.MkdirAll(classDir, 0o755)
+		cmd := exec.Command("javac", "-encoding", "UTF-8", "-d", classDir, src)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			compileErr = fmt.Errorf("javac: %v: %s", err, out)
+		}
+	})
+	return compileErr
+}
+
+// Inspect parses src using the embedded Java parser and returns a Program.
 func Inspect(src string) (*Program, error) {
-	node, err := jparser.Parse(src)
+	tmp, err := os.CreateTemp("", "jsonast-java-*.java")
 	if err != nil {
 		return nil, err
 	}
-	return &Program{Body: node.Body}, nil
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(src); err != nil {
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, err
+	}
+	return inspectFile(tmp.Name())
+}
+
+func inspectFile(path string) (*Program, error) {
+	if err := ensureCompiled(); err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("java", "-cp", classDir, "internal.AstJson", path)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("java error: %s", ee.Stderr)
+		}
+		return nil, err
+	}
+	var prog Program
+	if err := json.Unmarshal(out, &prog); err != nil {
+		return nil, err
+	}
+	return &prog, nil
 }

--- a/tools/json-ast/x/java/internal/AstJson.java
+++ b/tools/json-ast/x/java/internal/AstJson.java
@@ -1,0 +1,475 @@
+package internal;
+
+import com.sun.source.tree.*;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.util.JavacTask;
+import javax.tools.*;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class AstJson {
+    private final PrintWriter out;
+    public AstJson(PrintWriter out) { this.out = out; }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            System.err.println("usage: AstJson <file>");
+            System.exit(1);
+        }
+        File src = new File(args[0]);
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null);
+        Iterable<? extends JavaFileObject> fobjs = fm.getJavaFileObjects(src);
+        JavacTask task = (JavacTask) compiler.getTask(null, fm, null, null, null, fobjs);
+        Iterable<? extends CompilationUnitTree> units = task.parse();
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8));
+        AstJson printer = new AstJson(pw);
+        pw.print("{\"body\":");
+        printer.printUnits(units);
+        pw.print("}");
+        pw.flush();
+    }
+
+    private void printUnits(Iterable<? extends CompilationUnitTree> units) {
+        boolean firstStmt = true;
+        out.print("[");
+        for (CompilationUnitTree cu : units) {
+            for (Tree t : cu.getTypeDecls()) {
+                if (t.getKind() != Tree.Kind.CLASS) continue;
+                ClassTree ct = (ClassTree) t;
+                for (Tree m : ct.getMembers()) {
+                    if (m.getKind() == Tree.Kind.VARIABLE) {
+                        VariableTree vt = (VariableTree) m;
+                        if (!vt.getModifiers().getFlags().contains(javax.lang.model.element.Modifier.STATIC)) continue;
+                        if (!firstStmt) out.print(',');
+                        firstStmt = false;
+                        printVarDecl(vt);
+                    }
+                }
+                for (Tree m : ct.getMembers()) {
+                    if (m.getKind() == Tree.Kind.METHOD) {
+                        MethodTree mt = (MethodTree) m;
+                        if (!mt.getModifiers().getFlags().contains(javax.lang.model.element.Modifier.STATIC)) continue;
+                        if (mt.getName().contentEquals("main")) continue;
+                        if (!firstStmt) out.print(',');
+                        firstStmt = false;
+                        printFnDecl(mt);
+                    }
+                }
+                for (Tree m : ct.getMembers()) {
+                    if (m.getKind() == Tree.Kind.METHOD) {
+                        MethodTree mt = (MethodTree) m;
+                        if (mt.getName().contentEquals("main")) {
+                            for (StatementTree st : mt.getBody().getStatements()) {
+                                if (!firstStmt) out.print(',');
+                                firstStmt = false;
+                                printStmt(st);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out.print("]");
+    }
+
+    private void printVarDecl(VariableTree vt) {
+        out.print("{\"kind\":\"VarDecl\",\"name\":\"");
+        out.print(vt.getName());
+        out.print("\"");
+        if (vt.getType() != null) {
+            out.print(",\"type\":\"");
+            out.print(vt.getType());
+            out.print("\"");
+        }
+        if (vt.getInitializer() != null) {
+            out.print(",\"expr\":");
+            printExpr(vt.getInitializer());
+        }
+        out.print("}");
+    }
+
+    private void printFnDecl(MethodTree mt) {
+        out.print("{\"kind\":\"FnDecl\",\"name\":\"");
+        out.print(mt.getName());
+        out.print("\",\"params\":[");
+        boolean first = true;
+        for (VariableTree p : mt.getParameters()) {
+            if (!first) out.print(',');
+            first = false;
+            out.print("{\"name\":\"");
+            out.print(p.getName());
+            out.print("\"");
+            if (p.getType() != null) {
+                out.print(",\"type\":\"");
+                out.print(p.getType());
+                out.print("\"");
+            }
+            out.print("}");
+        }
+        out.print("],");
+        if (mt.getReturnType() != null) {
+            out.print("\"type\":\"");
+            out.print(mt.getReturnType());
+            out.print("\",");
+        }
+        out.print("\"body\":");
+        printBlockStatements(mt.getBody());
+        out.print("}");
+    }
+
+    private void printStmt(StatementTree st) {
+        switch (st.getKind()) {
+        case EXPRESSION_STATEMENT:
+            ExpressionStatementTree est = (ExpressionStatementTree) st;
+            ExpressionTree e = est.getExpression();
+            if (e.getKind() == Tree.Kind.ASSIGNMENT) {
+                AssignmentTree at = (AssignmentTree) e;
+                out.print("{\"kind\":\"Assign\",");
+                out.print("\"name\":\"");
+                out.print(at.getVariable());
+                out.print("\",\"target\":");
+                printExpr(at.getVariable());
+                out.print(",\"expr\":");
+                printExpr(at.getExpression());
+                out.print("}");
+                break;
+            }
+            if (e.getKind() == Tree.Kind.METHOD_INVOCATION) {
+                MethodInvocationTree mit = (MethodInvocationTree) e;
+                if (mit.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT) {
+                    MemberSelectTree ms = (MemberSelectTree) mit.getMethodSelect();
+                    if ("System.out.println".equals(ms.getExpression().toString()+"."+ms.getIdentifier())) {
+                        out.print("{\"kind\":\"Print\",\"expr\":");
+                        if (!mit.getArguments().isEmpty()) {
+                            printExpr(mit.getArguments().get(0));
+                        } else {
+                            out.print("{\"kind\":\"Literal\",\"value\":\"\"}");
+                        }
+                        out.print("}");
+                        break;
+                    }
+                }
+            }
+            out.print("{\"kind\":\"Expr\"}");
+            break;
+        case VARIABLE:
+            printVarDecl((VariableTree) st);
+            break;
+        case ENHANCED_FOR_LOOP:
+            EnhancedForLoopTree ef = (EnhancedForLoopTree) st;
+            out.print("{\"kind\":\"ForEach\",\"name\":\"");
+            out.print(ef.getVariable().getName());
+            out.print("\",\"expr\":");
+            printExpr(ef.getExpression());
+            out.print(",\"body\":");
+            printBlockStatements(ef.getStatement());
+            out.print("}");
+            break;
+        case FOR_LOOP:
+            ForLoopTree fl = (ForLoopTree) st;
+            if (fl.getInitializer().size() == 1 && fl.getInitializer().get(0).getKind() == Tree.Kind.VARIABLE) {
+                VariableTree iv = (VariableTree) fl.getInitializer().get(0);
+                out.print("{\"kind\":\"ForRange\",\"name\":\"");
+                out.print(iv.getName());
+                out.print("\",\"start\":");
+                printExpr(iv.getInitializer());
+                out.print(",\"end\":");
+                if (fl.getCondition() instanceof BinaryTree) {
+                    BinaryTree bt = (BinaryTree) fl.getCondition();
+                    printExpr(bt.getRightOperand());
+                } else {
+                    printExpr(fl.getCondition());
+                }
+                out.print(",\"body\":");
+                printBlockStatements(fl.getStatement());
+                out.print("}");
+                break;
+            }
+            out.print("{\"kind\":\"ForLoop\"}");
+            break;
+        case WHILE_LOOP:
+            WhileLoopTree wl = (WhileLoopTree) st;
+            out.print("{\"kind\":\"While\",\"cond\":");
+            printExpr(wl.getCondition());
+            out.print(",\"body\":");
+            printBlockStatements(wl.getStatement());
+            out.print("}");
+            break;
+        case BREAK:
+            out.print("{\"kind\":\"Break\"}");
+            break;
+        case CONTINUE:
+            out.print("{\"kind\":\"Continue\"}");
+            break;
+        case IF:
+            IfTree it = (IfTree) st;
+            out.print("{\"kind\":\"If\",\"cond\":");
+            printExpr(it.getCondition());
+            out.print(",\"then\":");
+            printBlockStatements(it.getThenStatement());
+            if (it.getElseStatement() != null) {
+                out.print(",\"else\":");
+                printBlockStatements(it.getElseStatement());
+            }
+            out.print("}");
+            break;
+        case RETURN:
+            ReturnTree rt = (ReturnTree) st;
+            out.print("{\"kind\":\"Return\"");
+            if (rt.getExpression() != null) {
+                out.print(",\"expr\":");
+                printExpr(rt.getExpression());
+            }
+            out.print("}");
+            break;
+        default:
+            out.print("{\"kind\":\"");
+            out.print(st.getKind().name());
+            out.print("\"}");
+        }
+    }
+
+    private void printBlockStatements(StatementTree stmt) {
+        if (stmt.getKind() == Tree.Kind.BLOCK) {
+            BlockTree block = (BlockTree) stmt;
+            out.print("[");
+            boolean first = true;
+            for (StatementTree s : block.getStatements()) {
+                if (!first) out.print(',');
+                first = false;
+                printStmt(s);
+            }
+            out.print("]");
+        } else {
+            out.print("[");
+            printStmt(stmt);
+            out.print("]");
+        }
+    }
+
+    private void printExpr(Tree expr) {
+        switch (expr.getKind()) {
+        case STRING_LITERAL:
+            out.print("{\"kind\":\"String\",\"value\":");
+            quote(((LiteralTree)expr).getValue().toString());
+            out.print("}");
+            break;
+        case INT_LITERAL:
+        case LONG_LITERAL:
+        case FLOAT_LITERAL:
+        case DOUBLE_LITERAL:
+        case BOOLEAN_LITERAL:
+            out.print("{\"kind\":\"Literal\",\"value\":\"");
+            out.print(((LiteralTree)expr).getValue());
+            out.print("\"}");
+            break;
+        case PARENTHESIZED:
+            ParenthesizedTree pt = (ParenthesizedTree) expr;
+            printExpr(pt.getExpression());
+            break;
+        case IDENTIFIER:
+            out.print("{\"kind\":\"Ident\",\"name\":\"");
+            out.print(((IdentifierTree)expr).getName());
+            out.print("\"}");
+            break;
+        case MEMBER_SELECT:
+            MemberSelectTree ms = (MemberSelectTree) expr;
+            out.print("{\"kind\":\"Member\",\"expr\":");
+            printExpr(ms.getExpression());
+            out.print(",\"name\":\"");
+            out.print(ms.getIdentifier());
+            out.print("\"}");
+            break;
+        case METHOD_INVOCATION:
+            MethodInvocationTree mit = (MethodInvocationTree) expr;
+            out.print("{\"kind\":\"Call\",\"target\":");
+            printExpr(mit.getMethodSelect());
+            out.print(",\"args\":[");
+            boolean f = true;
+            for (ExpressionTree a : mit.getArguments()) {
+                if (!f) out.print(',');
+                f = false;
+                printExpr(a);
+            }
+            out.print("]}");
+            break;
+        case LOGICAL_COMPLEMENT:
+            UnaryTree ut = (UnaryTree) expr;
+            out.print("{\"kind\":\"Unary\",\"op\":\"LOGICAL_COMPLEMENT\",\"expr\":");
+            printExpr(ut.getExpression());
+            out.print("}");
+            break;
+        case TYPE_CAST:
+            TypeCastTree tct = (TypeCastTree) expr;
+            out.print("{\"kind\":\"Cast\",\"value\":\"");
+            out.print(tct.getType());
+            out.print("\",\"expr\":");
+            printExpr(tct.getExpression());
+            out.print("}");
+            break;
+        case PLUS:
+        case MINUS:
+        case MULTIPLY:
+        case DIVIDE:
+        case REMAINDER:
+        case LESS_THAN:
+        case GREATER_THAN:
+        case EQUAL_TO:
+        case NOT_EQUAL_TO:
+        case LESS_THAN_EQUAL:
+        case GREATER_THAN_EQUAL:
+        case CONDITIONAL_AND:
+        case CONDITIONAL_OR:
+            BinaryTree bt = (BinaryTree) expr;
+            out.print("{\"kind\":\"Binary\",\"op\":\"");
+            out.print(expr.getKind().name());
+            out.print("\",\"left\":");
+            printExpr(bt.getLeftOperand());
+            out.print(",\"right\":");
+            printExpr(bt.getRightOperand());
+            out.print("}");
+            break;
+        case CONDITIONAL_EXPRESSION:
+            ConditionalExpressionTree ct = (ConditionalExpressionTree) expr;
+            out.print("{\"kind\":\"Cond\",\"cond\":");
+            printExpr(ct.getCondition());
+            out.print(",\"then\":");
+            printExpr(ct.getTrueExpression());
+            out.print(",\"else\":");
+            printExpr(ct.getFalseExpression());
+            out.print("}");
+            break;
+        case ARRAY_ACCESS:
+            ArrayAccessTree aa = (ArrayAccessTree) expr;
+            out.print("{\"kind\":\"Index\",\"expr\":");
+            printExpr(aa.getExpression());
+            out.print(",\"index\":");
+            printExpr(aa.getIndex());
+            out.print("}");
+            break;
+        case NEW_ARRAY: {
+            NewArrayTree na = (NewArrayTree) expr;
+            out.print("{\"kind\":\"NEW_ARRAY\"");
+            if (na.getType() != null) {
+                out.print(",\"type\":\"");
+                out.print(na.getType());
+                out.print("\"");
+            }
+            if (!na.getDimensions().isEmpty()) {
+                out.print(",\"dims\":[");
+                boolean fd = true;
+                for (ExpressionTree d : na.getDimensions()) {
+                    if (!fd) out.print(',');
+                    fd = false;
+                    printExpr(d);
+                }
+                out.print("]");
+            }
+            if (!na.getInitializers().isEmpty()) {
+                out.print(",\"elems\":[");
+                boolean fe = true;
+                for (ExpressionTree e : na.getInitializers()) {
+                    if (!fe) out.print(',');
+                    fe = false;
+                    printExpr(e);
+                }
+                out.print("]");
+            }
+            out.print("}");
+            break;
+        }
+        case NEW_CLASS: {
+            NewClassTree nc = (NewClassTree) expr;
+            out.print("{\"kind\":\"NEW_CLASS\"");
+            if (nc.getIdentifier() != null) {
+                out.print(",\"type\":\"");
+                out.print(nc.getIdentifier());
+                out.print("\"");
+            }
+            out.print(",\"args\":[");
+            boolean fa = true;
+            for (ExpressionTree a : nc.getArguments()) {
+                if (!fa) out.print(',');
+                fa = false;
+                printExpr(a);
+            }
+            out.print("]");
+            ClassTree body = nc.getClassBody();
+            if (body != null) {
+                out.print(",\"body\":[");
+                boolean fb = true;
+                for (Tree m : body.getMembers()) {
+                    if (m.getKind() == Tree.Kind.BLOCK) {
+                        BlockTree blk = (BlockTree) m;
+                        for (StatementTree st : blk.getStatements()) {
+                            if (!fb) out.print(',');
+                            fb = false;
+                            printStmt(st);
+                        }
+                    } else if (m.getKind() == Tree.Kind.VARIABLE) {
+                        if (!fb) out.print(',');
+                        fb = false;
+                        printVarDecl((VariableTree) m);
+                    } else if (m.getKind() == Tree.Kind.METHOD) {
+                        if (!fb) out.print(',');
+                        fb = false;
+                        printFnDecl((MethodTree) m);
+                    }
+                }
+                out.print("]");
+            }
+            out.print("}");
+            break;
+        }
+        case LAMBDA_EXPRESSION:
+            LambdaExpressionTree lt = (LambdaExpressionTree) expr;
+            out.print("{\"kind\":\"Lambda\",\"params\":[");
+            boolean fp = true;
+            for (VariableTree p : lt.getParameters()) {
+                if (!fp) out.print(',');
+                fp = false;
+                out.print("{\"name\":\"");
+                out.print(p.getName());
+                out.print("\"");
+                if (p.getType() != null) {
+                    out.print(",\"type\":\"");
+                    out.print(p.getType());
+                    out.print("\"");
+                }
+                out.print("}");
+            }
+            out.print("],");
+            if (lt.getBodyKind() == LambdaExpressionTree.BodyKind.EXPRESSION) {
+                out.print("\"expr\":");
+                printExpr((ExpressionTree) lt.getBody());
+            } else {
+                out.print("\"body\":");
+                printBlockStatements((StatementTree) lt.getBody());
+            }
+            out.print("}");
+            break;
+        default:
+            out.print("{\"kind\":\"");
+            out.print(expr.getKind().name());
+            out.print("\"}");
+        }
+    }
+
+    private void quote(String s) {
+        out.print('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\': out.print("\\\\"); break;
+            case '"': out.print("\\\""); break;
+            case '\n': out.print("\\n"); break;
+            case '\r': out.print("\\r"); break;
+            case '\t': out.print("\\t"); break;
+            default: out.print(c);
+            }
+        }
+        out.print('"');
+    }
+}


### PR DESCRIPTION
## Summary
- remove `Text` field from Java AST nodes
- parse `NEW_ARRAY` and `NEW_CLASS` expressions into nested elements and initializer blocks
- refresh Java inspector golden files without `text` placeholders

## Testing
- `go test ./tools/json-ast/x/java -tags=slow -update`


------
https://chatgpt.com/codex/tasks/task_e_6889869f4b248320adcbb7c530f082c6